### PR TITLE
POWR-744 - make service tab fragment identifier descriptive

### DIFF
--- a/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--field-service-mode.html.twig
@@ -11,11 +11,12 @@
 #}
 <ul class="nav nav-tabs" id="serviceModes" role="tablist">
   {% for item in items if key|first != '#' %}
+    {% set tabname = item.content['#paragraph'].field_service_modes.entity.name.value|lower|replace({' ': '-'}) %}
     <li class="nav-item" role="presentation">
-      <a role="tab" href="#pane-{{ loop.index }}" id="tab-{{ loop.index }}" data-toggle="tab"
+      <a role="tab" href="#{{ tabname }}" id="tab-{{ tabname }}" data-toggle="tab"
         {% if loop.first != true %} tabindex="-1" aria-selected="false"{% endif %}
         {% if loop.first %} aria-selected="true"{% endif %} 
-        aria-controls="pane-{{ loop.index }}"
+        aria-controls="{{ tabname }}"
         class="nav-link{% if loop.first %} active{% endif %}">
         {{ item.content['#paragraph'].field_service_modes.entity.name.value }}
       </a>
@@ -26,7 +27,8 @@
 {% if multiple %}
     <div id="serviceModesContent" class="tab-content mb-3">
         {% for item in items if key|first != '#' %}
-            <section role="tabpanel" id="pane-{{ loop.index }}" aria-labelledby="tab-{{ loop.index }}"
+            {% set tabname = item.content['#paragraph'].field_service_modes.entity.name.value|lower|replace({' ': '-'}) %}
+            <section role="tabpanel" id="{{ tabname }}" aria-labelledby="tab-{{ tabname }}"
                 {% if loop.first %} aria-hidden="true"{% endif %}
                 class="tab-pane fade{% if loop.first %} show active{% endif %}">{{ item.content }}</section>
         {% endfor %}


### PR DESCRIPTION
The service mode template has been updated to use the service mode names as the fragment identifiers. I've replaced spaces with hyphens and lowercased the names.