### PR TITLE
POWR-785-1 - Replace HTML Purifier (MERGE 2nd)

### DIFF
--- a/web/modules/custom/portland/modules/portland_media_embed_helper/src/Plugin/Filter/PortlandMediaEmbedHtmlFilter.php
+++ b/web/modules/custom/portland/modules/portland_media_embed_helper/src/Plugin/Filter/PortlandMediaEmbedHtmlFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\portland_media_embed_helper\Plugin\Filter;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\Xss;
+use Drupal\filter\FilterProcessResult;
+use Drupal\filter\Plugin\FilterBase;
+use Drupal\filter\Render\FilteredMarkup;
+
+/**
+ * @Filter(
+ *   id = "portland_media_embed_html_filter",
+ *   title = @Translation("Portland Media Embed HTML Filter"),
+ *   description = @Translation("Removes HTML elements that only contain non breaking spaces."),
+ *   type = Drupal\filter\Plugin\FilterInterface::TYPE_MARKUP_LANGUAGE,
+ * )
+ */
+class PortlandMediaEmbedHtmlFilter extends FilterBase {
+
+  /**
+   * @param [type] $text
+   * @param [type] $langcode
+   * @return void
+   */
+  public function process($text, $langcode)
+  {
+    $result = new FilterProcessResult($text);
+
+    $dom = Html::load($text);
+    $xpath = new \DOMXPath($dom);
+    $elems = $xpath->query( "//*[text()=\"\xC2\xA0\"]");
+    foreach ($elems as $elem) {
+      $elem->parentNode->removeChild($elem);
+    }
+    
+    $result->setProcessedText(Html::serialize($dom))
+      ->addAttachments([
+        'library' => [
+          'filter/caption',
+        ],
+      ]);
+
+    return $result;
+  }
+}

--- a/web/sites/default/config/filter.format.simple_editor.yml
+++ b/web/sites/default/config/filter.format.simple_editor.yml
@@ -20,7 +20,7 @@ filters:
   htmlpurifier:
     id: htmlpurifier
     provider: htmlpurifier
-    status: true
+    status: false
     weight: 0
     settings:
       htmlpurifier_configuration: "AutoFormat:\r\n  RemoveEmpty.RemoveNbsp.Exceptions:\r\n    td: true\r\n    th: true\r\n  RemoveEmpty.RemoveNbsp: true\r\n  RemoveEmpty: true\r\n  RemoveSpansWithoutAttributes: false\r\n"


### PR DESCRIPTION
This is the 2nd part of the merge, which enables the new text format filter, and uninstalls HTML Purifier and removes it from composer.json. This PR will not rebuild correctly in multidev without first having POWR-785-0 deployed to the environment.