### PR TITLE
POWR-1129 Update CircleCI for Dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,11 +118,16 @@ build_and_deploy: &build_and_deploy
           git rm --cache  web/sites/default/settings.local.php --ignore-unmatch
           git rm -r --cache web/sites/default/files --ignore-unmatch
           
-          # Set the git commit user name so it's clear in Pantheon log who made the change
-          git config --global user.name $CIRCLE_USERNAME
+          # Set the git commit user name and email address so it's clear in Pantheon log who made the change
+          if [[ $CIRCLE_USERNAME = "" ]]; then
+            git config --global user.name Dependabot
+          else
+            git config --global user.name $CIRCLE_USERNAME
+          fi
           git config --global user.email $eGov_Email
 
           git commit -m "CircleCI deployment" --quiet
+
           # When commit on master, we deploy to DEV
           if [[ $CIRCLE_BRANCH = "master" ]]; then
             echo "Deploy to Pantheon DEV site"
@@ -146,19 +151,37 @@ build_and_deploy: &build_and_deploy
               fi
             fi
           else
+            # Set Pantheon environment name
+            if [[ $CIRCLE_BRANCH =~ ^dependabot\/ ]] && [[ $CIRCLE_PULL_REQUEST =~ \/pull\/([0-9]+)$ ]]; then
+              echo "export PANTHEON_ENV=bot-${BASH_REMATCH[1]}" >> $BASH_ENV && source $BASH_ENV
+            else
+              echo "export PANTHEON_ENV=$CIRCLE_BRANCH" >> $BASH_ENV && source $BASH_ENV
+            fi
+            echo "Pantheon environment name is $PANTHEON_ENV"
+
             # Check if the multidev branch site exists. If not, create it
             terminus multidev:list --format=list --field=Name portlandor > ./env_list.txt
-            if grep -Fxq "$CIRCLE_BRANCH" ./env_list.txt; then
+            if grep -Fxq "$PANTHEON_ENV" ./env_list.txt; then
               echo "Found multidev site"
             else
               # Create a new Multi-Dev with files and database from Dev.
-              echo "Creating new multidev site. Please wait." && terminus multidev:create portlandor.dev $CIRCLE_BRANCH
+              echo "Creating new multidev site. Please wait." && terminus multidev:create portlandor.dev $PANTHEON_ENV
             fi
             rm -rf ./env_list.txt
             # Set the connection type to GIT
-            terminus connection:set portlandor.$CIRCLE_BRANCH git
-            # Force push to Pantheon
-            git push -f pantheon $CIRCLE_BRANCH
+            terminus connection:set portlandor.$PANTHEON_ENV git
+            # Force push $CIRCLE_BRANCH to Pantheon as branch named $PANTHEON_ENV
+            git push -f pantheon $CIRCLE_BRANCH:$PANTHEON_ENV
+            
+            # Trigger "Test" job for Dependabot dependency updates
+            if [[ $CIRCLE_BRANCH =~ ^dependabot\/ ]]; then
+              echo "Triggering test job for Dependabot PR (after sleeping for 3 minutes)"
+              sleep 180 # allow time for code sync
+              curl --user ${CIRCLE_API_USER_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=test \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            fi
           fi
 
 run_tests: &run_tests
@@ -194,19 +217,28 @@ run_tests: &run_tests
         command: |
           export PATH=/var/www/html/tests/vendor/bin:/tmp/vendor/pantheon-systems/terminus/bin:$PATH
           terminus auth:login --machine-token="$eGov_Terminus" --email="$eGov_Email" && terminus aliases
+
+          # Set Pantheon environment name
+          if [[ $CIRCLE_BRANCH =~ ^dependabot\/ ]] && [[ $CIRCLE_PULL_REQUEST =~ \/pull\/([0-9]+)$ ]]; then
+            echo "export PANTHEON_ENV=bot-${BASH_REMATCH[1]}" >> $BASH_ENV && source $BASH_ENV
+          else
+            echo "export PANTHEON_ENV=$CIRCLE_BRANCH" >> $BASH_ENV && source $BASH_ENV
+          fi
+          echo "Pantheon environment name is $PANTHEON_ENV"
+
           # Get all workflows
           terminus workflow:list --format=csv --fields=id,env,workflow,user,status portlandor > workflows.csv
-          # Fine the latest "Sync Code" workflow for the current branch
+          # Find the latest "Sync Code" workflow for the current branch
           WORKFLOW_ID="empty id"
           while IFS=',' read id env message user status
           do
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-              if [ "$env" == "dev" ] && [[ $message =~ ^\"Sync.*\"$ ]]; then
+            if [ "$PANTHEON_ENV" = "master" ]; then
+              if [ "$env" = "dev" ] && [[ $message =~ ^\"Sync.*\"$ ]]; then
                   WORKFLOW_ID=$id
                   break
               fi
             else
-              if [ "$env" == "$CIRCLE_BRANCH" ] && [[ $message =~ ^\"Sync.*\"$ ]]; then
+              if [ "$env" = "$PANTHEON_ENV" ] && [[ $message =~ ^\"Sync.*\"$ ]]; then
                   WORKFLOW_ID=$id
                   break
               fi
@@ -215,7 +247,7 @@ run_tests: &run_tests
 
           echo $WORKFLOW_ID
           if [[ $WORKFLOW_ID = "empty id" ]]; then
-            echo "Cannot find any Sync Code workflow for branch $CIRCLE_BRANCH. Try terminus workflow:list portlandor."
+            echo "Cannot find any Sync Code workflow for environment $PANTHEON_ENV. Try terminus workflow:list portlandor."
             exit 1
           fi
           # Show the logs of the latest "Sync Code" workflow for the current branch
@@ -239,14 +271,14 @@ run_tests: &run_tests
           cd tests
           # Split feature files by timing data so all split test jobs will finish around the same time
           TESTFILES=$(circleci tests glob "features/*.feature"  | circleci tests split --split-by=timings)
-          if [[ $CIRCLE_BRANCH = "master" ]]; then
+          if [[ $PANTHEON_ENV = "master" ]]; then
             echo 'export BEHAT_PARAMS="{\"extensions\" : {\"Behat\\\MinkExtension\" : {\"base_url\" : \"https://${HTTP_AUTH}@dev-portlandor.pantheonsite.io\"}, \"Drupal\\\DrupalExtension\" : {\"drush\" : { \"alias\": \"portlandor.dev\"}}}}"' >> $BASH_ENV && source $BASH_ENV
             for TESTFILE in $TESTFILES
             do
                 behat -c behat.yml ${TESTFILE}
             done
           else
-            echo 'export BEHAT_PARAMS="{\"extensions\" : {\"Behat\\\MinkExtension\" : {\"base_url\" : \"https://${CIRCLE_BRANCH}-portlandor.pantheonsite.io\"}, \"Drupal\\\DrupalExtension\" : {\"drush\" : { \"alias\": \"portlandor.${CIRCLE_BRANCH}\"}}}}"' >> $BASH_ENV && source $BASH_ENV
+            echo 'export BEHAT_PARAMS="{\"extensions\" : {\"Behat\\\MinkExtension\" : {\"base_url\" : \"https://${PANTHEON_ENV}-portlandor.pantheonsite.io\"}, \"Drupal\\\DrupalExtension\" : {\"drush\" : { \"alias\": \"portlandor.${PANTHEON_ENV}\"}}}}"' >> $BASH_ENV && source $BASH_ENV
             for TESTFILE in $TESTFILES
             do
                 behat -c behat.yml ${TESTFILE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ build_and_deploy: &build_and_deploy
                 terminus multidev:delete --delete-branch portlandor.${BASH_REMATCH[2]} -y
               fi
             fi
-          else
+          else  # All other commits deploy to a multidev
             # Set Pantheon environment name
             if [[ $CIRCLE_BRANCH =~ ^dependabot\/ ]] && [[ $CIRCLE_PULL_REQUEST =~ \/pull\/([0-9]+)$ ]]; then
               echo "export PANTHEON_ENV=bot-${BASH_REMATCH[1]}" >> $BASH_ENV && source $BASH_ENV
@@ -173,10 +173,27 @@ build_and_deploy: &build_and_deploy
             # Force push $CIRCLE_BRANCH to Pantheon as branch named $PANTHEON_ENV
             git push -f pantheon $CIRCLE_BRANCH:$PANTHEON_ENV
             
-            # Trigger "Test" job for Dependabot dependency updates
             if [[ $CIRCLE_BRANCH =~ ^dependabot\/ ]]; then
-              echo "Triggering test job for Dependabot PR (after sleeping for 3 minutes)"
-              sleep 180 # allow time for code sync
+              echo "Dependabot branch detected..."
+              
+              # Set the connection type to SFTP
+              terminus connection:set portlandor.$PANTHEON_ENV sftp
+
+              # Clone database from DEV
+              # This is necessary if the build gets re-run because the drush cim in the sync_code event can
+              # interfere with the drush cex below
+              terminus env:clone-content portlandor.dev $PANTHEON_ENV --db-only --cc -y
+              terminus drush portlandor.$PANTHEON_ENV -- cim -y
+
+              # Abort if there's any database updates that cause a configuration change
+              echo "Run database update... and abort if there's a configuration change"
+              echo "IMPORTANT: If there's a configuation change, download this branch and manually update the dependency"
+              terminus drush portlandor.$PANTHEON_ENV -- updb -y
+              terminus drush portlandor.$PANTHEON_ENV -- cex --no   # this will return failure code if there's config to export
+
+              # Trigger "Test" job for Dependabot dependency updates because it's not run via circleci_webhook.php for these branches
+              echo "Triggering test job for Dependabot PR"
+              #sleep 180 # allow time for sync_code event -- no longer necessary due to time required for database cloning
               curl --user ${CIRCLE_API_USER_TOKEN}: \
                 --data build_parameters[CIRCLE_JOB]=test \
                 --data revision=$CIRCLE_SHA1 \

--- a/composer.json
+++ b/composer.json
@@ -172,6 +172,7 @@
             "npm-asset"
         ],
         "enable-patching": true,
+        "composer-exit-on-patch-failure": 1,
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -31,7 +31,14 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     }
     else {
       // Get the suffix for the site based on the environment
-      $site_name = (getenv('CIRCLE_BRANCH') == "master") ? "dev" : getenv('CIRCLE_BRANCH');
+      if (getenv('CIRCLE_BRANCH') == "master") {
+        $site_name = "dev";
+      } elseif ( preg_match("/^dependabot\//", getenv('CIRCLE_BRANCH')) )  {
+        preg_match("/\/pull\/([0-9]+)$/", getenv('CIRCLE_PULL_REQUEST'), $matches);
+        $site_name = "bot-$matches[1]";
+      } else {
+        $site_name = getenv('CIRCLE_BRANCH');
+      }
 
       // Generate the link to login. Ignore stderr output
       if(strpos($name, '@') === FALSE) {

--- a/web/private/scripts/circleci_webhook.php
+++ b/web/private/scripts/circleci_webhook.php
@@ -18,11 +18,16 @@ print_r($env);
 echo "\n-------- END ENVIRONMENT ----------\n";
 */
 
+// Do NOT run for Dependabot branches
+if (preg_match('/^bot-\d+/', $_ENV['PANTHEON_ENVIRONMENT'])) {
+  die('Dependabot branch detected. Aborting!');
+}
+
 
 // Original source from: https://github.com/pantheon-systems/quicksilver-examples/tree/master/webhook
 
-// DO NOT run tests against Live or Test environment
-if( $_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 'test' ) {
+// Do NOT run tests against Live or Test environment
+if ($_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 'test') {
   $git_repo_name = $_ENV['PANTHEON_SITE_NAME']; // portlandor
   $git_branch_name = ($_ENV['PANTHEON_ENVIRONMENT'] === 'dev') ? 'master' : $_ENV['PANTHEON_ENVIRONMENT']; // master or powr-123
   $url = "https://circleci.com/api/v1.1/project/github/eGovPDX/$git_repo_name/tree/$git_branch_name";
@@ -64,8 +69,7 @@ if( $_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 
  *
  * @param array $requiredKeys  List of keys in secrets file that must exist.
  */
-function _get_secrets($requiredKeys, $defaults)
-{
+function _get_secrets($requiredKeys, $defaults) {
   $secretsFile = $_SERVER['HOME'] . '/files/private/secrets.json';
   if (!file_exists($secretsFile)) {
     die('No secrets file found. Aborting!');

--- a/web/private/scripts/circleci_webhook.php
+++ b/web/private/scripts/circleci_webhook.php
@@ -1,15 +1,28 @@
 <?php
 
+/*
+echo "Quicksilver Debuging Output";
+echo "\n\n";
+echo "\n========= START PAYLOAD ===========\n";
+print_r($_POST);
+echo "\n========== END PAYLOAD ============\n";
+
+echo "\n------- START ENVIRONMENT ---------\n";
+$env = $_ENV;
+foreach ($env as $key => $value) {
+  if (preg_match('#(PASSWORD|SALT|AUTH|SECURE|NONCE|LOGGED_IN)#', $key)) {
+    $env[$key] = '[REDACTED]';
+  }
+}
+print_r($env);
+echo "\n-------- END ENVIRONMENT ----------\n";
+*/
+
+
 // Original source from: https://github.com/pantheon-systems/quicksilver-examples/tree/master/webhook
 
-// Define the url the data should be sent to.
-// {wf_type} will be replaced with the workflow operation: 
-// clone_database, clear_cache, deploy, or sync_code.
-//
-// Useful to have one webhook handle multiple events.
-
 // DO NOT run tests against Live or Test environment
-if( $_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 'test') {
+if( $_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 'test' ) {
   $git_repo_name = $_ENV['PANTHEON_SITE_NAME']; // portlandor
   $git_branch_name = ($_ENV['PANTHEON_ENVIRONMENT'] === 'dev') ? 'master' : $_ENV['PANTHEON_ENVIRONMENT']; // master or powr-123
   $url = "https://circleci.com/api/v1.1/project/github/eGovPDX/$git_repo_name/tree/$git_branch_name";
@@ -39,7 +52,7 @@ if( $_ENV['PANTHEON_ENVIRONMENT'] != 'live' && $_ENV['PANTHEON_ENVIRONMENT'] != 
   curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
   curl_setopt($ch, CURLOPT_TIMEOUT, 5);
-  print("\n==== Posting to Webhook URL ====\n");
+  print("\n==== Posting to Webhook URL $url ====\n");
   $result = curl_exec($ch);
   // print("RESULT: $result");
   print("\n===== Post Complete! =====\n");

--- a/web/private/scripts/drush_post_deploy_cache_rebuild.php
+++ b/web/private/scripts/drush_post_deploy_cache_rebuild.php
@@ -1,5 +1,11 @@
 <?php
 
+// Do NOT run for Dependabot branches
+if (preg_match('/^bot-\d+/', $_ENV['PANTHEON_ENVIRONMENT'])) {
+    die('Dependabot branch detected. Aborting!');
+}
+
+
 //Clear the cache to make sure database doesn't conflict
 echo "Start rebuilding cache...\n";
 passthru('drush cr 2>&1');

--- a/web/private/scripts/drush_post_deploy_config_import.php
+++ b/web/private/scripts/drush_post_deploy_config_import.php
@@ -1,5 +1,11 @@
 <?php
 
+// Do NOT run for Dependabot branches
+if (preg_match('/^bot-\d+/', $_ENV['PANTHEON_ENVIRONMENT'])) {
+    die('Dependabot branch detected. Aborting!');
+}
+
+
 // Import all config changes.
 echo "Start importing configuration from yml files...\n";
 system('drush config-import -y 2>&1');

--- a/web/private/scripts/drush_post_deploy_cron.php
+++ b/web/private/scripts/drush_post_deploy_cron.php
@@ -1,5 +1,11 @@
 <?php
 
+// Do NOT run for Dependabot branches
+if (preg_match('/^bot-\d+/', $_ENV['PANTHEON_ENVIRONMENT'])) {
+    die('Dependabot branch detected. Aborting!');
+}
+
+
 // Run the cron.
 echo "Starting cron...\n";
 passthru('drush core:cron -y 2>&1');

--- a/web/private/scripts/drush_post_deploy_updatedb.php
+++ b/web/private/scripts/drush_post_deploy_updatedb.php
@@ -1,5 +1,11 @@
 <?php
 
+// Do NOT run for Dependabot branches
+if (preg_match('/^bot-\d+/', $_ENV['PANTHEON_ENVIRONMENT'])) {
+    die('Dependabot branch detected. Aborting!');
+}
+
+
 // Apply any database updates required.
 echo "Start applying any database updates required (as with running update.php)...\n";
 passthru('drush updatedb -y 2>&1');


### PR DESCRIPTION
**Key changes:**

* Dependabot PRs use the following naming convention for multidev sites: bot-### where ### is the PR number.
* Dependabot branches are renamed to bot-### when pushed to Github
* At the end of the deploy job for Dependabot branches, it pauses for 3 minutes then directly triggers the test job. (The Pantheon webhook tries to trigger the test job with the wrong branch name so it doesn't get run twice.)

https://github.com/eGovPDX/portlandor/pull/716 is an example of a Dependabot PR based off of this branch which has successfully passed both CI jobs.