### PR TITLE
POWR-323 - updates to tabs for accessibility

### DIFF
--- a/web/themes/custom/cloudy/js/global.js
+++ b/web/themes/custom/cloudy/js/global.js
@@ -52,7 +52,7 @@
         selectTab(urlHash, selectedTab);
       }
 
-      $('#serviceModes a.nav-link').click(function () {
+      $('#serviceModes a.nav-link').click(function (event) {
         // when service mode tab nav is clicked, add fragment to URL; use pushState so that
         // page doesn't jump to the anchor associated with the fragment.
         var linkHash = $(this).attr("href"); // i.e. #pane-2
@@ -88,6 +88,8 @@
 
       function selectTab(linkHash, tab) {
         // add tab to history/location
+        // NOTE: this adds the URL to the history, but it doesn't respect the url fragment
+        // to open the corresponding tab.
         if (history.pushState) {
           history.pushState(null, null, linkHash);
         } else {
@@ -100,10 +102,14 @@
 
         // aria-hidden should be true for all but visible pane
         $('#serviceModesContent .tab-pane').attr('aria-hidden', 'true');
-        $(linkHash).attr('aria-hidden', false)
+        var panel = $(linkHash);
+        panel.attr('aria-hidden', false);
 
-        // focus selected tab
-        tab.focus(); // NOTE: this has focus, but is not picking up focus style
+        // focus the first element in the panel; race condition requires a timeout
+        var first = panel.children().first();
+        first.attr('tabindex', '-1');
+        setTimeout(function() { first.focus(); }, 500);
+        first.focus(); // NOTE: this has focus, but is not picking up focus style
         focusedTab = tab;
       }
 

--- a/web/themes/custom/cloudy/js/global.js
+++ b/web/themes/custom/cloudy/js/global.js
@@ -39,51 +39,39 @@
   Drupal.behaviors.tab_handler = {
     attach: function (context, settings) {
 
-      // on initial load, check for tab navigation fragment in URL. if present, attempt to activate that tab.
       var urlHash = window.location.hash;
       var selectedTabIndex = 0;
       var selectedTab;
       var focusedTab;
+
+      // on initial load, check for tab navigation fragment in URL and activate indicated tab
       if (urlHash.indexOf('#pane-') > -1) {
         selectedTabIndex = getSelectedTabIndex(urlHash);
-        var tabId = '#tab-' + selectedTabIndex;
-        selectedTab = $(tabId);
+        selectedTab = $('#tab-' + selectedTabIndex);
         selectedTab.tab('show');
         selectTab(urlHash, selectedTab);
       }
 
-      // $(window).on('hashchange', function () {
-      //   selectedTabIndex = getSelectedTabIndex(urlHash);
-      //   var tabId = '#tab-' + selectedTabIndex;
-      //   selectedTab = $(tabId);
-      //   selectedTab.tab('show');
-      //   selectTab(urlHash, selectedTab);
-      // });
-
       $('#serviceModes a.nav-link').click(function (event) {
-        // when service mode tab nav is clicked, add fragment to URL; use pushState so that
-        // page doesn't jump to the anchor associated with the fragment.
         event.preventDefault();
-        var linkHash = $(this).attr("href"); // i.e. #pane-2
-        selectTab(linkHash, $(this));
+        // activate clicked tab using the link href
+        selectTab($(this).attr("href"), $(this));
       });
 
       $('#serviceModes').keydown(function(event) {
-        if (event.which == 39) { // right arrow
+        if (event.which == 39) {
           // focus tab to the right, if it exists
           var foundNext = focusedTab.parent().next().find('a');
           if (foundNext.attr('id')) {
             focusedTab = foundNext;
             focusedTab.focus();
-            console.log('focus ' + focusedTab.attr('id'));
           }
-        } else if (event.which == 37) { // left arrow
+        } else if (event.which == 37) {
           // focus tab to the left
           var foundPrev = focusedTab.parent().prev().find('a');
           if (foundPrev.attr('id')) {
             focusedTab = foundPrev;
             focusedTab.focus();
-            console.log('focus ' + focusedTab.attr('id'));
           }
         }
       });
@@ -96,9 +84,10 @@
       }
 
       function selectTab(linkHash, tab) {
-        // add tab to history/location
-        if (history.pushState) {
-          history.pushState(null, null, linkHash);
+        // add fragment to url; use replaceState to avoid filling up the history with tab changes;
+        // we are not supporting browser navigation between tabs/url fragments at this time
+        if (history.replaceState) {
+          history.replaceState(null, null, linkHash);
         } else {
           location.hash = linkHash;
         }
@@ -107,15 +96,13 @@
         $('#serviceModes a.nav-link').attr('tabindex', -1);
         tab.removeAttr('tabindex');
 
-        // aria-hidden should be true for all but visible pane
+        // aria-hidden should be true for all but visible pane; bootstrap doesn't handle this
         $('#serviceModesContent .tab-pane').attr('aria-hidden', 'true');
         var panel = $(linkHash);
         panel.attr('aria-hidden', false);
 
-        // focus the first element in the panel
-        var first = panel.children().first();
-        //setTimeout(function () { first.focus(); }, 2500);
-        first.focus();
+        // focus the active tab; necessary in the case of page reload or direct navigation
+        tab.focus();
         focusedTab = tab;
       }
     }

--- a/web/themes/custom/cloudy/js/global.js
+++ b/web/themes/custom/cloudy/js/global.js
@@ -13,24 +13,99 @@
       $('.page-node-1 .carousel').wrap('<div class="col-12 col-md-10 col-lg-8" />');
       $('.path-node .node--type-page').addClass('row');
 
-var classes = ['random1','random2', 'random3']; //add as many classes as u want
-var randomnumber = Math.floor(Math.random()*classes.length);
-$('body').addClass(classes[randomnumber]);
+      var classes = ['random1','random2', 'random3']; //add as many classes as u want
+      var randomnumber = Math.floor(Math.random()*classes.length);
+      $('body').addClass(classes[randomnumber]);
 
-$('.path-galerias #block-sass-starterkit-content').append("<div id='blueimp-gallery' class='blueimp-gallery'><div class='slides' /><h3 class='title' /><a class='prev'>‹</a><a class='next'>›</a><a class='close'>×</a><a class='play-pause' /><ol class='indicator' /></div>");
-$('.view-galerias').attr('id', 'links');
+      $('.path-galerias #block-sass-starterkit-content').append("<div id='blueimp-gallery' class='blueimp-gallery'><div class='slides' /><h3 class='title' /><a class='prev'>‹</a><a class='next'>›</a><a class='close'>×</a><a class='play-pause' /><ol class='indicator' /></div>");
+      $('.view-galerias').attr('id', 'links');
 
-$('.triple .view-content').addClass('ml-sm-1 mr-sm-1')
+      $('.triple .view-content').addClass('ml-sm-1 mr-sm-1');
 
-document.getElementById('links').onclick = function (event) {
-    event = event || window.event;
-    var target = event.target || event.srcElement,
-        link = target.src ? target.parentNode : target,
-        options = {index: link, event: event},
-        links = this.getElementsByTagName('a');
-    blueimp.Gallery(links, options);
-};
+      var links = document.getElementById('links');
+      if (links) {
+        links.onclick = function (event) {
+            event = event || window.event;
+            var target = event.target || event.srcElement,
+                link = target.src ? target.parentNode : target,
+                options = {index: link, event: event},
+                links = this.getElementsByTagName('a');
+            blueimp.Gallery(links, options);
+        };
+      }
+    }
+  };
 
+  Drupal.behaviors.tab_handler = {
+    attach: function (context, settings) {
+
+      // on initial load, check for tab navigation fragment in URL. if present, attempt to activate that tab.
+      var urlHash = window.location.hash;
+      var selectedTabIndex = 0;
+      var selectedTab;
+      var focusedTab;
+      if (urlHash.indexOf('#pane-') > -1) {
+        selectedTabIndex = getSelectedTabIndex(urlHash);
+        var tabId = '#tab-' + selectedTabIndex;
+        selectedTab = $(tabId);
+        selectedTab.tab('show');
+        selectTab(urlHash, selectedTab);
+      }
+
+      $('#serviceModes a.nav-link').click(function () {
+        // when service mode tab nav is clicked, add fragment to URL; use pushState so that
+        // page doesn't jump to the anchor associated with the fragment.
+        var linkHash = $(this).attr("href"); // i.e. #pane-2
+        selectTab(linkHash, $(this));
+      });
+
+      $('#serviceModes').keydown(function(event) {
+        if (event.which == 39) { // right arrow
+          // focus tab to the right, if it exists
+          var foundNext = focusedTab.parent().next().find('a');
+          if (foundNext.attr('id')) {
+            focusedTab = foundNext;
+            focusedTab.focus();
+            console.log('focus ' + focusedTab.attr('id'));
+          }
+        } else if (event.which == 37) { // left arrow
+          // focus tab to the left
+          var foundPrev = focusedTab.parent().prev().find('a');
+          if (foundPrev.attr('id')) {
+            focusedTab = foundPrev;
+            focusedTab.focus();
+            console.log('focus ' + focusedTab.attr('id'));
+          }
+        }
+      });
+
+      function getSelectedTabIndex(key) {
+        // search key for hyphen, and use rest of string as index. 
+        // we are assuming key will always be in format #tab-1 or #pane-1
+        var idx = key.indexOf("-");
+        return parseInt(key.substring(idx+1, key.length));
+      }
+
+      function selectTab(linkHash, tab) {
+        // add tab to history/location
+        if (history.pushState) {
+          history.pushState(null, null, linkHash);
+        } else {
+          location.hash = linkHash;
+        }
+
+        // toggle tabindex; should be -1 for all non-selected tabs for accessibility purposes
+        $('#serviceModes a.nav-link').attr('tabindex', -1);
+        tab.removeAttr('tabindex');
+
+        // aria-hidden should be true for all but visible pane
+        $('#serviceModesContent .tab-pane').attr('aria-hidden', 'true');
+        $(linkHash).attr('aria-hidden', false)
+
+        // focus selected tab
+        tab.focus(); // NOTE: this has focus, but is not picking up focus style
+        focusedTab = tab;
+      }
 
 
     }

--- a/web/themes/custom/cloudy/js/global.js
+++ b/web/themes/custom/cloudy/js/global.js
@@ -52,9 +52,18 @@
         selectTab(urlHash, selectedTab);
       }
 
+      // $(window).on('hashchange', function () {
+      //   selectedTabIndex = getSelectedTabIndex(urlHash);
+      //   var tabId = '#tab-' + selectedTabIndex;
+      //   selectedTab = $(tabId);
+      //   selectedTab.tab('show');
+      //   selectTab(urlHash, selectedTab);
+      // });
+
       $('#serviceModes a.nav-link').click(function (event) {
         // when service mode tab nav is clicked, add fragment to URL; use pushState so that
         // page doesn't jump to the anchor associated with the fragment.
+        event.preventDefault();
         var linkHash = $(this).attr("href"); // i.e. #pane-2
         selectTab(linkHash, $(this));
       });
@@ -88,8 +97,6 @@
 
       function selectTab(linkHash, tab) {
         // add tab to history/location
-        // NOTE: this adds the URL to the history, but it doesn't respect the url fragment
-        // to open the corresponding tab.
         if (history.pushState) {
           history.pushState(null, null, linkHash);
         } else {
@@ -105,15 +112,12 @@
         var panel = $(linkHash);
         panel.attr('aria-hidden', false);
 
-        // focus the first element in the panel; race condition requires a timeout
+        // focus the first element in the panel
         var first = panel.children().first();
-        first.attr('tabindex', '-1');
-        setTimeout(function() { first.focus(); }, 500);
-        first.focus(); // NOTE: this has focus, but is not picking up focus style
+        //setTimeout(function () { first.focus(); }, 2500);
+        first.focus();
         focusedTab = tab;
       }
-
-
     }
   };
 

--- a/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
@@ -11,18 +11,25 @@
 #}
 <ul class="nav nav-tabs" id="serviceModes" role="tablist">
   {% for item in items if key|first != '#' %}
-    <li class="nav-item">
-      <a class="nav-link{% if loop.first %} active{% endif %} " id="tab-{{ loop.index }}" data-toggle="tab" href="#pane-{{ loop.index }}" role="tab" aria-controls="pane-{{ loop.index }}"{% if loop.first %}  aria-selected="true"{% endif %}>
-      {{ item.content['#paragraph'].field_service_modes.entity.name.value }}
+    <li class="nav-item" role="presentation">
+      <a role="tab" href="#pane-{{ loop.index }}" id="tab-{{ loop.index }}" data-toggle="tab"
+        {% if loop.first != true %} tabindex="-1" aria-selected="false"{% endif %}
+        {% if loop.first %} aria-selected="true"{% endif %} 
+        aria-controls="pane-{{ loop.index }}"
+        class="nav-link{% if loop.first %} active{% endif %}"
+        title="Use arrow keys to navigate between tabs">
+        {{ item.content['#paragraph'].field_service_modes.entity.name.value }}
       </a>
     </li>
   {% endfor %}
 </ul>
 
 {% if multiple %}
-    <div class="tab-content mb-3" id="serviceModesContent">
+    <div id="serviceModesContent" class="tab-content mb-3">
         {% for item in items if key|first != '#' %}
-            <div class="tab-pane fade{% if loop.first %} show active{% endif %}" id="pane-{{ loop.index }}" role="tabpanel" aria-labelledby="tab-{{ loop.index }}">{{ item.content }}</div>
+            <section role="tabpanel" id="pane-{{ loop.index }}" aria-labelledby="tab-{{ loop.index }}"
+                {% if loop.first %} aria-hidden="true"{% endif %}
+                class="tab-pane fade{% if loop.first %} show active{% endif %}">{{ item.content }}</section>
         {% endfor %}
     </div>
 {% else %}

--- a/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
@@ -16,8 +16,7 @@
         {% if loop.first != true %} tabindex="-1" aria-selected="false"{% endif %}
         {% if loop.first %} aria-selected="true"{% endif %} 
         aria-controls="pane-{{ loop.index }}"
-        class="nav-link{% if loop.first %} active{% endif %}"
-        title="Use arrow keys to navigate between tabs">
+        class="nav-link{% if loop.first %} active{% endif %}">
         {{ item.content['#paragraph'].field_service_modes.entity.name.value }}
       </a>
     </li>


### PR DESCRIPTION
This is in QA and ready for review as soon as it passes testing.

The diff of global.js is showing some code updates that are unrelated to this story. The existing code was improperly indented, so I fixed it but did not materially change that code.

My new accessibility and URL fragment handling code is in global.js in the section Drupal.behaviors.tab_handler. The code does the following:

* Put fragment in URL
* Use URL fragment to activate specified tab on page reload or direct navigation
* Set tabindex = -1 for all non-active tabs
* Set aria-hidden = true for all non-visible panes
* Focus active tab, for when user reloads or arrives via direct navigation
* Enable left/right arrow key navigation on tabs

In field--field-service-mode.html.twig, I added a number of attributes to the tabs and panes, and changed the pane container element from div to section, based on the accessibility article on tabbed interfaces. 