### PR TITLE
update-search-api-solr - hotfix branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,8 @@ build_and_deploy: &build_and_deploy
     - run:
         name: Composer install
         command: |
+          # hotfix - getting error on module but can't update due to lightning dependency, try removing and getting fresh
+          rm -rf ./web/modules/contrib/search_api_solr
           # Pantheon don't allow these folders but Composer needs them
           rm -rf ./web/modules/contrib/facets
           # Run composer install with hirak/prestissimo for better performance


### PR DESCRIPTION
Try removing module then getting a fresh copy; can't update module due to unnecessary dependency from lighting.

Getting this error when the build process in dev (but not mulidev hmmm) tries to remove and re-install and re-patch module.