### PR TITLE
POWR-1535 Display contact information on all group types

### DIFF
--- a/web/sites/default/config/core.entity_form_display.group.advisory_group.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.advisory_group.default.yml
@@ -40,7 +40,7 @@ third_party_settings:
         - field_enable_events_menu_item
         - field_enable_documents_menu_item
       parent_name: ''
-      weight: 11
+      weight: 12
       format_type: fieldset
       format_settings:
         id: ''
@@ -49,19 +49,35 @@ third_party_settings:
         required_fields: false
       label: 'Site menu'
       region: content
+    group_contact_information:
+      children:
+        - field_email
+        - field_phone
+        - field_address
+        - field_location
+      parent_name: ''
+      weight: 7
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Contact information'
+      region: content
 id: group.advisory_group.default
 targetEntityType: group
 bundle: advisory_group
 mode: default
 content:
   field_address:
-    weight: 5
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content
   field_email:
-    weight: 7
+    weight: 8
     settings:
       size: 60
       placeholder: ''
@@ -97,7 +113,7 @@ content:
     type: boolean_checkbox
     region: content
   field_featured_content:
-    weight: 12
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -106,7 +122,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_featured_groups:
-    weight: 13
+    weight: 14
     settings:
       match_operator: CONTAINS
       size: 60
@@ -130,7 +146,7 @@ content:
     region: content
     third_party_settings: {  }
   field_location:
-    weight: 6
+    weight: 11
     settings:
       entity_browser: locations_browser
       field_widget_display: rendered_entity
@@ -145,7 +161,7 @@ content:
     type: entity_browser_entity_reference
     region: content
   field_menu_link:
-    weight: 16
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: menu_link_default
@@ -159,13 +175,13 @@ content:
     type: string_textfield
     region: content
   field_parent_group:
-    weight: 14
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: chosen_select
     region: content
   field_phone:
-    weight: 8
+    weight: 9
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -173,14 +189,14 @@ content:
     region: content
   field_redirects:
     type: string_textfield
-    weight: 15
+    weight: 16
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   field_search_keywords:
-    weight: 10
+    weight: 11
     settings:
       size: 60
       placeholder: ''
@@ -209,7 +225,7 @@ content:
     type: string_textarea
     region: content
   field_topics:
-    weight: 9
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: chosen_select

--- a/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
@@ -47,13 +47,13 @@ third_party_settings:
   field_group:
     group_contact_information:
       children:
-        - field_address
-        - field_location
-        - field_phone
         - field_email
+        - field_phone
         - field_facebook
         - field_twitter
         - field_instagram
+        - field_address
+        - field_location
         - field_building
       parent_name: ''
       weight: 4
@@ -91,7 +91,7 @@ bundle: bureau_office
 mode: default
 content:
   field_address:
-    weight: 21
+    weight: 28
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -103,7 +103,7 @@ content:
     type: chosen_select
     region: content
   field_building:
-    weight: 28
+    weight: 30
     settings:
       match_operator: CONTAINS
       size: 60
@@ -112,7 +112,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_email:
-    weight: 24
+    weight: 23
     settings:
       size: 60
       placeholder: ''
@@ -225,7 +225,7 @@ content:
     type: string_textfield
     region: content
   field_location:
-    weight: 22
+    weight: 29
     settings:
       entity_browser: locations_browser
       field_widget_display: rendered_entity
@@ -271,7 +271,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_phone:
-    weight: 23
+    weight: 24
     settings:
       placeholder: ''
       country: US

--- a/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.bureau_office.default.yml
@@ -16,9 +16,11 @@ dependencies:
     - field.field.group.bureau_office.field_enable_programs_menu_item
     - field.field.group.bureau_office.field_enable_projects_menu_item
     - field.field.group.bureau_office.field_enable_services_and_inform
+    - field.field.group.bureau_office.field_facebook
     - field.field.group.bureau_office.field_featured_content
     - field.field.group.bureau_office.field_featured_groups
     - field.field.group.bureau_office.field_featured_media
+    - field.field.group.bureau_office.field_instagram
     - field.field.group.bureau_office.field_location
     - field.field.group.bureau_office.field_logo
     - field.field.group.bureau_office.field_menu_link
@@ -29,6 +31,7 @@ dependencies:
     - field.field.group.bureau_office.field_shortname_or_acronym
     - field.field.group.bureau_office.field_summary
     - field.field.group.bureau_office.field_topics
+    - field.field.group.bureau_office.field_twitter
     - group.type.bureau_office
     - image.style.thumbnail
   module:
@@ -48,6 +51,9 @@ third_party_settings:
         - field_location
         - field_phone
         - field_email
+        - field_facebook
+        - field_twitter
+        - field_instagram
         - field_building
       parent_name: ''
       weight: 4
@@ -70,7 +76,7 @@ third_party_settings:
         - field_enable_programs_menu_item
         - field_enable_projects_menu_item
       parent_name: ''
-      weight: 11
+      weight: 13
       format_type: fieldset
       format_settings:
         id: ''
@@ -97,7 +103,7 @@ content:
     type: chosen_select
     region: content
   field_building:
-    weight: 25
+    weight: 28
     settings:
       match_operator: CONTAINS
       size: 60
@@ -169,8 +175,16 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
+  field_facebook:
+    weight: 25
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_featured_content:
-    weight: 12
+    weight: 14
     settings:
       match_operator: CONTAINS
       size: 60
@@ -179,7 +193,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_featured_groups:
-    weight: 13
+    weight: 15
     settings:
       match_operator: CONTAINS
       size: 60
@@ -202,6 +216,14 @@ content:
       open: false
     region: content
     third_party_settings: {  }
+  field_instagram:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_location:
     weight: 22
     settings:
@@ -219,14 +241,14 @@ content:
     region: content
   field_logo:
     type: image_image
-    weight: 8
+    weight: 11
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber
     region: content
     third_party_settings: {  }
   field_menu_link:
-    weight: 15
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: menu_link_default
@@ -258,14 +280,14 @@ content:
     region: content
   field_redirects:
     type: string_textfield
-    weight: 50
+    weight: 18
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   field_search_keywords:
-    weight: 14
+    weight: 16
     settings:
       size: 60
       placeholder: ''
@@ -281,7 +303,7 @@ content:
     type: string_textfield
     region: content
   field_summary:
-    weight: 10
+    weight: 12
     settings:
       rows: 2
       placeholder: ''
@@ -298,6 +320,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: chosen_select
+    region: content
+  field_twitter:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   label:
     type: string_textfield

--- a/web/sites/default/config/core.entity_form_display.group.elected_official.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.elected_official.default.yml
@@ -3,8 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - entity_browser.browser.locations_browser
-    - entity_browser.browser.media_browser
     - entity_browser.browser.image_browser_embed
     - field.field.group.elected_official.field_address
     - field.field.group.elected_official.field_building

--- a/web/sites/default/config/core.entity_form_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.program.default.yml
@@ -45,13 +45,13 @@ third_party_settings:
   field_group:
     group_contact_information:
       children:
-        - field_address
-        - field_location
-        - field_phone
         - field_email
+        - field_phone
         - field_facebook
         - field_twitter
         - field_instagram
+        - field_address
+        - field_location
         - field_building
       parent_name: ''
       weight: 5
@@ -88,7 +88,7 @@ bundle: program
 mode: default
 content:
   field_address:
-    weight: 6
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -100,7 +100,7 @@ content:
     type: chosen_select
     region: content
   field_building:
-    weight: 13
+    weight: 16
     settings:
       match_operator: CONTAINS
       size: 60
@@ -166,7 +166,7 @@ content:
     type: boolean_checkbox
     region: content
   field_facebook:
-    weight: 10
+    weight: 11
     settings:
       size: 60
       placeholder: ''
@@ -207,7 +207,7 @@ content:
     region: content
     third_party_settings: {  }
   field_instagram:
-    weight: 12
+    weight: 13
     settings:
       size: 60
       placeholder: ''
@@ -215,7 +215,7 @@ content:
     type: string_textfield
     region: content
   field_location:
-    weight: 7
+    weight: 15
     settings:
       entity_browser: locations_browser
       field_widget_display: rendered_entity
@@ -250,7 +250,7 @@ content:
     type: chosen_select
     region: content
   field_phone:
-    weight: 8
+    weight: 10
     settings:
       placeholder: ''
       country: US
@@ -301,7 +301,7 @@ content:
     type: chosen_select
     region: content
   field_twitter:
-    weight: 11
+    weight: 12
     settings:
       size: 60
       placeholder: ''

--- a/web/sites/default/config/core.entity_form_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.program.default.yml
@@ -15,9 +15,11 @@ dependencies:
     - field.field.group.program.field_enable_programs_menu_item
     - field.field.group.program.field_enable_projects_menu_item
     - field.field.group.program.field_enable_services_and_inform
+    - field.field.group.program.field_facebook
     - field.field.group.program.field_featured_content
     - field.field.group.program.field_featured_groups
     - field.field.group.program.field_featured_media
+    - field.field.group.program.field_instagram
     - field.field.group.program.field_location
     - field.field.group.program.field_logo
     - field.field.group.program.field_menu_link
@@ -27,6 +29,7 @@ dependencies:
     - field.field.group.program.field_shortname_or_acronym
     - field.field.group.program.field_summary
     - field.field.group.program.field_topics
+    - field.field.group.program.field_twitter
     - group.type.program
     - image.style.thumbnail
   module:
@@ -46,6 +49,9 @@ third_party_settings:
         - field_location
         - field_phone
         - field_email
+        - field_facebook
+        - field_twitter
+        - field_instagram
         - field_building
       parent_name: ''
       weight: 5
@@ -67,7 +73,7 @@ third_party_settings:
         - field_enable_programs_menu_item
         - field_enable_projects_menu_item
       parent_name: ''
-      weight: 9
+      weight: 12
       format_type: fieldset
       format_settings:
         id: ''
@@ -94,7 +100,7 @@ content:
     type: chosen_select
     region: content
   field_building:
-    weight: 10
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -159,8 +165,16 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
+  field_facebook:
+    weight: 10
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_featured_content:
-    weight: 11
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -169,7 +183,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_featured_groups:
-    weight: 12
+    weight: 14
     settings:
       match_operator: CONTAINS
       size: 60
@@ -192,6 +206,14 @@ content:
       open: false
     region: content
     third_party_settings: {  }
+  field_instagram:
+    weight: 12
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_location:
     weight: 7
     settings:
@@ -216,7 +238,7 @@ content:
     region: content
     third_party_settings: {  }
   field_menu_link:
-    weight: 14
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: menu_link_default
@@ -237,14 +259,14 @@ content:
     region: content
   field_redirects:
     type: string_textfield
-    weight: 50
+    weight: 17
     region: content
     settings:
       placeholder: ''
       size: 60
     third_party_settings: {  }
   field_search_keywords:
-    weight: 13
+    weight: 15
     settings:
       size: 60
       placeholder: ''
@@ -277,6 +299,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: chosen_select
+    region: content
+  field_twitter:
+    weight: 11
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   label:
     type: string_textfield

--- a/web/sites/default/config/core.entity_form_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.project.default.yml
@@ -48,7 +48,7 @@ third_party_settings:
         - field_enable_documents_menu_item
         - field_enable_projects_menu_item
       parent_name: ''
-      weight: 17
+      weight: 18
       format_type: fieldset
       format_settings:
         id: ''
@@ -57,13 +57,29 @@ third_party_settings:
         required_fields: true
       label: 'Site menu'
       region: content
+    group_contact_information:
+      children:
+        - field_email
+        - field_phone
+        - field_address
+        - field_location
+      parent_name: ''
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        required_fields: true
+      label: 'Contact information'
+      region: content
 id: group.project.default
 targetEntityType: group
 bundle: project
 mode: default
 content:
   field_address:
-    weight: 10
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: address_default
@@ -76,21 +92,21 @@ content:
     region: content
   field_display_date:
     type: string_textfield
-    weight: 16
+    weight: 17
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   field_display_date_toggle:
-    weight: 15
+    weight: 16
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_email:
-    weight: 12
+    weight: 13
     settings:
       size: 60
       placeholder: ''
@@ -133,7 +149,7 @@ content:
     type: boolean_checkbox
     region: content
   field_end_date:
-    weight: 14
+    weight: 15
     settings:
       title: ''
       format: mm/dd/yyyy
@@ -191,7 +207,7 @@ content:
     type: bootstrap_date_widget
     region: content
   field_featured_content:
-    weight: 18
+    weight: 19
     settings:
       match_operator: CONTAINS
       size: 60
@@ -200,7 +216,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_featured_groups:
-    weight: 19
+    weight: 20
     settings:
       match_operator: CONTAINS
       size: 60
@@ -224,7 +240,7 @@ content:
     region: content
     third_party_settings: {  }
   field_location:
-    weight: 9
+    weight: 16
     settings:
       entity_browser: locations_browser
       field_widget_display: rendered_entity
@@ -240,7 +256,7 @@ content:
     region: content
   field_map:
     type: entity_browser_entity_reference
-    weight: 20
+    weight: 21
     settings:
       entity_browser: map_browser_embed
       field_widget_display: rendered_entity
@@ -260,7 +276,7 @@ content:
     type: chosen_select
     region: content
   field_phone:
-    weight: 11
+    weight: 14
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -280,14 +296,14 @@ content:
     third_party_settings: {  }
   field_redirects:
     type: string_textfield
-    weight: 21
+    weight: 22
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   field_search_keywords:
-    weight: 22
+    weight: 23
     settings:
       size: 60
       placeholder: ''
@@ -303,7 +319,7 @@ content:
     type: string_textfield
     region: content
   field_start_date:
-    weight: 13
+    weight: 14
     settings:
       title: ''
       format: mm/dd/yyyy

--- a/web/sites/default/config/core.entity_view_display.group.advisory_group.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.advisory_group.default.yml
@@ -58,7 +58,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_email:
-    type: basic_string
+    type: email_mailto
     weight: 2
     region: content
     label: hidden

--- a/web/sites/default/config/core.entity_view_display.group.advisory_group.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.advisory_group.default.yml
@@ -23,7 +23,9 @@ dependencies:
     - field.field.group.advisory_group.field_topics
     - group.type.advisory_group
   module:
+    - address
     - ds
+    - telephone
 third_party_settings:
   ds:
     layout:
@@ -36,6 +38,9 @@ third_party_settings:
       content:
         - field_featured_media
         - field_summary
+        - field_email
+        - field_phone
+        - field_address
         - field_location
         - group_site_menu_entity_view_1
         - field_featured_content
@@ -45,8 +50,22 @@ targetEntityType: group
 bundle: advisory_group
 mode: default
 content:
-  field_featured_content:
+  field_address:
+    type: address_default
     weight: 4
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_email:
+    type: basic_string
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_featured_content:
+    weight: 7
     label: above
     settings:
       view_mode: featured
@@ -63,7 +82,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_featured_groups:
-    weight: 5
+    weight: 8
     label: above
     settings:
       view_mode: featured
@@ -96,7 +115,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_location:
-    weight: 2
+    weight: 5
     label: above
     settings:
       view_mode: teaser
@@ -112,6 +131,14 @@ content:
             classes: {  }
     type: entity_reference_entity_view
     region: content
+  field_phone:
+    type: telephone_link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
   field_summary:
     weight: 1
     label: hidden
@@ -149,15 +176,13 @@ content:
     type: string
     region: content
   group_site_menu_entity_view_1:
-    weight: 3
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   changed: true
   created: true
-  field_address: true
-  field_email: true
   field_enable_documents_menu_item: true
   field_enable_events_menu_item: true
   field_enable_guides_and_informat: true
@@ -165,7 +190,6 @@ hidden:
   field_menu_link: true
   field_official_organization_name: true
   field_parent_group: true
-  field_phone: true
   field_search_keywords: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
@@ -35,7 +35,6 @@ dependencies:
   module:
     - address
     - ds
-    - media_entity_twitter
     - telephone
 third_party_settings:
   ds:
@@ -72,7 +71,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_email:
-    type: basic_string
+    type: email_mailto
     weight: 2
     region: content
     label: hidden
@@ -81,9 +80,10 @@ content:
   field_facebook:
     weight: 4
     label: visually_hidden
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: twitter_embed
+    type: string
     region: content
   field_featured_content:
     weight: 10

--- a/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.bureau_office.default.yml
@@ -15,9 +15,11 @@ dependencies:
     - field.field.group.bureau_office.field_enable_programs_menu_item
     - field.field.group.bureau_office.field_enable_projects_menu_item
     - field.field.group.bureau_office.field_enable_services_and_inform
+    - field.field.group.bureau_office.field_facebook
     - field.field.group.bureau_office.field_featured_content
     - field.field.group.bureau_office.field_featured_groups
     - field.field.group.bureau_office.field_featured_media
+    - field.field.group.bureau_office.field_instagram
     - field.field.group.bureau_office.field_location
     - field.field.group.bureau_office.field_logo
     - field.field.group.bureau_office.field_menu_link
@@ -28,9 +30,13 @@ dependencies:
     - field.field.group.bureau_office.field_shortname_or_acronym
     - field.field.group.bureau_office.field_summary
     - field.field.group.bureau_office.field_topics
+    - field.field.group.bureau_office.field_twitter
     - group.type.bureau_office
   module:
+    - address
     - ds
+    - media_entity_twitter
+    - telephone
 third_party_settings:
   ds:
     layout:
@@ -43,6 +49,12 @@ third_party_settings:
       content:
         - field_featured_media
         - field_summary
+        - field_email
+        - field_phone
+        - field_facebook
+        - field_twitter
+        - field_instagram
+        - field_address
         - field_location
         - group_site_menu_entity_view_1
         - field_featured_content
@@ -52,8 +64,29 @@ targetEntityType: group
 bundle: bureau_office
 mode: default
 content:
-  field_featured_content:
+  field_address:
+    type: address_default
+    weight: 7
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_email:
+    type: basic_string
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_facebook:
     weight: 4
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: twitter_embed
+    region: content
+  field_featured_content:
+    weight: 10
     label: above
     settings:
       view_mode: featured
@@ -70,7 +103,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_featured_groups:
-    weight: 5
+    weight: 11
     label: above
     settings:
       view_mode: featured
@@ -123,8 +156,16 @@ content:
             fi: false
             fi-def-at: false
     region: content
+  field_instagram:
+    weight: 6
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_location:
-    weight: 2
+    weight: 8
     label: above
     settings:
       view_mode: teaser
@@ -140,6 +181,14 @@ content:
             classes: {  }
     type: entity_reference_entity_view
     region: content
+  field_phone:
+    type: telephone_link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
   field_summary:
     type: string
     weight: 1
@@ -176,18 +225,24 @@ content:
             fis: false
             fis-def-at: false
             fi-def-at: false
+  field_twitter:
+    weight: 5
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   group_site_menu_entity_view_1:
-    weight: 3
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   changed: true
   created: true
-  field_address: true
   field_audience: true
   field_building: true
-  field_email: true
   field_enable_documents_menu_item: true
   field_enable_events_menu_item: true
   field_enable_guides_and_informat: true
@@ -200,7 +255,6 @@ hidden:
   field_menu_link: true
   field_official_organization_name: true
   field_parent_group: true
-  field_phone: true
   field_search_keywords: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.default.yml
@@ -33,7 +33,6 @@ dependencies:
   module:
     - address
     - ds
-    - media_entity_twitter
     - telephone
 third_party_settings:
   ds:
@@ -79,9 +78,10 @@ content:
   field_facebook:
     weight: 4
     label: visually_hidden
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: twitter_embed
+    type: string
     region: content
   field_featured_content:
     weight: 10

--- a/web/sites/default/config/core.entity_view_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.default.yml
@@ -70,7 +70,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_email:
-    type: basic_string
+    type: email_mailto
     weight: 2
     region: content
     label: hidden

--- a/web/sites/default/config/core.entity_view_display.group.program.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.default.yml
@@ -14,9 +14,11 @@ dependencies:
     - field.field.group.program.field_enable_programs_menu_item
     - field.field.group.program.field_enable_projects_menu_item
     - field.field.group.program.field_enable_services_and_inform
+    - field.field.group.program.field_facebook
     - field.field.group.program.field_featured_content
     - field.field.group.program.field_featured_groups
     - field.field.group.program.field_featured_media
+    - field.field.group.program.field_instagram
     - field.field.group.program.field_location
     - field.field.group.program.field_logo
     - field.field.group.program.field_menu_link
@@ -26,9 +28,13 @@ dependencies:
     - field.field.group.program.field_shortname_or_acronym
     - field.field.group.program.field_summary
     - field.field.group.program.field_topics
+    - field.field.group.program.field_twitter
     - group.type.program
   module:
+    - address
     - ds
+    - media_entity_twitter
+    - telephone
 third_party_settings:
   ds:
     layout:
@@ -41,6 +47,12 @@ third_party_settings:
       content:
         - field_featured_media
         - field_summary
+        - field_email
+        - field_phone
+        - field_facebook
+        - field_twitter
+        - field_instagram
+        - field_address
         - field_location
         - group_site_menu_entity_view_1
         - field_featured_content
@@ -50,8 +62,29 @@ targetEntityType: group
 bundle: program
 mode: default
 content:
-  field_featured_content:
+  field_address:
+    type: address_default
+    weight: 7
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_email:
+    type: basic_string
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_facebook:
     weight: 4
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: twitter_embed
+    region: content
+  field_featured_content:
+    weight: 10
     label: above
     settings:
       view_mode: featured
@@ -69,7 +102,7 @@ content:
     region: content
   field_featured_groups:
     type: entity_reference_entity_view
-    weight: 5
+    weight: 11
     region: content
     label: above
     settings:
@@ -121,8 +154,16 @@ content:
             fi-def-at: false
     type: entity_reference_entity_view
     region: content
+  field_instagram:
+    weight: 6
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_location:
-    weight: 2
+    weight: 8
     label: above
     settings:
       view_mode: teaser
@@ -138,6 +179,14 @@ content:
             classes: {  }
     type: entity_reference_entity_view
     region: content
+  field_phone:
+    type: telephone_link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
   field_summary:
     weight: 1
     settings:
@@ -174,18 +223,24 @@ content:
     region: content
     type: string
     label: hidden
+  field_twitter:
+    weight: 5
+    label: visually_hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   group_site_menu_entity_view_1:
-    weight: 3
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   changed: true
   created: true
-  field_address: true
   field_audience: true
   field_building: true
-  field_email: true
   field_enable_documents_menu_item: true
   field_enable_events_menu_item: true
   field_enable_guides_and_informat: true
@@ -196,7 +251,6 @@ hidden:
   field_logo: true
   field_menu_link: true
   field_parent_group: true
-  field_phone: true
   field_search_keywords: true
   field_shortname_or_acronym: true
   field_topics: true

--- a/web/sites/default/config/core.entity_view_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.project.default.yml
@@ -48,12 +48,12 @@ third_party_settings:
         - field_featured_media
         - group_date
         - field_display_date_toggle
-        - field_display_date
         - field_summary
-        - field_start_date
+        - field_display_date
         - field_email
-        - field_end_date
+        - field_start_date
         - field_phone
+        - field_end_date
         - field_address
         - field_location
         - group_site_menu_entity_view_1
@@ -120,7 +120,7 @@ content:
     type: boolean
     region: content
   field_email:
-    type: basic_string
+    type: email_mailto
     weight: 3
     region: content
     label: hidden

--- a/web/sites/default/config/core.entity_view_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_view_display.group.project.default.yml
@@ -30,9 +30,11 @@ dependencies:
     - field.field.group.project.field_topics
     - group.type.project
   module:
+    - address
     - datetime
     - ds
     - field_group
+    - telephone
 third_party_settings:
   ds:
     layout:
@@ -49,8 +51,11 @@ third_party_settings:
         - field_display_date
         - field_summary
         - field_start_date
-        - field_location
+        - field_email
         - field_end_date
+        - field_phone
+        - field_address
+        - field_location
         - group_site_menu_entity_view_1
         - field_featured_content
         - field_featured_groups
@@ -82,6 +87,13 @@ targetEntityType: group
 bundle: project
 mode: default
 content:
+  field_address:
+    type: address_default
+    weight: 5
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
   field_display_date:
     weight: 2
     label: hidden
@@ -107,6 +119,13 @@ content:
             classes: {  }
     type: boolean
     region: content
+  field_email:
+    type: basic_string
+    weight: 3
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_end_date:
     type: datetime_default
     weight: 4
@@ -124,7 +143,7 @@ content:
             lb-col: false
             classes: {  }
   field_featured_content:
-    weight: 5
+    weight: 8
     label: above
     settings:
       view_mode: featured
@@ -142,7 +161,7 @@ content:
     region: content
   field_featured_groups:
     type: entity_reference_entity_view
-    weight: 6
+    weight: 9
     region: content
     label: above
     settings:
@@ -195,7 +214,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_location:
-    weight: 3
+    weight: 6
     label: above
     settings:
       view_mode: teaser
@@ -213,7 +232,7 @@ content:
     region: content
   field_map:
     type: entity_reference_entity_view
-    weight: 7
+    weight: 10
     label: hidden
     settings:
       view_mode: embedded
@@ -227,6 +246,14 @@ content:
             lb-col: false
             classes: {  }
     region: content
+  field_phone:
+    type: telephone_link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
   field_start_date:
     weight: 3
     label: hidden
@@ -280,23 +307,20 @@ content:
     type: string
     region: content
   group_site_menu_entity_view_1:
-    weight: 4
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   changed: true
   created: true
-  field_address: true
   field_audience: true
-  field_email: true
   field_enable_documents_menu_item: true
   field_enable_events_menu_item: true
   field_enable_guides_and_informat: true
   field_enable_news_and_notices_me: true
   field_enable_projects_menu_item: true
   field_parent_group: true
-  field_phone: true
   field_project_status: true
   field_project_type: true
   field_search_keywords: true

--- a/web/sites/default/config/field.field.group.advisory_group.field_address.yml
+++ b/web/sites/default/config/field.field.group.advisory_group.field_address.yml
@@ -16,7 +16,7 @@ id: group.advisory_group.field_address
 field_name: field_address
 entity_type: group
 bundle: advisory_group
-label: 'Mailing Address'
+label: 'Mailing address'
 description: ''
 required: false
 translatable: true

--- a/web/sites/default/config/field.field.group.advisory_group.field_address.yml
+++ b/web/sites/default/config/field.field.group.advisory_group.field_address.yml
@@ -16,14 +16,29 @@ id: group.advisory_group.field_address
 field_name: field_address
 entity_type: group
 bundle: advisory_group
-label: Address
+label: 'Mailing Address'
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    langcode: ''
+    country_code: US
+    administrative_area: ''
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    organization: ''
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
-  available_countries: {  }
+  available_countries:
+    US: US
   langcode_override: ''
   field_overrides:
     givenName:

--- a/web/sites/default/config/field.field.group.bureau_office.field_address.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_address.yml
@@ -16,7 +16,7 @@ id: group.bureau_office.field_address
 field_name: field_address
 entity_type: group
 bundle: bureau_office
-label: 'Mailing Address'
+label: 'Mailing address'
 description: ''
 required: false
 translatable: false

--- a/web/sites/default/config/field.field.group.bureau_office.field_address.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_address.yml
@@ -16,8 +16,8 @@ id: group.bureau_office.field_address
 field_name: field_address
 entity_type: group
 bundle: bureau_office
-label: Address
-description: 'Please provide the mailing address for this office.'
+label: 'Mailing Address'
+description: ''
 required: false
 translatable: false
 default_value:

--- a/web/sites/default/config/field.field.group.bureau_office.field_facebook.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_facebook.yml
@@ -1,0 +1,25 @@
+uuid: f11e7e76-c63d-4afa-acc2-e11d00b083c2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_facebook
+    - group.type.bureau_office
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.bureau_office.field_facebook
+field_name: field_facebook
+entity_type: group
+bundle: bureau_office
+label: 'Facebook username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.bureau_office.field_instagram.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_instagram.yml
@@ -1,0 +1,25 @@
+uuid: 6a2194ec-8279-458a-ae2c-d847022d0959
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_instagram
+    - group.type.bureau_office
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.bureau_office.field_instagram
+field_name: field_instagram
+entity_type: group
+bundle: bureau_office
+label: 'Instagram username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.bureau_office.field_twitter.yml
+++ b/web/sites/default/config/field.field.group.bureau_office.field_twitter.yml
@@ -1,0 +1,25 @@
+uuid: d85094a5-cc7b-46c0-805e-d6ec7e701cae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_twitter
+    - group.type.bureau_office
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.bureau_office.field_twitter
+field_name: field_twitter
+entity_type: group
+bundle: bureau_office
+label: 'Twitter username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.elected_official.field_address.yml
+++ b/web/sites/default/config/field.field.group.elected_official.field_address.yml
@@ -16,7 +16,7 @@ id: group.elected_official.field_address
 field_name: field_address
 entity_type: group
 bundle: elected_official
-label: 'Mailing Address'
+label: 'Mailing address'
 description: ''
 required: false
 translatable: true
@@ -24,14 +24,14 @@ default_value:
   -
     langcode: ''
     country_code: US
-    administrative_area: null
-    locality: null
+    administrative_area: ''
+    locality: ''
     dependent_locality: null
-    postal_code: null
+    postal_code: ''
     sorting_code: null
-    address_line1: null
-    address_line2: null
-    organization: null
+    address_line1: ''
+    address_line2: ''
+    organization: ''
     given_name: null
     additional_name: null
     family_name: null

--- a/web/sites/default/config/field.field.group.elected_official.field_address.yml
+++ b/web/sites/default/config/field.field.group.elected_official.field_address.yml
@@ -16,11 +16,25 @@ id: group.elected_official.field_address
 field_name: field_address
 entity_type: group
 bundle: elected_official
-label: Address
-description: 'Please provide the mailing address for this office.'
+label: 'Mailing Address'
+description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    langcode: ''
+    country_code: US
+    administrative_area: null
+    locality: null
+    dependent_locality: null
+    postal_code: null
+    sorting_code: null
+    address_line1: null
+    address_line2: null
+    organization: null
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
   available_countries:

--- a/web/sites/default/config/field.field.group.program.field_address.yml
+++ b/web/sites/default/config/field.field.group.program.field_address.yml
@@ -16,7 +16,7 @@ id: group.program.field_address
 field_name: field_address
 entity_type: group
 bundle: program
-label: 'Mailing Address'
+label: 'Mailing address'
 description: ''
 required: false
 translatable: true

--- a/web/sites/default/config/field.field.group.program.field_address.yml
+++ b/web/sites/default/config/field.field.group.program.field_address.yml
@@ -16,25 +16,25 @@ id: group.program.field_address
 field_name: field_address
 entity_type: group
 bundle: program
-label: Address
-description: 'Please provide the mailing address for this office.'
+label: 'Mailing Address'
+description: ''
 required: false
 translatable: true
 default_value:
   -
+    langcode: ''
     country_code: US
-    langcode: null
     administrative_area: ''
     locality: ''
-    dependent_locality: ''
+    dependent_locality: null
     postal_code: ''
-    sorting_code: ''
+    sorting_code: null
     address_line1: ''
     address_line2: ''
     organization: ''
-    given_name: ''
-    additional_name: ''
-    family_name: ''
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
   available_countries:

--- a/web/sites/default/config/field.field.group.program.field_facebook.yml
+++ b/web/sites/default/config/field.field.group.program.field_facebook.yml
@@ -1,0 +1,25 @@
+uuid: 026c84a5-095b-4c6b-9713-ef85b6fa97cb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_facebook
+    - group.type.program
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.program.field_facebook
+field_name: field_facebook
+entity_type: group
+bundle: program
+label: 'Facebook username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.program.field_instagram.yml
+++ b/web/sites/default/config/field.field.group.program.field_instagram.yml
@@ -1,0 +1,25 @@
+uuid: fe5562a8-1cd4-40e7-8e72-48cf46fb800f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_instagram
+    - group.type.program
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.program.field_instagram
+field_name: field_instagram
+entity_type: group
+bundle: program
+label: 'Instagram username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.program.field_twitter.yml
+++ b/web/sites/default/config/field.field.group.program.field_twitter.yml
@@ -1,0 +1,25 @@
+uuid: 951f429f-bbd9-4fe6-b08b-b9a0b1e895bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.field_twitter
+    - group.type.program
+  module:
+    - custom_add_another
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: group.program.field_twitter
+field_name: field_twitter
+entity_type: group
+bundle: program
+label: 'Twitter username'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.field.group.project.field_address.yml
+++ b/web/sites/default/config/field.field.group.project.field_address.yml
@@ -16,7 +16,7 @@ id: group.project.field_address
 field_name: field_address
 entity_type: group
 bundle: project
-label: 'Mailing Address'
+label: 'Mailing address'
 description: ''
 required: false
 translatable: true

--- a/web/sites/default/config/field.field.group.project.field_address.yml
+++ b/web/sites/default/config/field.field.group.project.field_address.yml
@@ -16,14 +16,29 @@ id: group.project.field_address
 field_name: field_address
 entity_type: group
 bundle: project
-label: Address
+label: 'Mailing Address'
 description: ''
 required: false
 translatable: true
-default_value: {  }
+default_value:
+  -
+    langcode: ''
+    country_code: US
+    administrative_area: ''
+    locality: ''
+    dependent_locality: null
+    postal_code: ''
+    sorting_code: null
+    address_line1: ''
+    address_line2: ''
+    organization: ''
+    given_name: null
+    additional_name: null
+    family_name: null
 default_value_callback: ''
 settings:
-  available_countries: {  }
+  available_countries:
+    US: US
   langcode_override: ''
   field_overrides:
     givenName:


### PR DESCRIPTION
* Enabled display of contact info fields on all types except Elected Official (it was already enabled there)
* Made fields consistent across group types
** Set United States as country
** Changed Address label to Mailing address and removed useless help text
* Added social media fields to Bureau/Office and Program