### PR TITLE
POWR-1438 Address intermittent build error

### DIFF
--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -90,7 +90,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    */
   public function waitForThePageToBeLoaded()
   {
-      $this->getSession()->wait(10000, "document.readyState === 'complete'");
+      $this->getSession()->wait(20000, "document.readyState === 'complete'");
   }
 
   /** @Given I am using a 1440x900 browser window */


### PR DESCRIPTION
I noticed that the majority of the recent "fake" build failures happened right after the waitForThePageToBeLoaded() function/test which had a timeout of 10s. I suspect our failures are caused by intermittent uncached page loads exceeding 10s. So I've bumped the timeout up to 20s hoping that resolves the issue.