### PR TITLE
POWR-142 Expand pathauto options for group content list pages

### DIFF
--- a/web/modules/custom/portland/portland.module
+++ b/web/modules/custom/portland/portland.module
@@ -2,15 +2,27 @@
 
 use Drupal\group\Entity\GroupInterface;
 
+const GROUP_CONTENT_TYPES = array('services', 'locations', 'buildings');
 
 /**
  * Implements hook_ENTITY_TYPE_insert().
  */
 function portland_group_insert(GroupInterface $group) {
 
-    echo "HALT portland_group_insert";
-    exit();
+    $gid = $group->id();
+    $shortname = substr(str_replace(" ","_",trim(strtolower($group->get('field_shortname_or_acronym')->value))),0,60);
 
+    // POWR-142
+    // 1.2. Generate URL aliases for content type subpages using group shortname (ie. /bds/services)
+    foreach (GROUP_CONTENT_TYPES as $type) {
+        $system = "/group/$gid/$type";
+        $alias = "/$shortname/$type";
+        // save new path alias
+        $path = \Drupal::service('path.alias_storage')->save($system, $alias, "en");
+    }
+
+    // POWR-142 TODO:
+    // 1.3. Generate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
 }
   
 /**
@@ -18,10 +30,55 @@ function portland_group_insert(GroupInterface $group) {
  */
 function portland_group_update(GroupInterface $group) {
 
-    // TODO: if field field_shortname_or_acronym has changed, we need to update all the URL aliases
-    //       for content under this group 
-    
-    echo "HALT portland_group_update";
-    exit();
+    $gid = $group->id();
+    $shortname = substr(str_replace(" ","_",trim(strtolower($group->get('field_shortname_or_acronym')->value))),0,60);
+    $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    // POWR-142 TODO:
+    // 1.2. Regenerate URL aliases for content type subpages using group shortname (ie. /bds/services)
+    foreach (GROUP_CONTENT_TYPES as $type) {
+        $system = "/group/$gid/$type";
+        $alias = "/$shortname/$type";
+
+        // if it exists, delete it if it's changed
+        $exists = \Drupal::service('path.alias_storage')->aliasExists($alias, $lang);
+        if ($exists) {
+            \Drupal::service('path.alias_storage')->delete(['alias' => $alias, 'langcode' => $lang]);
+        }
+
+        // save alias
+        $path = \Drupal::service('path.alias_storage')->save($system, $alias, $lang);
+
+        // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Path%21AliasStorage.php/class/AliasStorage/8.2.x
+
+        //      $is_exists = \Drupal::service('path.alias_storage')->aliasExists($alias, $element['langcode']['#value'], $element['source']['#value']);
+
+        //    $conditions = [
+            // 'source' => '/' . $entity->toUrl()->getInternalPath(),
+            // 'langcode' => $entity->language()->getId(),
+            // ];
+            // \Drupal::service('path.alias_storage')->delete($conditions);
+
+
+        // if alias doesn't exist, create/save it.
+
+        // if alias does exist but is different, delete old then create new
+
+        // if alias does exist and hasn't changed, do nothing
+
+        // update?
+        // $existing_alias = \Drupal::service('path.alias_storage')->lookupPathAlias($system, $lang);
+        // if ($existing_alias != $alias) {
+        // }
+
+        //$group->toUrl()->toString(): "/silly-silly"
+
+        $test = 1;
+    }
+
+    // 1.3. Regenerate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
+    // 4.2. Bulk regenerate URL aliases for group child content usin group shortname
+    // 4.3. Regenerate URL aliases for group action links usin group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
+
 
 }

--- a/web/modules/custom/portland/portland.module
+++ b/web/modules/custom/portland/portland.module
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\group\Entity\GroupInterface;
+use Drupal\pathauto\Form\PathautoBulkUpdateForm;
 
 const GROUP_CONTENT_TYPES = array('services', 'locations', 'buildings');
 
@@ -21,8 +22,7 @@ function portland_group_insert(GroupInterface $group) {
         $path = \Drupal::service('path.alias_storage')->save($system, $alias, "en");
     }
 
-    // POWR-142 TODO:
-    // 1.3. Generate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
+    // <TODO:>LOW PRIORITY: Generate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members)</TODO:>
 }
   
 /**
@@ -30,55 +30,52 @@ function portland_group_insert(GroupInterface $group) {
  */
 function portland_group_update(GroupInterface $group) {
 
+    // 4.2. Bulk regenerate URL aliases for content by running pathauto batch processing
+    $batch = array(
+        'title' => t('Bulk updating URL aliases'),
+        'operations' => array(
+          array('Drupal\pathauto\Form\PathautoBulkUpdateForm::batchStart', array()),
+        ),
+        'finished' => 'Drupal\pathauto\Form\PathautoBulkUpdateForm::batchFinished',
+    );
+    $batch['operations'][] = array('Drupal\pathauto\Form\PathautoBulkUpdateForm::batchProcess', ["canonical_entities:node", "update"]);
+    $batch['operations'][] = array('Drupal\pathauto\Form\PathautoBulkUpdateForm::batchProcess', ["canonical_entities:group", "update"]);
+    $batch['operations'][] = array('Drupal\pathauto\Form\PathautoBulkUpdateForm::batchProcess', ["canonical_entities:group_content", "update"]);
+    batch_set($batch);
+
+    // get goup shortname and build paths
     $gid = $group->id();
     $shortname = substr(str_replace(" ","_",trim(strtolower($group->get('field_shortname_or_acronym')->value))),0,60);
     $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-    // POWR-142 TODO:
-    // 1.2. Regenerate URL aliases for content type subpages using group shortname (ie. /bds/services)
+    // TODO: manually regenerate URL alias for main group page; pathauto bulk update isn't getting it sometimes
+    $existing_alias = \Drupal::service('path.alias_storage')->lookupPathAlias("/group/$gid", $lang);
+    $alias = "/$shortname";
+    // if it exists and doesn't match current alias, delete and re-save
+    if ($existing_alias && $existing_alias != $alias) {
+        \Drupal::service('path.alias_storage')->delete(['alias' => $existing_alias, 'langcode' => $lang]);
+        $path = \Drupal::service('path.alias_storage')->save("/group/$gid", $alias, $lang);
+    }
+    
+    // POWR-142: Regenerate URL aliases for content type subpages using group shortname (ie. /bds/services)
+    // reference: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Path%21AliasStorage.php/class/AliasStorage/8.6.x
     foreach (GROUP_CONTENT_TYPES as $type) {
-        $system = "/group/$gid/$type";
+        $system_path = "/group/$gid/$type";
         $alias = "/$shortname/$type";
 
-        // if it exists, delete it if it's changed
-        $exists = \Drupal::service('path.alias_storage')->aliasExists($alias, $lang);
-        if ($exists) {
-            \Drupal::service('path.alias_storage')->delete(['alias' => $alias, 'langcode' => $lang]);
+        $existing_alias = \Drupal::service('path.alias_storage')->lookupPathAlias($system_path, $lang);
+
+        // if it already exists and matches, do nothing
+        if ($existing_alias && $existing_alias == $alias) continue;
+
+        // if it exists and doesn't match current alias, delete in preparation for re-save
+        if ($existing_alias && $existing_alias != $alias) {
+            \Drupal::service('path.alias_storage')->delete(['alias' => $existing_alias, 'langcode' => $lang]);
         }
 
-        // save alias
-        $path = \Drupal::service('path.alias_storage')->save($system, $alias, $lang);
-
-        // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Path%21AliasStorage.php/class/AliasStorage/8.2.x
-
-        //      $is_exists = \Drupal::service('path.alias_storage')->aliasExists($alias, $element['langcode']['#value'], $element['source']['#value']);
-
-        //    $conditions = [
-            // 'source' => '/' . $entity->toUrl()->getInternalPath(),
-            // 'langcode' => $entity->language()->getId(),
-            // ];
-            // \Drupal::service('path.alias_storage')->delete($conditions);
-
-
-        // if alias doesn't exist, create/save it.
-
-        // if alias does exist but is different, delete old then create new
-
-        // if alias does exist and hasn't changed, do nothing
-
-        // update?
-        // $existing_alias = \Drupal::service('path.alias_storage')->lookupPathAlias($system, $lang);
-        // if ($existing_alias != $alias) {
-        // }
-
-        //$group->toUrl()->toString(): "/silly-silly"
-
-        $test = 1;
+        // save new or updated alias
+        $path = \Drupal::service('path.alias_storage')->save($system_path, $alias, $lang);
     }
 
-    // 1.3. Regenerate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
-    // 4.2. Bulk regenerate URL aliases for group child content usin group shortname
-    // 4.3. Regenerate URL aliases for group action links usin group shortname (ie. /bds/content, /bds/members) - LOW PRIORITY/DEFER
-
-
+    // <TODO:>LOW PRIORITY: rEGenerate URL aliases for group action links using group shortname (ie. /bds/content, /bds/members)</TODO:>
 }

--- a/web/modules/custom/portland/portland.module
+++ b/web/modules/custom/portland/portland.module
@@ -1,0 +1,27 @@
+<?php
+
+use Drupal\group\Entity\GroupInterface;
+
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function portland_group_insert(GroupInterface $group) {
+
+    echo "HALT portland_group_insert";
+    exit();
+
+}
+  
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function portland_group_update(GroupInterface $group) {
+
+    // TODO: if field field_shortname_or_acronym has changed, we need to update all the URL aliases
+    //       for content under this group 
+    
+    echo "HALT portland_group_update";
+    exit();
+
+}

--- a/web/sites/default/config/field.field.group.bureau_office.field_shortname_or_acronym.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_shortname_or_acronym.yml
@@ -10,7 +10,7 @@ field_name: field_shortname_or_acronym
 entity_type: group
 bundle: bureau_office
 label: 'Shortname or acronym'
-description: 'This is the commonly used shortname or acronym for the organization and is used to create the URL path.'
+description: 'This is the commonly used shortname or acronym for the organization and is used to create the URL path for the landing page and all child content. If this value is changed, the URL paths for all content in this organization will be updated automatically.'
 required: true
 translatable: false
 default_value: {  }

--- a/web/sites/default/config/field.field.group.program.field_shortname_or_acronym.yml
+++ b/web/sites/default/config/field.field.group.program.field_shortname_or_acronym.yml
@@ -10,7 +10,7 @@ field_name: field_shortname_or_acronym
 entity_type: group
 bundle: program
 label: 'Shortname or acronym'
-description: 'This is the commonly used shortname or acronym for the organization and is used to create URL path.'
+description: 'This is the commonly used shortname or acronym for the program and is used to create the URL path for the landing page and all child content. If this value is changed, the URL paths for all content in this program will be updated automatically.'
 required: true
 translatable: true
 default_value: {  }

--- a/web/sites/default/config/pathauto.pattern.group_title.yml
+++ b/web/sites/default/config/pathauto.pattern.group_title.yml
@@ -3,12 +3,22 @@ langcode: en
 status: true
 dependencies:
   module:
+    - ctools
     - group
 id: group_title
 label: 'Group title'
 type: 'canonical_entities:group'
 pattern: '[group:field_shortname_or_acronym]'
-selection_criteria: {  }
+selection_criteria:
+  19ceae56-d96c-4aec-84f8-f48c0e7261b5:
+    id: 'entity_bundle:group'
+    bundles:
+      bureau_office: bureau_office
+      program: program
+    negate: false
+    context_mapping:
+      group: group
+    uuid: 19ceae56-d96c-4aec-84f8-f48c0e7261b5
 selection_logic: and
 weight: -10
 relationships: {  }


### PR DESCRIPTION
The majority of functionality for this story is in the portland.module file, which has two hooks to capture the group create and update events. That is where the URL aliases are created/updated. Config updates include: field description updates and some pathauto pattern updates.