### PR TITLE
POWR-1478 Convert city seal in footer from a background image to an inline image

### DIFF
--- a/web/themes/custom/cloudy/scss/_overrides.scss
+++ b/web/themes/custom/cloudy/scss/_overrides.scss
@@ -216,10 +216,11 @@ ol.steps ul ul {
 }
 
 .block-copyright-block {
-  background: url(/themes/custom/cloudy/images/city-seal.png) no-repeat bottom
-    right;
   width: 100%;
   min-height: 200px;
+  img {
+    float: right;
+  }
 }
 
 .view-header {

--- a/web/themes/custom/cloudy/templates/block/block.html.twig
+++ b/web/themes/custom/cloudy/templates/block/block.html.twig
@@ -55,6 +55,9 @@
     {% block content %}
       <div{{ content_attributes.addClass('content') }}>
         {{ content }}
+        {% if 'copyright' in plugin_id %}
+          <img src="/themes/custom/cloudy/images/city-seal.png" alt="City of Portland, Oregon. 1851" />
+        {% endif %}
       </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
I removed the copyright footer image from the background, and replaced it with an image tag that renders after the content if it's plugin-id contains the substring 'copyright'.