### PR TITLE
POWR-810 fix reference to twistie-up.svg

### DIFF
--- a/web/themes/custom/cloudy/scss/components/_tablesort-indicator.scss
+++ b/web/themes/custom/cloudy/scss/components/_tablesort-indicator.scss
@@ -13,14 +13,14 @@
   float: left;
 }
 .tablesort--asc {
-  background-image: url(../../../core/misc/icons/004875/twistie-down.svg);
+  background-image: url(/core/misc/icons/004875/twistie-down.svg);
 }
 a:hover .tablesort--asc {
-  background-image: url(../../../core/misc/icons/008ee6/twistie-down.svg);
+  background-image: url(/core/misc/icons/008ee6/twistie-down.svg);
 }
 .tablesort--desc {
-  background-image: url(../../../core/misc/icons/004875/twistie-up.svg);
+  background-image: url(/core/misc/icons/004875/twistie-up.svg);
 }
 a:hover .tablesort--desc {
-  background-image: url(../../../core/misc/icons/008ee6/twistie-up.svg);
+  background-image: url(/core/misc/icons/008ee6/twistie-up.svg);
 }


### PR DESCRIPTION
n our scss components, _tablesort-indicator.scss references ../../../core/misc/icons/004875/twistie-up.svg... which doesn't exist.

We think you should be able to just use site relative paths such as /core/misc/icons/004875/twistie-up.svg.