### PR TITLE
POWR 545 - Stories that stem from user testing and WAVE tool analysis

### DIFF
--- a/web/modules/custom/portland/templates/portland-alert.html.twig
+++ b/web/modules/custom/portland/templates/portland-alert.html.twig
@@ -76,33 +76,32 @@
 
 <div>
   <div{{ attributes.addClass(classes).addClass(alert_classes) }} data-nid="{{ nid }}" data-changed="{{ changed_timestamp }}" role="alert" aria-live="polite">
-      <div{{ header_attribute.addClass(header_classes) }}>
+    <div{{ header_attribute.addClass(header_classes) }}>
       {# <i{{ icon_attribute.addClass(icon_classes) }}></i> #}
-        {% if title %}
-          <span{{ title_attribute.addClass(title_classes) }}>{{ title }}</span>
-        {% endif %}
-        {% if dismissible == 1 %}
-          <span>
-            <button type="button" class="close" data-dismiss="alert" aria-label="Dismiss notification">
-              <span{{ dismiss_attribute.addClass(dismiss_classes) }} aria-hidden="true">
-                <i{{ dismiss_icon_attribute.addClass(dismiss_icon_classes) }}></i>
-                Dismiss
-              </span>
-            </button>
-          </span>
-        {% endif %}
-      </div>
-      <div class="mb-0">
-        {{ text }}
-      </div>
-      {% if link_url %}
-        <a{{ link_attribute.addClass(link_classes).setAttribute('href', link_url) }}>
-          {{ link_text }}
-        </a>
+      {% if title %}
+        <span{{ title_attribute.addClass(title_classes) }}>{{ title }}</span>
       {% endif %}
-      <div>
-        <small>{{ changed }}</small>
-      </div>
+      {% if dismissible == 1 %}
+        <span>
+          <button type="button" class="close" data-dismiss="alert" aria-label="Dismiss notification">
+            <span{{ dismiss_attribute.addClass(dismiss_classes) }} aria-hidden="true">
+              <i{{ dismiss_icon_attribute.addClass(dismiss_icon_classes) }}></i>
+              Dismiss
+            </span>
+          </button>
+        </span>
+      {% endif %}
+    </div>
+    <div class="mb-0">
+      {{ text }}
+    </div>
+    {% if link_url %}
+      <a{{ link_attribute.addClass(link_classes).setAttribute('href', link_url) }}>
+        {{ link_text }}
+      </a>
+    {% endif %}
+    <div>
+      <small>{{ changed }}</small>
     </div>
   </div>
 </div>

--- a/web/sites/default/config/views.view.bureaus_and_offices.yml
+++ b/web/sites/default/config/views.view.bureaus_and_offices.yml
@@ -169,7 +169,7 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_op
-            label: ''
+            label: 'Search bureaus and offices'
             description: ''
             use_operator: false
             operator: search_api_fulltext_op

--- a/web/sites/default/config/views.view.services_index.yml
+++ b/web/sites/default/config/views.view.services_index.yml
@@ -165,7 +165,7 @@ display:
           exposed: true
           expose:
             operator_id: search_api_fulltext_op
-            label: ''
+            label: 'Search city services'
             description: ''
             use_operator: false
             operator: search_api_fulltext_op
@@ -177,9 +177,7 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-              layout_manager: '0'
-              media_creator: '0'
-              media_manager: '0'
+              sitewide_editor: '0'
             placeholder: ''
           is_grouped: false
           group_info:

--- a/web/themes/custom/cloudy/cloudy.theme
+++ b/web/themes/custom/cloudy/cloudy.theme
@@ -83,3 +83,15 @@ function cloudy_preprocess_html(&$variables) {
   }
 }
 
+function cloudy_preprocess_form(&$vars) {
+  // add role="search" to site search form
+  if ($vars['element']['#form_id'] == 'search_api_page_block_form') {
+    $vars['attributes']['role'] = 'search';
+  }
+}
+
+function cloudy_form_search_api_page_block_form_alter(&$form, $form_state, $form_id)
+{
+  // modify invisible (sr-only) label for site search form
+  $form['keys']['#title'] = t('Search portland.gov');
+}

--- a/web/themes/custom/cloudy/cloudy.theme
+++ b/web/themes/custom/cloudy/cloudy.theme
@@ -83,6 +83,10 @@ function cloudy_preprocess_html(&$variables) {
   }
 }
 
+/**
+ * Implements theme_preprocess_HOOK
+ *
+ */
 function cloudy_preprocess_form(&$vars) {
   // add role="search" to site search form
   if ($vars['element']['#form_id'] == 'search_api_page_block_form') {
@@ -90,8 +94,23 @@ function cloudy_preprocess_form(&$vars) {
   }
 }
 
+/**
+ * Implements hook_form_FORM_ID_alter
+ *
+ */
 function cloudy_form_search_api_page_block_form_alter(&$form, $form_state, $form_id)
 {
   // modify invisible (sr-only) label for site search form
   $form['keys']['#title'] = t('Search portland.gov');
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter
+ *
+ */
+function cloudy_form_views_exposed_form_alter(&$form, $form_state, $form_id) {
+  if ($form['#id'] == 'views-exposed-form-bureaus-and-offices-page-1' ||
+      $form['#id'] == 'views-exposed-form-services-index-page-1') {
+    $form['search']['#title_display'] = "invisible";
+  }
 }

--- a/web/themes/custom/cloudy/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/cloudy/templates/block/block--system-menu-block.html.twig
@@ -1,0 +1,56 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-menu',
+    'navigation',
+    'menu--' ~ derivative_plugin_id|clean_class,
+  ]
+%}
+{% set heading_id = attributes.id ~ '-menu'|clean_id %}
+<div role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+  {# Label. If not displayed, we still provide it for screen readers. #}
+  {% if not configuration.label_display %}
+    {% set title_attributes = title_attributes.addClass('sr-only') %}
+  {% endif %}
+  {{ title_prefix }}
+  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  {{ title_suffix }}
+
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/cloudy/templates/field/field--paragraph--field-step-title.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--paragraph--field-step-title.html.twig
@@ -24,8 +24,8 @@
     'step-title'
   ]
 %}
-<h3{{ attributes.addClass(classes) }}>
+<h2{{ attributes.addClass(classes) }}>
   {%- for item in items -%}
     {{ item.content }}
   {%- endfor -%}
-</h3>
+</h2>

--- a/web/themes/custom/cloudy/templates/layout/html.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/html.html.twig
@@ -1,0 +1,74 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display the basic html structure of a single
+ * Drupal page.
+ *
+ * Variables:
+ * - $css: An array of CSS files for the current page.
+ * - $language: (object) The language the site is being displayed in.
+ *   $language->language contains its textual representation.
+ *   $language->dir contains the language direction. It will either be 'ltr' or
+ *   'rtl'.
+ * - $rdf_namespaces: All the RDF namespace prefixes used in the HTML document.
+ * - $grddl_profile: A GRDDL profile allowing agents to extract the RDF data.
+ * - $head_title: A modified version of the page title, for use in the TITLE
+ *   tag.
+ * - $head_title_array: (array) An associative array containing the string parts
+ *   that were used to generate the $head_title variable, already prepared to be
+ *   output as TITLE tag. The key/value pairs may contain one or more of the
+ *   following, depending on conditions:
+ *   - title: The title of the current page, if any.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site, if any, and if there is no title.
+ * - $head: Markup for the HEAD section (including meta tags, keyword tags, and
+ *   so on).
+ * - $styles: Style tags necessary to import all CSS files for the page.
+ * - $scripts: Script tags necessary to load the JavaScript files and settings
+ *   for the page.
+ * - $page_top: Initial markup from any modules that have altered the
+ *   page. This variable should always be output first, before all other dynamic
+ *   content.
+ * - $page: The rendered page content.
+ * - $page_bottom: Final closing markup from any modules that have altered the
+ *   page. This variable should always be output last, after all other dynamic
+ *   content.
+ * - $classes String of classes that can be used to style contextually through
+ *   CSS.
+ *
+ * @ingroup templates
+ *
+ * @see bootstrap_preprocess_html()
+ * @see template_preprocess()
+ * @see template_preprocess_html()
+ * @see template_process()
+ */
+#}
+{%
+  set body_classes = [
+    logged_in ? 'user-logged-in',
+    not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+    node_type ? 'page-node-type-' ~ node_type|clean_class,
+    db_offline ? 'db-offline',
+    theme.settings.navbar_position ? 'navbar-is-' ~ theme.settings.navbar_position,
+    theme.has_glyphicons ? 'has-glyphicons',
+  ]
+%}
+<!DOCTYPE html>
+<html {{ html_attributes }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token|raw }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token|raw }}">
+    <js-placeholder token="{{ placeholder_token|raw }}">
+  </head>
+  <body{{ attributes.addClass(body_classes) }}>
+    <a href="#main" class="visually-hidden focusable skip-link">
+      {{ 'Skip to main content'|t }}
+    </a>
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+    <js-bottom-placeholder token="{{ placeholder_token|raw }}">
+  </body>
+</html>

--- a/web/themes/custom/cloudy/templates/layout/html.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/html.html.twig
@@ -63,9 +63,6 @@
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>
   <body{{ attributes.addClass(body_classes) }}>
-    <a href="#main" class="visually-hidden focusable skip-link">
-      {{ 'Skip to main content'|t }}
-    </a>
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -108,10 +108,11 @@
         </div>
       {% endblock %}
     {% endif %}
-    {% if page.tabs %}
+    {% set tabs = page.tabs|render %}
+    {% if tabs %}
       {% block tabs %}
         <div class="tabs container-fluid bg-light" role="navigation">
-          {{ page.tabs }}
+          {{ tabs }}
         </div>
       {% endblock %}
     {% endif %}    

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -129,7 +129,6 @@
           <div class="row row-offcanvas row-offcanvas-left clearfix">
               <main{{ content_attributes }}>
                 <section class="section">
-                  <a id="main-content" tabindex="-1"></a>
                   {{ page.content }}
                 </section>
               </main>

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -108,7 +108,7 @@
         </div>
       {% endblock %}
     {% endif %}
-    {% if page.tabs|render|striptags|trim|length > 0 %}
+    {% if page.tabs %}
       {% block tabs %}
         <div class="tabs container-fluid bg-light" role="navigation">
           {{ page.tabs }}

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -70,6 +70,9 @@
 <div id="page-wrapper">
   <div id="page">
     <div class="container-fluid">{{ page.top_header }}</div>
+    <a href="#main" class="visually-hidden focusable skip-link">
+        {{ 'Skip to main content'|t }}
+    </a>
     <header id="header" class="header" aria-label="{{ 'Site header'|t}}" role="banner">
       {% block head %}
         <nav{{ navbar_attributes }}>

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -70,7 +70,7 @@
 <div id="page-wrapper">
   <div id="page">
     <div class="container-fluid">{{ page.top_header }}</div>
-    <header id="header" class="header" aria-label="{{ 'Site header'|t}}">
+    <header id="header" class="header" aria-label="{{ 'Site header'|t}}" role="banner">
       {% block head %}
         <nav{{ navbar_attributes }}>
           {% if container_navbar %}

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -108,7 +108,7 @@
         </div>
       {% endblock %}
     {% endif %}
-    {% if page.tabs %}
+    {% if page.tabs|render|striptags|trim|length > 0 %}
       {% block tabs %}
         <div class="tabs container-fluid bg-light" role="navigation">
           {{ page.tabs }}

--- a/web/themes/custom/cloudy/templates/navigation/pager.html.twig
+++ b/web/themes/custom/cloudy/templates/navigation/pager.html.twig
@@ -1,0 +1,96 @@
+{#
+/**
+ * @file
+ * Theme override to display a pager.
+ *
+ * Available variables:
+ * - items: List of pager items.
+ *   The list is keyed by the following elements:
+ *   - first: Item for the first page; not present on the first page of results.
+ *   - previous: Item for the previous page; not present on the first page
+ *     of results.
+ *   - next: Item for the next page; not present on the last page of results.
+ *   - last: Item for the last page; not present on the last page of results.
+ *   - pages: List of pages, keyed by page number.
+ *   Sub-sub elements:
+ *   items.first, items.previous, items.next, items.last, and each item inside
+ *   items.pages contain the following elements:
+ *   - href: URL with appropriate query parameters for the item.
+ *   - attributes: A keyed list of HTML attributes for the item.
+ *   - text: The visible text used for the item link, such as "‹ Previous"
+ *     or "Next ›".
+ * - current: The page number of the current page.
+ * - ellipses: If there are more pages than the quantity allows, then an
+ *   ellipsis before or after the listed pages may be present.
+ *   - previous: Present if the currently visible list of pages does not start
+ *     at the first page.
+ *   - next: Present if the visible list of pages ends before the last page.
+ *
+ * @see template_preprocess_pager()
+ */
+#}
+{% if items %}
+  <nav aria-label="Page navigation" role="navigation" aria-labeledby="pagination-heading">
+    <h3 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h3>
+    <ul class="pagination">
+      {# Print first item if we are not on the first page. #}
+      {% if items.first %}
+        <li class="page-item">
+          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }} class="page-link">
+            <span aria-hidden="true">«</span>
+            <span class="sr-only">{{ items.first.text|default('First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="page-item">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }} class="page-link">
+            <span aria-hidden="true">‹</span>
+            <span class="sr-only">{{ items.previous.text|default('Previous'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if ellipses.previous %}
+        <li class="page-item" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Now generate the actual pager piece. #}
+      {% for key, item in items.pages %}
+        <li class="page-item {{ current == key ? 'active' : '' }}">
+          {% if current == key %}
+            <span class="page-link">
+              {{- key -}}
+            </span>
+          {% else %}
+            <a href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }} class="page-link">
+              {{- key -}}
+            </a>
+          {% endif %}
+        </li>
+      {% endfor %}
+      {# Add an ellipsis if there are further next pages. #}
+      {% if ellipses.next %}
+        <li class="page-item" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Print next item if we are not on the last page. #}
+      {% if items.next %}
+        <li class="pager__item--next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }} class="page-link">
+            <span aria-hidden="true">›</span>
+            <span class="sr-only">{{ items.next.text|default('Next'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print last item if we are not on the last page. #}
+      {% if items.last %}
+        <li class="page-item">
+          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }} class="page-link">
+            <span aria-hidden="true">»</span>
+            <span class="sr-only">{{ items.last.text|default('Last'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}


### PR DESCRIPTION
This branch and PR includes a number of very small updates. I'v aggregated them into a single branch to prevent all the overhead of multiple branches/PRs. These are all sub-stories of POWR-545.

POWR-551 Add role="banner" to site header
POWR-552 Remove/hide empty tabs region
POWR-553 Remove duplicate nav element from main navigation
POWR-554 Pager nav needs role and aria-labelledby
POWR-557 Service step headings should be h2
POWR-548 Homepage search add role and update label
POWR-556 Services page search input needs label
POWR-555 Update skip link to point to #main and remove old anchor
POWR-580 Move alerts to above "skip to main content" link for accessibilty

I've unit tested these all in the powr-545 multidev, and code is rebased as of 11/29 at 1:00 pm.