### PR TITLE
POWR-785 - new custom filter to replace HTML Purifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "drupal/group": "^1.0",
         "drupal/groupmedia": "^2.0",
         "drupal/hsts": "^1.0",
-        "drupal/htmlpurifier": "^1.0@RC",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/key": "^1.8",
         "drupal/link_class": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ece1eee908df73192c1156feded3ddf4",
+    "content-hash": "9c9d56dd1802299116fa5acd2cb88fc8",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -239,7 +239,7 @@
             "version": "3.3.1",
             "source": {
                 "type": "git",
-                "url": "git@github.com:jquery/jquery-dist.git",
+                "url": "https://github.com/jquery/jquery-dist.git",
                 "reference": "9e8ec3d10fad04748176144f108d7355662ae75e"
             },
             "dist": {
@@ -5482,63 +5482,6 @@
             "homepage": "https://www.drupal.org/project/hsts",
             "support": {
                 "source": "http://cgit.drupalcode.org/hsts"
-            }
-        },
-        {
-            "name": "drupal/htmlpurifier",
-            "version": "1.0.0-rc1",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupal.org/project/htmlpurifier",
-                "reference": "8.x-1.0-rc1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/htmlpurifier-8.x-1.0-rc1.zip",
-                "reference": "8.x-1.0-rc1",
-                "shasum": "715aede359c3c1a7d8e057ba2c84945d7b3697d3"
-            },
-            "require": {
-                "drupal/core": "~8.0",
-                "ezyang/htmlpurifier": "^4.10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.0-rc1",
-                    "datestamp": "1526637485",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "ezyang",
-                    "homepage": "https://www.drupal.org/user/211688"
-                },
-                {
-                    "name": "heddn",
-                    "homepage": "https://www.drupal.org/user/1463982"
-                },
-                {
-                    "name": "juanolalla",
-                    "homepage": "https://www.drupal.org/user/913844"
-                }
-            ],
-            "description": "Standards compliant HTML filter written in PHP",
-            "homepage": "https://www.drupal.org/project/htmlpurifier",
-            "support": {
-                "source": "http://cgit.drupalcode.org/htmlpurifier",
-                "issues": "https://www.drupal.org/project/issues/htmlpurifier"
             }
         },
         {
@@ -17008,7 +16951,6 @@
         "drupal/custom_add_another": 10,
         "drupal/field_defaults": 5,
         "drupal/field_permissions": 5,
-        "drupal/htmlpurifier": 5,
         "drupal/inline_entity_form": 5,
         "drupal/openid_connect": 10,
         "drupal/page_manager": 10,

--- a/web/modules/custom/portland/modules/portland_media_embed_helper/src/Plugin/Filter/PortlandMediaEmbedHtmlFilter.php
+++ b/web/modules/custom/portland/modules/portland_media_embed_helper/src/Plugin/Filter/PortlandMediaEmbedHtmlFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\portland_media_embed_helper\Plugin\Filter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Xss;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+use Drupal\filter\Render\FilteredMarkup;
+
+/**
+ * @Filter(
+ *   id = "portland_media_embed_html_filter",
+ *   title = @Translation("Portland Media Embed HTML Filter"),
+ *   description = @Translation("Removes HTML elements that only contain non breaking spaces."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE,
+ * )
+ */
+class PortlandMediaEmbedHtmlFilter extends FilterBase {
+
+  /**
+   * @param [type] $text
+   * @param [type] $langcode
+   * @return void
+   */
+  public function process($text, $langcode)
+  {
+    $result = new FilterProcessResult($text);
+
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    $elems = $xpath->query( "//*[text()=\"\xC2\xA0\"]");
+    foreach ($elems as $elem) {
+      $elem->parentNode->removeChild($elem);
+    }
+    
+    $result->setProcessedText(Html::serialize($dom))
+      ->addAttachments([
+        'library' => [
+          'filter/caption',
+        ],
+      ]);
+
+    return $result;
+  }
+}

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -64,7 +64,6 @@ module:
   hal: 0
   help: 0
   history: 0
-  htmlpurifier: 0
   image: 0
   image_widget_crop: 0
   inline_entity_form: 0

--- a/web/sites/default/config/filter.format.rich_text.yml
+++ b/web/sites/default/config/filter.format.rich_text.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - editor
     - entity_embed
+    - portland_media_embed_helper
 _core:
   default_config_hash: Mc8Hl-Ya14lrbMXaUx7Ybmv-18vtqE4lw2DpgNHPj-s
 name: 'Rich Text'
@@ -15,31 +16,31 @@ filters:
     id: filter_align
     provider: filter
     status: true
-    weight: -48
+    weight: -47
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: true
-    weight: -47
+    weight: -46
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -46
+    weight: -45
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
-    weight: -45
+    weight: -44
     settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -49
+    weight: -48
     settings: {  }
   filter_html:
     id: filter_html
@@ -54,24 +55,36 @@ filters:
     id: filter_autop
     provider: filter
     status: false
-    weight: -43
+    weight: -42
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -44
+    weight: -43
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -41
+    weight: -40
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: false
-    weight: -42
+    weight: -41
     settings:
       filter_url_length: 72
+  portland_media_embed_helper_filter:
+    id: portland_media_embed_helper_filter
+    provider: portland_media_embed_helper
+    status: false
+    weight: -39
+    settings: {  }
+  portland_media_embed_html_filter:
+    id: portland_media_embed_html_filter
+    provider: portland_media_embed_helper
+    status: true
+    weight: -49
+    settings: {  }

--- a/web/sites/default/config/filter.format.simple_editor.yml
+++ b/web/sites/default/config/filter.format.simple_editor.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - htmlpurifier
+    - portland_media_embed_helper
 name: 'Simplified Editor'
 format: simple_editor
 weight: 0
@@ -17,10 +17,9 @@ filters:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p> <hr> <sup> <sub> <s> <a href hreflang !href accesskey id rel target title>'
       filter_html_help: true
       filter_html_nofollow: false
-  htmlpurifier:
-    id: htmlpurifier
-    provider: htmlpurifier
+  portland_media_embed_html_filter:
+    id: portland_media_embed_html_filter
+    provider: portland_media_embed_helper
     status: true
     weight: 0
-    settings:
-      htmlpurifier_configuration: "AutoFormat:\r\n  RemoveEmpty.RemoveNbsp.Exceptions:\r\n    td: true\r\n    th: true\r\n  RemoveEmpty.RemoveNbsp: true\r\n  RemoveEmpty: true\r\n  RemoveSpansWithoutAttributes: false\r\n"
+    settings: {  }

--- a/web/sites/default/config/filter.format.simplified_editor_with_media_embed.yml
+++ b/web/sites/default/config/filter.format.simplified_editor_with_media_embed.yml
@@ -5,7 +5,6 @@ dependencies:
   module:
     - editor
     - entity_embed
-    - htmlpurifier
     - portland_media_embed_helper
 name: 'Simplified editor with media embed'
 format: simplified_editor_with_media_embed
@@ -20,18 +19,11 @@ filters:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <hr> <sup> <sub> <s> <img src alt data-entity-type data-entity-uuid> <a href hreflang !href accesskey id rel target title class=" btn-cta-outline"> <h1> <pre> <i class=""> <drupal-entity data-* title alt data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button> <div class="">'
       filter_html_help: true
       filter_html_nofollow: false
-  htmlpurifier:
-    id: htmlpurifier
-    provider: htmlpurifier
-    status: false
-    weight: -45
-    settings:
-      htmlpurifier_configuration: "AutoFormat:\r\n  RemoveEmpty.RemoveNbsp.Exceptions:\r\n    td: true\r\n    th: true\r\n    i: true\r\n  RemoveEmpty.RemoveNbsp: true\r\n  RemoveEmpty: true\r\n  RemoveSpansWithoutAttributes: false\r\n  RemoveEmpty.Predicate:\r\n    iframe:\r\n      - src\r\n    i:\r\n      - class\r\nHTML:\r\n  SafeIframe: true\r\nURI:\r\n  DisableExternalResources: false\r\n  SafeIframeRegexp: '%^(https?:)?(\\/\\/www\\.youtube\\.com\\/embed\\/|player\\.vimeo\\.com/video/)%'\r\n"
   entity_embed:
     id: entity_embed
     provider: entity_embed
     status: true
-    weight: -46
+    weight: -45
     settings: {  }
   editor_file_reference:
     id: editor_file_reference
@@ -43,7 +35,7 @@ filters:
     id: filter_align
     provider: filter
     status: true
-    weight: -48
+    weight: -47
     settings: {  }
   filter_autop:
     id: filter_autop
@@ -55,7 +47,7 @@ filters:
     id: filter_caption
     provider: filter
     status: true
-    weight: -47
+    weight: -46
     settings: {  }
   filter_htmlcorrector:
     id: filter_htmlcorrector
@@ -84,6 +76,12 @@ filters:
       filter_url_length: 72
   portland_media_embed_helper_filter:
     id: portland_media_embed_helper_filter
+    provider: portland_media_embed_helper
+    status: true
+    weight: -48
+    settings: {  }
+  portland_media_embed_html_filter:
+    id: portland_media_embed_html_filter
     provider: portland_media_embed_helper
     status: true
     weight: -49


### PR DESCRIPTION
This PR incorporates two different branches:

Branch POWR-785: removes HTML Purifier from the Simple Editor text format (must be disabled before the module can be uninstalled), and pushes up the php file for the new custom text editor filter.

Branch POWR-785-1: uninstalls HTML Purifier and removes it from composer.json, and enables the new Portland HTML custom filter in the text editors.

Both branches were pushed into 785 for testing purposes, but need to be individually merged and promoted up the environment chain. Branch 785 is fully merged into 785-1.

I noticed in composer.lock that for some reason the URL for bower-asset/jquery was changed from git@github.com to https://github.com. Is that a concern? I don't know why it would have changed; it's completely unrelated to anything I've been doing in this story.