### PR TITLE
POWR-59 Add community actions block to homepage.

### DIFF
--- a/web/sites/default/config/block.block.communityactions.yml
+++ b/web/sites/default/config/block.block.communityactions.yml
@@ -1,0 +1,35 @@
+uuid: 21442a61-d2c3-4102-b701-22bdce6a0e26
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools_block
+    - system
+  theme:
+    - portlandor
+id: communityactions
+theme: portlandor
+region: content
+weight: 0
+provider: null
+plugin: 'entity_field:node:field_community_actions'
+settings:
+  id: 'entity_field:node:field_community_actions'
+  label: 'Community actions'
+  provider: ctools_block
+  label_display: '0'
+  formatter:
+    label: hidden
+    type: entity_reference_label
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+  context_mapping:
+    entity: '@node.node_route_context:node'
+visibility:
+  request_path:
+    id: request_path
+    pages: /node
+    negate: false
+    context_mapping: {  }

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -69,6 +69,8 @@ module:
   openapi_redoc: 0
   options: 0
   page_cache: 0
+  page_manager: 0
+  page_manager_ui: 0
   panelizer: 0
   panelizer_quickedit: 0
   panels: 0

--- a/web/sites/default/config/lightning_core.versions.yml
+++ b/web/sites/default/config/lightning_core.versions.yml
@@ -106,3 +106,5 @@ redirect: 1.1.0
 redirect_404: 1.1.0
 textarea_widget_for_text: 1.1.0
 views_bulk_operations: 2.2.0
+page_manager: 0.0.0
+page_manager_ui: 0.0.0

--- a/web/sites/default/config/page_manager.page.frontpage.yml
+++ b/web/sites/default/config/page_manager.page.frontpage.yml
@@ -1,0 +1,12 @@
+uuid: 5dbdf61b-58a1-4c64-b773-cb24f40fbb1b
+langcode: en
+status: true
+dependencies: {  }
+id: frontpage
+label: Frontpage
+description: 'Homepage for overall site.'
+use_admin_theme: false
+path: /node
+access_logic: and
+access_conditions: {  }
+parameters: {  }

--- a/web/sites/default/config/page_manager.page.node_view.yml
+++ b/web/sites/default/config/page_manager.page.node_view.yml
@@ -1,0 +1,18 @@
+uuid: 0669b9de-60fd-4a09-88a0-63c7958af3a8
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: RCVWP-yHwxSNiQORMIabDgHMEVqOMW58w80BQgRFJ4k
+id: node_view
+label: 'Node view'
+description: 'When enabled, this overrides the default Drupal behavior for displaying nodes at <em>/node/{node}</em>. If you add variants, you may use selection criteria such as node type or language or user access to provide different views of nodes. If no variant is selected, the default Drupal node view will be used. This page only affects nodes viewed as pages, it will not affect nodes viewed in lists or at other locations.'
+use_admin_theme: false
+path: '/node/{node}'
+access_logic: and
+access_conditions: {  }
+parameters:
+  node:
+    machine_name: node
+    type: 'entity:node'
+    label: Node

--- a/web/sites/default/config/page_manager.page_variant.frontpage-panels_variant-0.yml
+++ b/web/sites/default/config/page_manager.page_variant.frontpage-panels_variant-0.yml
@@ -1,0 +1,41 @@
+uuid: 0ebed85b-ec9d-4364-81b2-bb1ab33f3193
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.frontpage
+    - views.view.community_actions
+  module:
+    - panels
+    - views
+id: frontpage-panels_variant-0
+label: Panels
+variant: panels_variant
+variant_settings:
+  blocks:
+    828ef4e2-871e-42b7-baec-1377e49d97a0:
+      id: 'views_block:community_actions-block_1'
+      label: ''
+      provider: views
+      label_display: '0'
+      views_label: ''
+      items_per_page: none
+      region: content
+      weight: 0
+      uuid: 828ef4e2-871e-42b7-baec-1377e49d97a0
+      context_mapping: {  }
+  id: panels_variant
+  uuid: 1cbab72a-c89f-41e2-a24f-6b48487cc61d
+  label: null
+  weight: 0
+  layout: layout_onecol
+  layout_settings: {  }
+  page_title: ''
+  storage_type: page_manager
+  storage_id: frontpage-panels_variant-0
+  builder: standard
+page: frontpage
+weight: 0
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/web/sites/default/config/views.view.community_actions.yml
+++ b/web/sites/default/config/views.view.community_actions.yml
@@ -1,0 +1,158 @@
+uuid: 1f8f619f-ea8c-4cb5-bb25-1903fb2d889f
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.community_actions
+  module:
+    - taxonomy
+    - user
+id: community_actions
+label: 'Community actions'
+module: views
+description: 'Homepage menu of actions a community member might take in interacting with the city.'
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: null
+          offset: 0
+      style:
+        type: grid
+        options:
+          grouping: {  }
+          columns: 4
+          automatic_width: true
+          alignment: horizontal
+          col_class_default: true
+          col_class_custom: ''
+          row_class_default: true
+          row_class_custom: ''
+      row:
+        type: fields
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          entity_type: taxonomy_term
+          entity_field: name
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          type: string
+          settings:
+            link_to_entity: true
+          plugin_id: term_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          value:
+            community_actions: community_actions
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+      sorts: {  }
+      title: 'Community actions'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_category: 'Lists (Views)'
+      allow:
+        items_per_page: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/web/sites/default/config/views.view.frontpage.yml
+++ b/web/sites/default/config/views.view.frontpage.yml
@@ -1,5 +1,6 @@
+uuid: null
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.node.rss


### PR DESCRIPTION
Please note, I went ahead and added Pages and the Page Manager UI to this feature so that I could create a homepage that could have blocks placed on it. We can use Page manager for content type or path specific layouts as we go forward. I'll demo this with the team next week.