### PR TITLE
POWR-1498 update bulk actions to include revision user

### DIFF
--- a/web/modules/custom/portland/src/Plugin/Action/ArchiveAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/ArchiveAction.php
@@ -43,12 +43,12 @@ class ArchiveAction extends ViewsBulkOperationsActionBase {
     else if($entity->getEntityTypeId() == 'media') {
       $entity->moderation_state->value = 'unpublished_archived';
     }
-    
+
     $entity->setNewRevision(TRUE);
-    if($entity->hasField('revision_log')) 
+    if($entity->hasField('revision_log'))
       $entity->revision_log = 'Archived by '. $user_display_name;
     $entity->setRevisionCreationTime(REQUEST_TIME);
-    // $node->setRevisionUserId(\Drupal::currentUser()->id());
+    $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->save();
     // Don't return anything for a default completion message, otherwise return translatable markup.
     return $this->t('Archived by '. $user_display_name);

--- a/web/modules/custom/portland/src/Plugin/Action/ArchiveAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/ArchiveAction.php
@@ -46,12 +46,12 @@ class ArchiveAction extends ViewsBulkOperationsActionBase {
 
     $entity->setNewRevision(TRUE);
     if($entity->hasField('revision_log'))
-      $entity->revision_log = 'Archived by '. $user_display_name;
+      $entity->revision_log = 'Bulk operation: unpublished by '. $user_display_name;
     $entity->setRevisionCreationTime(REQUEST_TIME);
     $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->save();
     // Don't return anything for a default completion message, otherwise return translatable markup.
-    return $this->t('Archived by '. $user_display_name);
+    return $this->t('Bulk operation: unpublished by '. $user_display_name);
   }
 
   /**

--- a/web/modules/custom/portland/src/Plugin/Action/MarkForReviewAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/MarkForReviewAction.php
@@ -35,6 +35,7 @@ class MarkForReviewAction extends ViewsBulkOperationsActionBase {
     $entity->field_reviewer->entity = $reviewer_uid;
     $entity->setNewRevision(TRUE);
     $entity->revision_log = 'Assigned to '. $user_display_name .' for review';
+    $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->setRevisionCreationTime(REQUEST_TIME);
     $entity->save();
     // Don't return anything for a default completion message, otherwise return translatable markup.

--- a/web/modules/custom/portland/src/Plugin/Action/MarkForReviewAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/MarkForReviewAction.php
@@ -34,12 +34,12 @@ class MarkForReviewAction extends ViewsBulkOperationsActionBase {
     $entity->moderation_state->value = 'review';
     $entity->field_reviewer->entity = $reviewer_uid;
     $entity->setNewRevision(TRUE);
-    $entity->revision_log = 'Assigned to '. $user_display_name .' for review';
+    $entity->revision_log = 'Bulk operation: assigned to '. $user_display_name .' for review';
     $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->setRevisionCreationTime(REQUEST_TIME);
     $entity->save();
     // Don't return anything for a default completion message, otherwise return translatable markup.
-    return $this->t('Assigned to '. $user_display_name .' for review');
+    return $this->t('Bulk operation: assigned to '. $user_display_name .' for review');
   }
 
   /**

--- a/web/modules/custom/portland/src/Plugin/Action/PublishAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/PublishAction.php
@@ -35,14 +35,14 @@ class PublishAction extends ViewsBulkOperationsActionBase {
     $entity->moderation_state->value = 'published';
     // Make this change a new revision
     if($entity->hasField('revision_log'))
-      $entity->revision_log = 'Published by '. $user_display_name;
+      $entity->revision_log = 'Bulk operation: published by '. $user_display_name;
     $entity->setNewRevision(TRUE);
     $entity->setRevisionCreationTime(REQUEST_TIME);
     $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->save();
 
     // Don't return anything for a default completion message, otherwise return translatable markup.
-    return $this->t('Published by '. $user_display_name);
+    return $this->t('Bulk operation: published by '. $user_display_name);
   }
 
   /**

--- a/web/modules/custom/portland/src/Plugin/Action/PublishAction.php
+++ b/web/modules/custom/portland/src/Plugin/Action/PublishAction.php
@@ -34,10 +34,11 @@ class PublishAction extends ViewsBulkOperationsActionBase {
     $entity->status->value = 1;
     $entity->moderation_state->value = 'published';
     // Make this change a new revision
-    if($entity->hasField('revision_log')) 
+    if($entity->hasField('revision_log'))
       $entity->revision_log = 'Published by '. $user_display_name;
     $entity->setNewRevision(TRUE);
     $entity->setRevisionCreationTime(REQUEST_TIME);
+    $entity->setRevisionUserId(\Drupal::currentUser()->id());
     $entity->save();
 
     // Don't return anything for a default completion message, otherwise return translatable markup.

--- a/web/sites/default/config/views.view.group_nodes.yml
+++ b/web/sites/default/config/views.view.group_nodes.yml
@@ -254,7 +254,6 @@ display:
           include_exclude: include
           selected_actions:
             - archive_content
-            - mark_for_review
             - node_break_lock_action
             - pathauto_update_alias_node
             - publish_content

--- a/web/sites/default/config/views.view.my_content.yml
+++ b/web/sites/default/config/views.view.my_content.yml
@@ -251,7 +251,6 @@ display:
           include_exclude: include
           selected_actions:
             - archive_content
-            - mark_for_review
             - node_save_action
             - pathauto_update_alias_node
             - publish_content


### PR DESCRIPTION
Previously, the bulk actions did not record who made the action outside of the revision log. This is problematic for seeing who bulk unpublished or published content.

Addtionally, the bulk action to Mark for Review is not triggering the reviewer field to be built for either the group content or my content views. I temporarily removed that feature as there is not a quick fix to making that form build that I can see. It works fine on the sitewide admin content view, so I left the feature in place at that level to troubleshoot in a future story.