### PR TITLE
alert-styles: re-implementing alert style from POWR-259 correctly in …

### DIFF
--- a/web/themes/custom/cloudy/css/style.css
+++ b/web/themes/custom/cloudy/css/style.css
@@ -29,7 +29,7 @@ h3, .h3 {
   font-size: 1.42383rem; }
 
 h4, .h4 {
-  font-size: 1.26562rem; }
+  font-size: 1.26563rem; }
 
 h5, .h5 {
   font-size: 1.125rem; }
@@ -6392,6 +6392,9 @@ a.text-dark:hover, a.text-dark:focus {
  * @file
  * Visual styles for comments in Barrio.
  */
+div.always-show div.portland-alert {
+  display: block; }
+
 /**
  * @file
  * Bootstrap Barrio specific styling for the Book module.
@@ -8225,9 +8228,6 @@ ul.pagination {
 
 div.portland-alert {
   display: none; }
-
-div.always-show div.portland-alert {
-  display: block; }
 
 .created, .updated {
   color: #505050; }

--- a/web/themes/custom/cloudy/scss/components/alerts.scss
+++ b/web/themes/custom/cloudy/scss/components/alerts.scss
@@ -2,3 +2,7 @@
  * @file
  * Visual styles for comments in Barrio.
  */
+
+ div.always-show div.portland-alert {
+  display: block; }
+


### PR DESCRIPTION
…sass and rebuilding; had previously been written directly to the css.

Also, had to rename this branch to "alert-sty" because the name was too long for multidev. Pantheon only allows 11-char names.