### PR TITLE
POWR-450 - Fix for broken node revisions

### DIFF
--- a/web/themes/custom/cloudy/cloudy.theme
+++ b/web/themes/custom/cloudy/cloudy.theme
@@ -56,6 +56,9 @@ function cloudy_preprocess_html(&$variables) {
   $route_match = \Drupal::service('current_route_match');
   // if this is a node
   if ($node = $route_match->getParameter('node')) {
+    if (!$node instanceof \Drupal\Core\Entity\ContentEntityInterface) {
+      $node = \Drupal\node\Entity\Node::load($node);
+    }
     // that is group content
     foreach (GroupContent::loadByEntity($node) as $group_content) {
       // give it the shortname as a class


### PR DESCRIPTION
When loading a past revision, the $node var is a string representation of the node id, but the following loadByEntity($node) function expects an object of type ContentEntityInterface. I added logic to check the type, and reload $node as a node object if it's not the right type.