### PR TITLE
POWR-164 Configure Chosen to only target specific fields

### DIFF
--- a/web/sites/default/config/chosen.settings.yml
+++ b/web/sites/default/config/chosen.settings.yml
@@ -2,7 +2,7 @@ minimum_single: 0
 minimum_multiple: 0
 disable_search_threshold: 0
 minimum_width: 0
-jquery_selector: 'select:visible'
+jquery_selector: 'select#edit-field-topics, select#edit-field-audience, select#edit-field-community-actions'
 search_contains: false
 disable_search: true
 allow_single_deselect: false
@@ -13,8 +13,8 @@ disabled_themes:
   seven: '0'
   adminimal_theme: '0'
   bootstrap: '0'
-  particle: '0'
-  portlandor: '0'
-chosen_include: 2
+  bootstrap_barrio: '0'
+  stormy: '0'
+chosen_include: 0
 _core:
   default_config_hash: JUHKHJeHl1bWXY41HMIcDR-VmAWvJ4OJycDubCkIeDU


### PR DESCRIPTION
I've modified the Chosen config to only target three specific fields: 

- select#edit-field-topics
- select#edit-field-audience
- select#edit-field-community-actions

Contrary to Mike's comments in the meeting today, it's not possible to otherwise turn Chosen off using other config options. You can turn it ON for all controls, but not turn it OFF for all. Specifying the controls it targets seems to be the sole way this is done.