### PR TITLE
POWR-379 - Added default metadata configuration and changed site name to Portland.gov

### DIFF
--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.contact_information.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.contact_information.yml
@@ -102,6 +102,7 @@ hidden:
   field_building: true
   field_legacy_path: true
   field_logo: true
+  field_parent_group: true
   field_shortname_or_acronym: true
   field_summary: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.search_result.yml
@@ -151,6 +151,7 @@ hidden:
   field_legacy_path: true
   field_logo: true
   field_official_organization_name: true
+  field_parent_group: true
   field_phone: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.teaser.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.teaser.yml
@@ -89,6 +89,7 @@ hidden:
   field_legacy_path: true
   field_logo: true
   field_official_organization_name: true
+  field_parent_group: true
   field_phone: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.program.contact_information.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.contact_information.yml
@@ -58,6 +58,7 @@ hidden:
   field_building: true
   field_legacy_path: true
   field_logo: true
+  field_parent_group: true
   field_shortname_or_acronym: true
   field_summary: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
@@ -149,6 +149,7 @@ hidden:
   field_email: true
   field_legacy_path: true
   field_logo: true
+  field_parent_group: true
   field_phone: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -93,6 +93,8 @@ module:
   menu_ui: 0
   metatag: 0
   moderation_dashboard: 0
+  metatag_open_graph: 0
+  metatag_twitter_cards: 0
   node: 0
   openapi: 0
   openapi_ui: 0

--- a/web/sites/default/config/lightning_core.versions.yml
+++ b/web/sites/default/config/lightning_core.versions.yml
@@ -159,3 +159,5 @@ config_filter: 1.3.0
 config_split: 1.4.0
 easy_breadcrumb: 1.8.0
 media_library: 8.6.1
+metatag_open_graph: 0.0.0
+metatag_twitter_cards: 0.0.0

--- a/web/sites/default/config/metatag.metatag_defaults.403.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.403.yml
@@ -7,5 +7,4 @@ _core:
 id: '403'
 label: '403 access denied'
 tags:
-  canonical_url: '[site:url]'
-  shortlink: '[site:url]'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.404.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.404.yml
@@ -7,5 +7,4 @@ _core:
 id: '404'
 label: '404 page not found'
 tags:
-  canonical_url: '[site:url]'
-  shortlink: '[site:url]'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.front.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.front.yml
@@ -8,4 +8,11 @@ id: front
 label: 'Front page'
 tags:
   canonical_url: '[site:url]'
-  shortlink: '[site:url]'
+  description: '[site:slogan]'
+  title: 'Home | [site:name]'
+  og_description: '[site:slogan]'
+  og_site_name: '[site:name]'
+  og_title: 'Home | [site:name]'
+  twitter_cards_page_url: '[site:url]'
+  twitter_cards_title: 'Home | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.global.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.global.yml
@@ -8,4 +8,12 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
+  description: '[node:field_summary]'
   title: '[current-page:title] | [site:name]'
+  og_description: '[node:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[node:field_summary]'
+  twitter_cards_page_url: '[current-page:url]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.group__bureau_office.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group__bureau_office.yml
@@ -1,0 +1,17 @@
+uuid: 2f84c324-e72d-49e7-bedc-d84c0cada80c
+langcode: en
+status: true
+dependencies: {  }
+id: group__bureau_office
+label: 'Group: Bureau/office'
+tags:
+  canonical_url: '[current-page:url]'
+  description: '[group:field_summary]'
+  title: '[current-page:title] | [site:name]'
+  og_description: '[group:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[group:field_summary]'
+  twitter_cards_page_url: '[current-page:url]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.group__elected_official.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group__elected_official.yml
@@ -1,0 +1,16 @@
+uuid: 09dd0eb3-e6ec-4c51-86a9-00429cf603f5
+langcode: en
+status: true
+dependencies: {  }
+id: group__elected_official
+label: 'Group: Elected official'
+tags:
+  canonical_url: '[current-page:url]'
+  description: '[group:field_summary]'
+  title: '[current-page:title] | [site:name]'
+  og_description: '[group:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[group:field_summary]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.group__program.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group__program.yml
@@ -1,0 +1,17 @@
+uuid: 5ae43d80-0398-4c2e-a414-5083af9d5c2f
+langcode: en
+status: true
+dependencies: {  }
+id: group__program
+label: 'Group: Program'
+tags:
+  canonical_url: '[current-page:url]'
+  description: '[group:field_summary]'
+  title: '[current-page:title] | [site:name]'
+  og_description: '[group:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[group:field_summary]'
+  twitter_cards_page_url: '[current-page:url]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.group__project.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group__project.yml
@@ -1,0 +1,17 @@
+uuid: 3176e31d-d96e-46bb-8244-05c718fecfe6
+langcode: en
+status: true
+dependencies: {  }
+id: group__project
+label: 'Group: Project'
+tags:
+  canonical_url: '[current-page:url]'
+  description: '[group:field_summary]'
+  title: '[current-page:title] | [site:name]'
+  og_description: '[group:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[group:field_summary]'
+  twitter_cards_page_url: '[current-page:url]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ab6b4e6568ca8.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ab6b4e6568ca8.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: group_content__group_content_type_ab6b4e6568ca8
 label: 'Group content: Elected official: Group node (Notification)'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ab6b4e6568ca8.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ab6b4e6568ca8.yml
@@ -1,0 +1,8 @@
+uuid: 8ddc094e-58a7-48db-b35d-68bfcf62b12a
+langcode: en
+status: true
+dependencies: {  }
+id: group_content__group_content_type_ab6b4e6568ca8
+label: 'Group content: Elected official: Group node (Notification)'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ba2512a3d9225.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ba2512a3d9225.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: group_content__group_content_type_ba2512a3d9225
 label: 'Group content: Bureau/office: Group node (Notification)'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ba2512a3d9225.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__group_content_type_ba2512a3d9225.yml
@@ -1,0 +1,8 @@
+uuid: 1ea85b89-6334-4fe0-94f5-eeb10d1620fa
+langcode: en
+status: true
+dependencies: {  }
+id: group_content__group_content_type_ba2512a3d9225
+label: 'Group content: Bureau/office: Group node (Notification)'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__program-group_node-notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__program-group_node-notification.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: group_content__program-group_node-notification
 label: 'Group content: Program: Group node (Notification)'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__program-group_node-notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__program-group_node-notification.yml
@@ -1,0 +1,8 @@
+uuid: b4a377ea-743b-4f54-bcf4-025f6dcefc52
+langcode: en
+status: true
+dependencies: {  }
+id: group_content__program-group_node-notification
+label: 'Group content: Program: Group node (Notification)'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__project-group_node-notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__project-group_node-notification.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: group_content__project-group_node-notification
 label: 'Group content: Project: Group node (Notification)'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.group_content__project-group_node-notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.group_content__project-group_node-notification.yml
@@ -1,0 +1,8 @@
+uuid: 8985d3d8-a978-444e-b31d-26a0d4b4ff7c
+langcode: en
+status: true
+dependencies: {  }
+id: group_content__project-group_node-notification
+label: 'Group content: Project: Group node (Notification)'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.node.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.node.yml
@@ -7,6 +7,12 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
-  description: '[node:summary]'
   canonical_url: '[node:url]'
+  description: '[node:field_summary]'
+  title: '[node:title] | [site:name]'
+  og_description: '[node:field_summary]'
+  og_site_name: '[site:name]'
+  og_title: '[current-page:title] | [site:name]'
+  twitter_cards_description: '[node:field_summary]'
+  twitter_cards_title: '[current-page:title] | [site:name]'
+  twitter_cards_type: summary

--- a/web/sites/default/config/metatag.metatag_defaults.node__alert.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.node__alert.yml
@@ -1,8 +1,8 @@
-uuid: 26a2b734-eab4-425c-b69c-c1387f44f4bb
+uuid: 90b1e5ab-1fcf-4749-a03e-6e495c1a725e
 langcode: en
 status: true
 dependencies: {  }
 id: node__alert
 label: 'Content: Alert'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.metatag_defaults.node__alert.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.node__alert.yml
@@ -1,0 +1,8 @@
+uuid: 26a2b734-eab4-425c-b69c-c1387f44f4bb
+langcode: en
+status: true
+dependencies: {  }
+id: node__alert
+label: 'Content: Alert'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.node__notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.node__notification.yml
@@ -1,0 +1,8 @@
+uuid: 416eae20-9c74-4b10-9d90-e855f5b8b7eb
+langcode: en
+status: true
+dependencies: {  }
+id: node__notification
+label: 'Content: Notification'
+tags:
+  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'

--- a/web/sites/default/config/metatag.metatag_defaults.node__notification.yml
+++ b/web/sites/default/config/metatag.metatag_defaults.node__notification.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: node__notification
 label: 'Content: Notification'
 tags:
-  robots: 'noindex, nofollow, noarchive, nosnippet, noydir, noimageindex'
+  robots: 'noindex, nofollow'

--- a/web/sites/default/config/metatag.settings.yml
+++ b/web/sites/default/config/metatag.settings.yml
@@ -1,0 +1,154 @@
+entity_type_groups:
+  group:
+    bureau_office:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    elected_official:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+  group_content:
+    bureau_office-group_node-event:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    bureau_office-group_node-guide:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    bureau_office-group_node-news:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    elected_official-group_node-news:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    group_content_type_25b7c32483485:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    group_content_type_671ea594dce34:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    group_content_type_c088a2077a0c7:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    group_content_type_d0bd127ef9e5c:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    group_content_type_f8c21c1e82c21:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program-group_node-city_service:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program-group_node-event:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program-group_node-guide:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program-group_node-information:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    program-group_node-news:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project-group_node-city_service:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project-group_node-event:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project-group_node-guide:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project-group_node-information:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    project-group_node-news:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+  node:
+    building:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    city_service:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    event:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    guide:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    information:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    news:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
+    service_location:
+      basic: basic
+      advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards

--- a/web/sites/default/config/system.site.yml
+++ b/web/sites/default/config/system.site.yml
@@ -1,7 +1,7 @@
 uuid: 191eddb9-0929-4dbd-bbfa-3f97bf1d93e0
-name: 'Portland Oregon'
+name: Portland.gov
 mail: joshua.mitchell@portlandoregon.gov
-slogan: ''
+slogan: 'This is the slogan'
 page:
   403: ''
   404: ''


### PR DESCRIPTION
As discussed in sprint planning, I've taken a quick look at what other cities are using as their site name and how it's formatted. They're all over the place, but the format we discussed seems to be the most common for sites with short, concise domain names ("Page Title | Portland.gov"). I think this is the shortest, cleanest approach and is used by boston.gov, seattle.gov, raleighnc.gov, riversideca.gov, AustinTexas.gov, et al.

This is ready for review & merge as soon as it passes QA.