### PR TITLE
POWR-122 - Programmatic redirects from content edit form

### DIFF
--- a/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.info.yml
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.info.yml
@@ -1,0 +1,9 @@
+name: Portland Legacy Redirects module
+description: Creates custom redirects for migrated content from the legacy site.
+package: Custom
+type: module
+version: 0.1
+core: 8.x
+
+dependencies:
+  - 'portland'

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
@@ -20,9 +20,13 @@ function portland_legacy_redirects_entity_bundle_field_info_alter(&$fields, \Dru
  */
 function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_state, $form_id)
 {
+  // we want to check for and sync redirects on any node of a content type that includes the legacy path field
   if (array_key_exists('field_legacy_path', $form)) {
-    portland_legacy_redirects_sync_redirects($form);
-    // NOTE: if source is duplicate but destination changes, should we update redirect?
+    // only  call the sync function if the node has already been saved
+    $this_node = \Drupal::routeMatch()->getParameter('node');
+    if ($this_node) portland_legacy_redirects_sync_redirects($form, $this_node->Id());
+    
+    // TODO: if source is duplicate but destination changes, should we update redirect?
   }
 }
 
@@ -32,17 +36,21 @@ function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_s
  *
  * @return void
  */
-function portland_legacy_redirects_sync_redirects(&$form) {
+function portland_legacy_redirects_sync_redirects(&$form, $nid) {
 
-  $nid = \Drupal::routeMatch()->getParameter('node')->Id();
+  // if this is a new node, 
+  $this_node = \Drupal::routeMatch()->getParameter('node');
+  if (!$this_node) return;
+
+  $nid = $this_node->Id();
   $redirect_url = "entity:node/$nid";
   $redirects = \Drupal::service('redirect.repository')->findByDestinationUri([$redirect_url]);
   $new_deltas = array();
   $field = $form['field_legacy_path']['widget'];
   $max_delta = $field['#max_delta'];
 
-    // if max_delta is zero, that means no paths have been saved, and a blank field has
-    // been added to the form. we want that blank field to be at the end.
+  // if max_delta is zero, that means no paths have been saved, and a blank field has
+  // been added to the form. we want that blank field to be at the end.
   $delta_counter = $max_delta == 0 ? $max_delta : $max_delta + 1;
   $save_empty_delta;
   if ($max_delta == 0) {
@@ -53,12 +61,12 @@ function portland_legacy_redirects_sync_redirects(&$form) {
     $delta_counter = $max_delta + 1;
   }
 
-    // need to make sure there's a field delta for each of the redirects in $redirects,
+  // need to make sure there's a field delta for each of the redirects in $redirects,
   foreach ($redirects as $key => $redirect) {
 
     $source_path = $redirect->getSource()['path'];
 
-      // spin through field_legacy_path values to see if $source_path is in there. if not, add.
+    // spin through field_legacy_path values to see if $source_path is in there. if not, add.
     for ($i = 0; $i < $max_delta; $i++) {
       $source_value = portland_legacy_redirects_strip_leading_slash($field[$i]['value']['#default_value']);
       if ($source_path == $source_value) {
@@ -66,8 +74,8 @@ function portland_legacy_redirects_sync_redirects(&$form) {
       }
     }
 
-      // if there wasn't a match and break by this point, add $source_path to a temporary array,
-      // which will be appended to field_legacy_path widget after the loops.
+    // if there wasn't a match and break by this point, add $source_path to a temporary array,
+    // which will be appended to field_legacy_path widget after the loops.
     $new_deltas[$delta_counter] = [
       '#delta' => $delta_counter,
       '#weight' => $delta_counter,

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
@@ -20,13 +20,23 @@ function portland_legacy_redirects_entity_bundle_field_info_alter(&$fields, \Dru
  */
 function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_state, $form_id)
 {
-  // we want to check for and sync redirects on any node of a content type that includes the legacy path field
-  if (array_key_exists('field_legacy_path', $form)) {
-    // only  call the sync function if the node has already been saved
-    $this_node = \Drupal::routeMatch()->getParameter('node');
-    if ($this_node) portland_legacy_redirects_sync_redirects($form, $this_node->Id());
-    
-    // TODO: if source is duplicate but destination changes, should we update redirect?
+  // so that we don't need to call out all applicable forms by id, try to get the entity type.
+  // the form and entity methods we need aren't available in all instances where this hook might
+  // be called, so we've added a bunch of null ref checks so nothing break.s
+  $form_object = $form_state->getFormObject();
+  if ($form_object && method_exists($form_object, 'getEntity')) {
+    $entity = $form_object->getEntity();
+    if ($entity && method_exists($entity, 'getEntityTypeId')) {
+      $type = $entity->getEntityTypeId();
+
+      // we want to check for and sync redirects on any node of a content type that includes the legacy path field
+      if (($type == 'node' || $type == 'group') && array_key_exists('field_legacy_path', $form)) {
+        // only  call the sync function if the node has already been saved
+        $this_node = \Drupal::routeMatch()->getParameter($type);
+        if ($this_node) portland_legacy_redirects_sync_redirects($form, $this_node->Id(), $type);
+      }
+      
+    }
   }
 }
 
@@ -36,14 +46,14 @@ function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_s
  *
  * @return void
  */
-function portland_legacy_redirects_sync_redirects(&$form, $nid) {
+function portland_legacy_redirects_sync_redirects(&$form, $nid, $type) {
 
-  // if this is a new node, 
-  $this_node = \Drupal::routeMatch()->getParameter('node');
+  // if this is a new node, return now
+  $this_node = \Drupal::routeMatch()->getParameter($type);
   if (!$this_node) return;
 
   $nid = $this_node->Id();
-  $redirect_url = "entity:node/$nid";
+  $redirect_url = "entity:$type/$nid";
   $redirects = \Drupal::service('redirect.repository')->findByDestinationUri([$redirect_url]);
   $new_deltas = array();
   $field = $form['field_legacy_path']['widget'];
@@ -105,12 +115,13 @@ function portland_legacy_redirects_sync_redirects(&$form, $nid) {
  */
 function portland_legacy_redirects_entity_update($entity) {
   // if this is a node that has the legacy path field, create redirects
-  if ($entity->getEntityTypeId() == 'node' && $entity->hasField('field_legacy_path')){
+  $type = $entity->getEntityTypeId();
+  if (($type == 'node' || $type == 'group') && $entity->hasField('field_legacy_path')){
 
     $field = $entity->get('field_legacy_path')->getValue();
     $field_orig = $entity->get('field_legacy_path')->getValue();
 
-    $redirect_url = "entity:node/" . $entity->id(); // $entity->toUrl()->toUriString()
+    $redirect_url = "entity:$type/" . $entity->id(); // $entity->toUrl()->toUriString()
     // $entity->toUrl()->toUriString() generates a URI string that looks like this: route:entity.node.canonical;node=332.
     // The Redirect module stores a string that looks like this: entity:node/332.
     // Both work for redirection, but only ones in the latter format appear in the node's URL Redirects panel.

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
@@ -1,0 +1,145 @@
+<?php
+
+use Drupal\redirect\Entity\Redirect;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_entity_bundle_field_info_alter().
+ * - Adds relative_path constraint to field_legacy_path if it exists in fields array for the given bundle
+ */
+function portland_legacy_redirects_entity_bundle_field_info_alter(&$fields, \Drupal\Core\Entity\EntityTypeInterface $entity_type, $bundle)
+{
+  if (array_key_exists('field_legacy_path', $fields)) {
+    $fields['field_legacy_path']->addConstraint('relative_path', []);
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ * - Queries db for redirects that point to this node's URI and adds them to the legacy_path field
+ */
+function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_state, $form_id)
+{
+  if (array_key_exists('field_legacy_path', $form)) {
+    portland_legacy_redirects_sync_redirects($form);
+    // NOTE: if source is duplicate but destination changes, should we update redirect?
+  }
+}
+
+/**
+ * Called by hook_form_alter, this function synchrnized the legacy_paths field with the redirects table.
+ * The legacy_paths field is essentially a new specialized UI for redirects.
+ *
+ * @return void
+ */
+function portland_legacy_redirects_sync_redirects(&$form) {
+
+  $nid = \Drupal::routeMatch()->getParameter('node')->Id();
+  $redirect_url = "entity:node/$nid";
+  $redirects = \Drupal::service('redirect.repository')->findByDestinationUri([$redirect_url]);
+  $new_deltas = array();
+  $field = $form['field_legacy_path']['widget'];
+  $max_delta = $field['#max_delta'];
+
+    // if max_delta is zero, that means no paths have been saved, and a blank field has
+    // been added to the form. we want that blank field to be at the end.
+  $delta_counter = $max_delta == 0 ? $max_delta : $max_delta + 1;
+  $save_empty_delta;
+  if ($max_delta == 0) {
+    $delta_counter = 0;
+    $save_empty_delta = $form['field_legacy_path']['widget'][0];
+    unset($form['field_legacy_path']['widget'][0]);
+  } else {
+    $delta_counter = $max_delta + 1;
+  }
+
+    // need to make sure there's a field delta for each of the redirects in $redirects,
+  foreach ($redirects as $key => $redirect) {
+
+    $source_path = $redirect->getSource()['path'];
+
+      // spin through field_legacy_path values to see if $source_path is in there. if not, add.
+    for ($i = 0; $i < $max_delta; $i++) {
+      $source_value = portland_legacy_redirects_strip_leading_slash($field[$i]['value']['#default_value']);
+      if ($source_path == $source_value) {
+        break 2;
+      }
+    }
+
+      // if there wasn't a match and break by this point, add $source_path to a temporary array,
+      // which will be appended to field_legacy_path widget after the loops.
+    $new_deltas[$delta_counter] = [
+      '#delta' => $delta_counter,
+      '#weight' => $delta_counter,
+      'value' => [
+        '#type' => 'textfield',
+        '#size' => 60,
+        '#maxlength' => 255,
+        '#default_value' => '/' . $source_path
+      ],
+    ];
+
+    $delta_counter++;
+    $test = $form;
+  }
+
+    // now add new deltas to field
+  foreach ($new_deltas as $idx => $delta) {
+    $form['field_legacy_path']['widget'][] = $delta;
+  }
+  if ($max_delta == 0) {
+    $form['field_legacy_path']['widget'][] = $save_empty_delta;
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function portland_legacy_redirects_entity_update($entity) {
+  // if this is a node that has the legacy path field, create redirects
+  if ($entity->getEntityTypeId() == 'node' && $entity->hasField('field_legacy_path')){
+
+    $field = $entity->get('field_legacy_path')->getValue();
+    $field_orig = $entity->get('field_legacy_path')->getValue();
+
+    $redirect_url = "entity:node/" . $entity->id(); // $entity->toUrl()->toUriString()
+    // $entity->toUrl()->toUriString() generates a URI string that looks like this: route:entity.node.canonical;node=332.
+    // The Redirect module stores a string that looks like this: entity:node/332.
+    // Both work for redirection, but only ones in the latter format appear in the node's URL Redirects panel.
+
+    // existing redirects
+    $redirects = \Drupal::service('redirect.repository')->findByDestinationUri([$redirect_url]);
+
+
+    foreach ($field as $delta => $value) {
+      $from_orig = $field_orig[$delta]['value'];
+      $from = $value['value']; // from should always be unique because you can't have a source URL pointing to multiple destinations.
+      if (substr($from, 0, 1) == "/") { $from = substr($from, 1); }
+
+      $existing_from = \Drupal::service('redirect.repository')->findBySourcePath($from);
+
+      if ($existing_from) {
+        // this one already exists, don't add it to redirects table
+        continue;
+      }
+
+      // when to break?
+      // if (!$from == !$from_orig) break;
+
+      if ($from == $from_orig && !$existing_from) {
+        // first time, create it, nothing to delete
+      }
+
+      Redirect::create([
+        'redirect_source' => $from,
+        'redirect_redirect' => $redirect_url,
+        'status_code' => 301,
+      ])->save();
+    }
+  }
+}
+
+function portland_legacy_redirects_strip_leading_slash($path) {
+  return substr($path, 0, 1) == "/" ? substr($path, 1) : $path;
+}
+

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/portland_legacy_redirects.module
@@ -20,9 +20,9 @@ function portland_legacy_redirects_entity_bundle_field_info_alter(&$fields, \Dru
  */
 function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_state, $form_id)
 {
-  // so that we don't need to call out all applicable forms by id, try to get the entity type.
-  // the form and entity methods we need aren't available in all instances where this hook might
-  // be called, so we've added a bunch of null ref checks so nothing break.s
+  // this hook gets called on every form in the site. filter out requests by checking the
+  // entity type. not all form objects support the getEntityTypeId method, so we need to do
+  // some checks first so nothing breaks.
   $form_object = $form_state->getFormObject();
   if ($form_object && method_exists($form_object, 'getEntity')) {
     $entity = $form_object->getEntity();
@@ -35,7 +35,7 @@ function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_s
         $this_node = \Drupal::routeMatch()->getParameter($type);
         if ($this_node) portland_legacy_redirects_sync_redirects($form, $this_node->Id(), $type);
       }
-      
+
     }
   }
 }
@@ -48,7 +48,7 @@ function portland_legacy_redirects_form_alter(&$form, FormStateInterface $form_s
  */
 function portland_legacy_redirects_sync_redirects(&$form, $nid, $type) {
 
-  // if this is a new node, return now
+  // if this is a new node form, exit this function
   $this_node = \Drupal::routeMatch()->getParameter($type);
   if (!$this_node) return;
 
@@ -80,7 +80,7 @@ function portland_legacy_redirects_sync_redirects(&$form, $nid, $type) {
     for ($i = 0; $i < $max_delta; $i++) {
       $source_value = portland_legacy_redirects_strip_leading_slash($field[$i]['value']['#default_value']);
       if ($source_path == $source_value) {
-        break 2;
+        continue 2;
       }
     }
 

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraint.php
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraint.php
@@ -22,5 +22,6 @@ class RelativePathConstraint extends Constraint
    */
   public $not_relative = "The legacy path must be relative (i.e. no protocol or domain) and start with a slash.";
   public $illegal_chars = "The legacy path contains invalid characters. It should only contain letters, numbers, and the following symbols: slash (/), dot (.), hyphen (-), and underscore (_)";
-
+  public $duplicate_in_form = "A legacy path may only be entered once. Please remove the duplicate path.";
+  public $duplicate_redirect = "This legacy path already redirects to a content node in the system. A path cannot redirect to multiple nodes.";
 }

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraint.php
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraint.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\portland_legacy_redirects\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Make sure end date/time is after start date/time.
+ *
+ * @Constraint(
+ *   id = "relative_path",
+ *   label = @Translation("Verifies path is relative.", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class RelativePathConstraint extends Constraint
+{
+  /**
+   * Message shown when the path is not relative (i.e. /some/path/here).
+   *
+   * @var string
+   */
+  public $not_relative = "The legacy path must be relative (i.e. no protocol or domain) and start with a slash.";
+  public $illegal_chars = "The legacy path contains invalid characters. It should only contain letters, numbers, and the following symbols: slash (/), dot (.), hyphen (-), and underscore (_)";
+
+}

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraintValidator.php
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraintValidator.php
@@ -100,13 +100,13 @@ class RelativePathConstraintValidator extends ConstraintValidator {
 
   function validateUniquePathInSystem($path)
   {
-    // search for any nodes that already use this path
-    $this_node = \Drupal::routeMatch()->getParameter('node');
+    // search for any nodes that already use this pathf
+    $this_node = \Drupal::routeMatch()->getParameter('group');
     $this_id = $this_node->Id();
-    $result = \Drupal::entityQuery('node')->condition("field_legacy_path", $path)->execute();
+    $result = \Drupal::entityQuery('group')->condition("field_legacy_path", $path)->execute();
     foreach ($result as $idx => $found_id) {
       if ($found_id == $this_id) continue;
-      return \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $found_id);
+      return \Drupal::service('path.alias_manager')->getAliasByPath('/group/' . $found_id);
     }
     return true;
   }

--- a/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraintValidator.php
+++ b/web/modules/custom/portland/modules/portland_legacy_redirects/src/Plugin/Validation/Constraint/RelativePathConstraintValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\portland_legacy_redirects\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Drupal\Core\Field\FieldItemListInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+/**
+ * Validates the PreventAnon constraint.
+ */
+class RelativePathConstraintValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($field, Constraint $constraint) {
+
+    // is it single value or FieldItemList?
+    if ($field instanceof FieldItemListInterface) {
+      foreach( $field as $delta => $value) {
+        $path = $value->value;
+
+        // test if path is bare (no protocol)
+        if (!$this->validateRelative($path)) {
+          // remove protocol from path for use as a suggestion in the validation message
+          $relative_path = parse_url($path, PHP_URL_PATH);
+          $message = $constraint->not_relative . " Try using \"$relative_path\" instead.";
+          $this->setViolation($message, $delta);
+        }
+
+        // test if path starts with slash
+        if (!$this->validateStartsWithSlash($path)) {
+          $message = $constraint->not_relative;
+          $this->setViolation($message, $delta);
+        }
+
+        // test if any illegal characters
+        if (!$this->validateValidChars($path)) {
+          $message = $constraint->illegal_chars;
+          $this->setViolation($message, $delta);
+        }
+
+      }
+    }
+    
+    $test = "stop";
+  }
+
+  // creates and adds a violation, but also sets the property path so that the
+  // correct field in the multiple-value widget is targeted.
+  function setViolation($message, $delta) {
+    $this->context->buildViolation($message)
+      ->atPath((string) $delta)
+      ->addViolation();
+  }
+
+  function validateRelative($path) {
+    // don't want to see http/https at start of path.
+    return !preg_match('/^(?:http|https):\/\/.+$/', $path);
+  }
+
+  function validateStartsWithSlash($path) {
+    // want to see slash at start of path
+    return preg_match('/^\/.+/', $path);
+  }
+
+  function validateValidChars($path) {
+    // only want to see these characters in path
+    return !preg_match('/[^\/\w.-]/', $path);
+  }
+}

--- a/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.bureau_office.field_audience
     - field.field.group.bureau_office.field_building
     - field.field.group.bureau_office.field_email
+    - field.field.group.bureau_office.field_legacy_path
     - field.field.group.bureau_office.field_logo
     - field.field.group.bureau_office.field_official_organization_name
     - field.field.group.bureau_office.field_phone
@@ -73,6 +74,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_legacy_path:
+    weight: 25
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_logo:
     type: image_image

--- a/web/sites/default/config/core.entity_form_display.group.elected_official.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.elected_official.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.elected_official.field_building
     - field.field.group.elected_official.field_bureaus
     - field.field.group.elected_official.field_email
+    - field.field.group.elected_official.field_legacy_path
     - field.field.group.elected_official.field_logo
     - field.field.group.elected_official.field_official_title
     - field.field.group.elected_official.field_phone
@@ -74,6 +75,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_legacy_path:
+    weight: 21
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_logo:
     type: image_image

--- a/web/sites/default/config/core.entity_form_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.program.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.program.field_audience
     - field.field.group.program.field_building
     - field.field.group.program.field_email
+    - field.field.group.program.field_legacy_path
     - field.field.group.program.field_logo
     - field.field.group.program.field_phone
     - field.field.group.program.field_shortname_or_acronym
@@ -72,6 +73,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_legacy_path:
+    weight: 21
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_logo:
     type: image_image

--- a/web/sites/default/config/core.entity_form_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.project.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.group.project.field_audience
     - field.field.group.project.field_date_time_range
+    - field.field.group.project.field_legacy_path
     - field.field.group.project.field_shortname_or_acronym
     - field.field.group.project.field_summary
     - field.field.group.project.field_topics
@@ -29,6 +30,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: daterange_default
+    region: content
+  field_legacy_path:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_shortname_or_acronym:
     weight: 1

--- a/web/sites/default/config/core.entity_form_display.node.building.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.building.default.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.node.building.field_address
+    - field.field.node.building.field_legacy_path
     - node.type.building
   module:
     - address
     - content_moderation
-    - datetime
     - path
 id: node.building.default
 targetEntityType: node
@@ -27,6 +27,14 @@ content:
       default_country: null
     third_party_settings: {  }
     type: address_default
+    region: content
+  field_legacy_path:
+    weight: 51
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   moderation_state:
     type: moderation_state_default
@@ -84,4 +92,7 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
 hidden: {  }

--- a/web/sites/default/config/core.entity_form_display.node.city_service.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.city_service.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.city_service.field_audience
     - field.field.node.city_service.field_community_actions
+    - field.field.node.city_service.field_legacy_path
     - field.field.node.city_service.field_related_content
     - field.field.node.city_service.field_service_mode
     - field.field.node.city_service.field_summary
@@ -38,6 +39,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: chosen_select
+    region: content
+  field_legacy_path:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_related_content:
     weight: 7

--- a/web/sites/default/config/core.entity_form_display.node.event.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_end_date
     - field.field.node.event.field_end_time
     - field.field.node.event.field_event_location
+    - field.field.node.event.field_legacy_path
     - field.field.node.event.field_start_date
     - field.field.node.event.field_start_time
     - field.field.node.event.field_summary
@@ -88,6 +89,14 @@ content:
       form_display_mode: default
       default_paragraph_type: ''
     third_party_settings: {  }
+    region: content
+  field_legacy_path:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_start_date:
     weight: 7

--- a/web/sites/default/config/core.entity_form_display.node.guide.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.guide.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.guide.field_body
+    - field.field.node.guide.field_legacy_path
     - field.field.node.guide.field_related_content
     - field.field.node.guide.field_summary_and_lead_paragraph
     - field.field.node.guide.field_topics
@@ -41,6 +42,14 @@ content:
         add_above: add_above
     third_party_settings: {  }
     type: paragraphs
+    region: content
+  field_legacy_path:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_related_content:
     weight: 4

--- a/web/sites/default/config/core.entity_form_display.node.information.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.information.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.information.field_body
+    - field.field.node.information.field_legacy_path
     - node.type.information
   module:
     - content_moderation
@@ -37,6 +38,14 @@ content:
         collapse_edit_all: collapse_edit_all
         add_above: add_above
     third_party_settings: {  }
+    region: content
+  field_legacy_path:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   moderation_state:
     type: moderation_state_default

--- a/web/sites/default/config/core.entity_form_display.node.news.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.news.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.news.field_body
+    - field.field.node.news.field_legacy_path
     - field.field.node.news.field_summary_and_lead_paragraph
     - field.field.node.news.field_topics
     - node.type.news
@@ -40,6 +41,14 @@ content:
         add_above: add_above
     third_party_settings: {  }
     type: paragraphs
+    region: content
+  field_legacy_path:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_summary_and_lead_paragraph:
     weight: 1

--- a/web/sites/default/config/core.entity_form_display.node.service_location.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.service_location.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.service_location.field_building
     - field.field.node.service_location.field_floor
     - field.field.node.service_location.field_get_directions
+    - field.field.node.service_location.field_legacy_path
     - field.field.node.service_location.field_open_hours
     - node.type.service_location
   module:
@@ -40,6 +41,14 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  field_legacy_path:
+    weight: 51
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_open_hours:
     weight: 3
     settings:
@@ -56,6 +65,9 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
 hidden:
   created: true
   moderation_state: true

--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.bureau_office.field_audience
     - field.field.group.bureau_office.field_building
     - field.field.group.bureau_office.field_email
+    - field.field.group.bureau_office.field_legacy_path
     - field.field.group.bureau_office.field_logo
     - field.field.group.bureau_office.field_official_organization_name
     - field.field.group.bureau_office.field_phone
@@ -67,6 +68,14 @@ targetEntityType: group
 bundle: bureau_office
 mode: default
 content:
+  field_legacy_path:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_summary:
     type: string
     weight: 1

--- a/web/sites/default/config/core.entity_view_display.group.elected_official.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.elected_official.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.elected_official.field_building
     - field.field.group.elected_official.field_bureaus
     - field.field.group.elected_official.field_email
+    - field.field.group.elected_official.field_legacy_path
     - field.field.group.elected_official.field_logo
     - field.field.group.elected_official.field_official_title
     - field.field.group.elected_official.field_phone
@@ -41,6 +42,7 @@ hidden:
   field_building: true
   field_bureaus: true
   field_email: true
+  field_legacy_path: true
   field_logo: true
   field_official_title: true
   field_phone: true

--- a/web/sites/default/config/core.entity_view_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.program.field_audience
     - field.field.group.program.field_building
     - field.field.group.program.field_email
+    - field.field.group.program.field_legacy_path
     - field.field.group.program.field_logo
     - field.field.group.program.field_phone
     - field.field.group.program.field_shortname_or_acronym
@@ -41,6 +42,7 @@ hidden:
   field_audience: true
   field_building: true
   field_email: true
+  field_legacy_path: true
   field_logo: true
   field_phone: true
   field_shortname_or_acronym: true

--- a/web/sites/default/config/core.entity_view_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.project.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.group.project.field_audience
     - field.field.group.project.field_date_time_range
+    - field.field.group.project.field_legacy_path
     - field.field.group.project.field_shortname_or_acronym
     - field.field.group.project.field_summary
     - field.field.group.project.field_topics
@@ -61,5 +62,6 @@ content:
 hidden:
   changed: true
   created: true
+  field_legacy_path: true
   field_shortname_or_acronym: true
   uid: true

--- a/web/sites/default/config/core.entity_view_display.node.building.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.building.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.building.field_address
+    - field.field.node.building.field_legacy_path
     - node.type.building
   module:
     - address
@@ -29,5 +30,6 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_legacy_path: true
   links: true
   scheduled_publication: true

--- a/web/sites/default/config/core.entity_view_display.node.city_service.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.city_service.field_audience
     - field.field.node.city_service.field_community_actions
+    - field.field.node.city_service.field_legacy_path
     - field.field.node.city_service.field_related_content
     - field.field.node.city_service.field_service_mode
     - field.field.node.city_service.field_summary
@@ -59,6 +60,7 @@ content:
 hidden:
   field_audience: true
   field_community_actions: true
+  field_legacy_path: true
   field_related_content: true
   field_topics: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.event.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.event.field_end_date
     - field.field.node.event.field_end_time
     - field.field.node.event.field_event_location
+    - field.field.node.event.field_legacy_path
     - field.field.node.event.field_start_date
     - field.field.node.event.field_start_time
     - field.field.node.event.field_summary
@@ -105,4 +106,5 @@ content:
     type: string
     region: content
 hidden:
+  field_legacy_path: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.guide.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.guide.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.guide.field_body
+    - field.field.node.guide.field_legacy_path
     - field.field.node.guide.field_related_content
     - field.field.node.guide.field_summary_and_lead_paragraph
     - field.field.node.guide.field_topics
@@ -46,6 +47,7 @@ content:
     type: string
     region: content
 hidden:
+  field_legacy_path: true
   field_related_content: true
   field_topics: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.information.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.information.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.information.field_body
+    - field.field.node.information.field_legacy_path
     - node.type.information
   module:
     - entity_reference_revisions
@@ -35,5 +36,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_legacy_path: true
   links: true
   scheduled_publication: true

--- a/web/sites/default/config/core.entity_view_display.node.news.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.news.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.news.field_body
+    - field.field.node.news.field_legacy_path
     - field.field.node.news.field_summary_and_lead_paragraph
     - field.field.node.news.field_topics
     - node.type.news
@@ -53,4 +54,5 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  field_legacy_path: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.service_location.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.service_location.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.service_location.field_building
     - field.field.node.service_location.field_floor
     - field.field.node.service_location.field_get_directions
+    - field.field.node.service_location.field_legacy_path
     - field.field.node.service_location.field_open_hours
     - node.type.service_location
   module:
@@ -62,5 +63,6 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_legacy_path: true
   links: true
   scheduled_publication: true

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -100,6 +100,7 @@ module:
   panels_ipe: 0
   path: 0
   portland: 0
+  portland_legacy_redirects: 0
   quickedit: 0
   rdf: 0
   redirect: 0

--- a/web/sites/default/config/facets.facet.bureaus_by_audience.yml
+++ b/web/sites/default/config/facets.facet.bureaus_by_audience.yml
@@ -36,17 +36,17 @@ processor_configs:
     weights:
       sort: -10
     settings:
-      sort: DESC
+      sort: ASC
   count_widget_order:
     processor_id: count_widget_order
     weights:
-      sort: -10
+      sort: -9
     settings:
       sort: DESC
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: -8
     settings:
       sort: ASC
   url_processor_handler:
@@ -57,3 +57,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
+show_title: false

--- a/web/sites/default/config/facets.facet.bureaus_by_topic.yml
+++ b/web/sites/default/config/facets.facet.bureaus_by_topic.yml
@@ -36,17 +36,17 @@ processor_configs:
     weights:
       sort: -10
     settings:
-      sort: DESC
+      sort: ASC
   count_widget_order:
     processor_id: count_widget_order
     weights:
-      sort: -10
+      sort: -9
     settings:
       sort: DESC
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: -8
     settings:
       sort: ASC
   url_processor_handler:

--- a/web/sites/default/config/facets.facet.services_by_action.yml
+++ b/web/sites/default/config/facets.facet.services_by_action.yml
@@ -36,7 +36,7 @@ processor_configs:
     weights:
       sort: -10
     settings:
-      sort: DESC
+      sort: ASC
   count_limit:
     processor_id: count_limit
     weights:
@@ -47,13 +47,13 @@ processor_configs:
   count_widget_order:
     processor_id: count_widget_order
     weights:
-      sort: -10
+      sort: -9
     settings:
       sort: DESC
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: -8
     settings:
       sort: ASC
   url_processor_handler:

--- a/web/sites/default/config/facets.facet.services_by_audience.yml
+++ b/web/sites/default/config/facets.facet.services_by_audience.yml
@@ -36,7 +36,7 @@ processor_configs:
     weights:
       sort: -10
     settings:
-      sort: DESC
+      sort: ASC
   count_limit:
     processor_id: count_limit
     weights:
@@ -47,13 +47,13 @@ processor_configs:
   count_widget_order:
     processor_id: count_widget_order
     weights:
-      sort: -10
+      sort: -9
     settings:
       sort: DESC
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: -8
     settings:
       sort: ASC
   url_processor_handler:

--- a/web/sites/default/config/facets.facet.services_by_topic.yml
+++ b/web/sites/default/config/facets.facet.services_by_topic.yml
@@ -34,9 +34,9 @@ processor_configs:
   active_widget_order:
     processor_id: active_widget_order
     weights:
-      sort: -10
+      sort: -9
     settings:
-      sort: DESC
+      sort: ASC
   count_limit:
     processor_id: count_limit
     weights:
@@ -53,7 +53,7 @@ processor_configs:
   display_value_widget_order:
     processor_id: display_value_widget_order
     weights:
-      sort: -10
+      sort: -8
     settings:
       sort: ASC
   url_processor_handler:

--- a/web/sites/default/config/field.field.group.bureau_office.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: b267b013-b8f0-483e-8a46-8af7ae22e4f1
+uuid: 92c509f0-b75b-4cd3-a6c0-975f7e8048e5
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_legacy_path
-    - node.type.building
+    - field.storage.group.field_legacy_path
+    - group.type.bureau_office
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
     custom_add_another: 'Add another path'
     custom_remove: 'Remove this path'
-id: node.building.field_legacy_path
+id: group.bureau_office.field_legacy_path
 field_name: field_legacy_path
-entity_type: node
-bundle: building
+entity_type: group
+bundle: bureau_office
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.group.elected_official.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.group.elected_official.field_legacy_path.yml
@@ -1,20 +1,20 @@
-uuid: b267b013-b8f0-483e-8a46-8af7ae22e4f1
+uuid: f39707fb-7773-453a-ae7c-c493e372f081
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_legacy_path
-    - node.type.building
+    - field.storage.group.field_legacy_path
+    - group.type.elected_official
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
     custom_add_another: 'Add another path'
     custom_remove: 'Remove this path'
-id: node.building.field_legacy_path
+id: group.elected_official.field_legacy_path
 field_name: field_legacy_path
-entity_type: node
-bundle: building
+entity_type: group
+bundle: elected_official
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false

--- a/web/sites/default/config/field.field.group.program.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.group.program.field_legacy_path.yml
@@ -1,20 +1,20 @@
-uuid: b267b013-b8f0-483e-8a46-8af7ae22e4f1
+uuid: c9a98f53-f450-47f0-bebf-8c1422a8ea91
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_legacy_path
-    - node.type.building
+    - field.storage.group.field_legacy_path
+    - group.type.program
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
     custom_add_another: 'Add another path'
     custom_remove: 'Remove this path'
-id: node.building.field_legacy_path
+id: group.program.field_legacy_path
 field_name: field_legacy_path
-entity_type: node
-bundle: building
+entity_type: group
+bundle: program
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false

--- a/web/sites/default/config/field.field.group.project.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.group.project.field_legacy_path.yml
@@ -1,20 +1,20 @@
-uuid: b267b013-b8f0-483e-8a46-8af7ae22e4f1
+uuid: 87eb93c6-aee5-4205-9f6b-cd0a9cf10666
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_legacy_path
-    - node.type.building
+    - field.storage.group.field_legacy_path
+    - group.type.project
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
     custom_add_another: 'Add another path'
     custom_remove: 'Remove this path'
-id: node.building.field_legacy_path
+id: group.project.field_legacy_path
 field_name: field_legacy_path
-entity_type: node
-bundle: building
+entity_type: group
+bundle: project
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false

--- a/web/sites/default/config/field.field.node.building.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.building.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: b267b013-b8f0-483e-8a46-8af7ae22e4f1
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.building
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.building.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: building
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.node.city_service.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.city_service.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: a65b4289-f651-486e-b299-7be8ad659800
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.city_service
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.city_service.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: city_service
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.node.city_service.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.city_service.field_legacy_path.yml
@@ -9,8 +9,8 @@ dependencies:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: ''
-    custom_remove: ''
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
 id: node.city_service.field_legacy_path
 field_name: field_legacy_path
 entity_type: node

--- a/web/sites/default/config/field.field.node.event.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.event.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: 13f4421d-d9e9-4a1c-baa2-9bb188c6fd3a
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.event
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.event.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: event
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.node.event.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.event.field_legacy_path.yml
@@ -9,8 +9,8 @@ dependencies:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: ''
-    custom_remove: ''
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
 id: node.event.field_legacy_path
 field_name: field_legacy_path
 entity_type: node

--- a/web/sites/default/config/field.field.node.guide.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.guide.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: e801fefe-bfe1-49f4-96bb-df382757afe5
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.guide
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.guide.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: guide
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.node.guide.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.guide.field_legacy_path.yml
@@ -9,8 +9,8 @@ dependencies:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: ''
-    custom_remove: ''
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
 id: node.guide.field_legacy_path
 field_name: field_legacy_path
 entity_type: node

--- a/web/sites/default/config/field.field.node.information.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.information.field_legacy_path.yml
@@ -1,0 +1,25 @@
+uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_legacy_path
+    - node.type.information
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
+id: node.information.field_legacy_path
+field_name: field_legacy_path
+entity_type: node
+bundle: information
+label: 'Legacy path'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.node.news.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.news.field_legacy_path.yml
@@ -9,8 +9,8 @@ dependencies:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: ''
-    custom_remove: ''
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
 id: node.news.field_legacy_path
 field_name: field_legacy_path
 entity_type: node

--- a/web/sites/default/config/field.field.node.news.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.news.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: 2df9324b-0e58-4ffb-928a-c67733c32729
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.news
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.news.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: news
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.field.node.service_location.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.service_location.field_legacy_path.yml
@@ -9,8 +9,8 @@ dependencies:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: ''
-    custom_remove: ''
+    custom_add_another: 'Add another path'
+    custom_remove: 'Remove this path'
 id: node.service_location.field_legacy_path
 field_name: field_legacy_path
 entity_type: node

--- a/web/sites/default/config/field.field.node.service_location.field_legacy_path.yml
+++ b/web/sites/default/config/field.field.node.service_location.field_legacy_path.yml
@@ -1,24 +1,24 @@
-uuid: f170fc7a-c53a-47c8-8588-d59737bad775
+uuid: 275089ed-0a28-4e42-89f7-3b89cbacd804
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_legacy_path
-    - node.type.information
+    - node.type.service_location
   module:
     - custom_add_another
 third_party_settings:
   custom_add_another:
-    custom_add_another: 'Add another path'
-    custom_remove: 'Remove this path'
-id: node.information.field_legacy_path
+    custom_add_another: ''
+    custom_remove: ''
+id: node.service_location.field_legacy_path
 field_name: field_legacy_path
 entity_type: node
-bundle: information
+bundle: service_location
 label: 'Legacy path'
 description: 'This field is used to create redirects to this page from legacy pages in the old site. Multiple paths may be entered in case several pages have been combined during migration. Once these paths are created, they may only be modified or removed by an administrator. Paths must be relative and start with a slash. For example, the page "https://www.portlandoregon.gov/bts/39479" should be entered as "/bts/39479."'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/sites/default/config/field.storage.group.field_legacy_path.yml
+++ b/web/sites/default/config/field.storage.group.field_legacy_path.yml
@@ -1,0 +1,21 @@
+uuid: c6ef0c72-30bc-46bc-a4b4-15ef8d396de9
+langcode: en
+status: true
+dependencies:
+  module:
+    - group
+id: group.field_legacy_path
+field_name: field_legacy_path
+entity_type: group
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/sites/default/config/field.storage.node.field_legacy_path.yml
+++ b/web/sites/default/config/field.storage.node.field_legacy_path.yml
@@ -1,0 +1,21 @@
+uuid: bcd842fd-281f-4b32-aff8-a266e9354b52
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_legacy_path
+field_name: field_legacy_path
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/sites/default/config/lightning_core.versions.yml
+++ b/web/sites/default/config/lightning_core.versions.yml
@@ -65,7 +65,7 @@ metatag: 0.0.0
 node: 0.0.0
 openapi: 0.0.0
 openapi_ui: 0.0.0
-openapi_ui_swagger: 0
+openapi_ui_swagger: '0'
 openapi_ui_redoc: 0.0.0
 options: 0.0.0
 page_cache: 0.0.0

--- a/web/sites/default/config/lightning_core.versions.yml
+++ b/web/sites/default/config/lightning_core.versions.yml
@@ -147,3 +147,4 @@ comment: 8.5.6
 search_api_page: 1.0.0-alpha12
 extlink: 1.1.0
 clamav: 1.0.0
+portland_legacy_redirects: 0.1.0

--- a/web/sites/default/config/views.view.bureaus_and_offices.yml
+++ b/web/sites/default/config/views.view.bureaus_and_offices.yml
@@ -40,7 +40,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Search
+          submit_button: 'Search bureaus and offices'
           reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -71,14 +71,18 @@ display:
       style:
         type: html_list
         options:
-          grouping: {  }
-          row_class: list-group-item
-          default_row_class: true
+          row_class: 'list-group-item list-group-item-action'
+          default_row_class: false
+          uses_fields: false
           type: ul
           wrapper_class: container
           class: 'list-group col-12'
       row:
-        type: fields
+        type: search_api
+        options:
+          view_modes:
+            'entity:group':
+              bureau_office: teaser
       fields:
         label:
           id: label

--- a/web/sites/default/config/views.view.services_index.yml
+++ b/web/sites/default/config/views.view.services_index.yml
@@ -36,7 +36,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Search
+          submit_button: 'Search services'
           reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -67,14 +67,18 @@ display:
       style:
         type: html_list
         options:
-          grouping: {  }
-          row_class: list-group-item
+          row_class: 'list-group-item list-group-item-action'
           default_row_class: true
+          uses_fields: false
           type: ul
           wrapper_class: container
           class: 'list-group col-12'
       row:
-        type: fields
+        type: search_api
+        options:
+          view_modes:
+            'entity:node':
+              city_service: teaser
       fields:
         title:
           id: title
@@ -192,7 +196,7 @@ display:
           parse_mode: terms
           min_length: null
           fields:
-            rendered_item: rendered_item
+            - rendered_item
           plugin_id: search_api_fulltext
       sorts:
         title:


### PR DESCRIPTION
This story adds a custom field to all content and group types (except Alert and Notification) that allows editors to enter one or many paths that should redirect to the current node. Once past validation and the node is saved, these paths are saved as redirects using the Redirect module API.

The functionality has been created in a new module portland_legacy_redirects.