### PR TITLE
POWR-1543 Add badge to services in /group/services

### DIFF
--- a/web/sites/default/config/core.entity_view_display.node.city_service.teaser.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.teaser.yml
@@ -36,15 +36,50 @@ third_party_settings:
         link_custom: ''
         classes:
           layout_class: {  }
+          first: {  }
+          second: {  }
     regions:
       second:
+        - 'bundle_field:node'
         - field_popular
         - node_title
         - field_summary
     fields:
+      'bundle_field:node':
+        plugin_id: 'bundle_field:node'
+        weight: 0
+        label: hidden
+        formatter: default
+        ft:
+          id: expert
+          settings:
+            lb: ''
+            prefix: ''
+            lbw-el: ''
+            lbw-cl: ''
+            lbw-at: ''
+            ow-el: ''
+            ow-cl: ''
+            ow-at: ''
+            fis-el: ''
+            fis-cl: ''
+            fis-at: ''
+            fi: true
+            fi-el: div
+            fi-cl: 'badge badge-pill badge-light'
+            fi-at: ''
+            suffix: ''
+            lbw: false
+            lb-col: false
+            ow: false
+            ow-def-at: false
+            ow-def-cl: false
+            fis: false
+            fis-def-at: false
+            fi-def-at: false
       node_title:
         plugin_id: node_title
-        weight: 11
+        weight: 2
         label: hidden
         formatter: default
         settings:
@@ -64,7 +99,7 @@ mode: teaser
 content:
   field_popular:
     type: boolean
-    weight: 10
+    weight: 1
     region: second
     label: hidden
     settings:
@@ -102,7 +137,7 @@ content:
             fi-def-at: false
   field_summary:
     type: string
-    weight: 12
+    weight: 3
     region: second
     label: hidden
     settings:

--- a/web/themes/custom/cloudy/scss/components/_badge.scss
+++ b/web/themes/custom/cloudy/scss/components/_badge.scss
@@ -9,6 +9,12 @@
   background-color: $navbar-menu-alert-badge-bg;
 }
 
+.badge-popular {
+  @extend .badge-dark;
+    color: $black;
+    background-color: $gold;
+}
+
 /* admin content/media view tables */
 .view-admin-group-content .status-badge {
   margin-right: 5px;

--- a/web/themes/custom/cloudy/templates/field/field--field-popular.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--field-popular.html.twig
@@ -1,7 +1,14 @@
- {% spaceless %}
-    {% block content %}
-      {%- for item in element['#items'] if item.getValue()['value'] == 1 -%}
-          {% trans %}Popular{% endtrans %}
-      {%- endfor -%}
-    {% endblock %}
-  {% endspaceless %}
+{%
+  set classes = classes|default([
+    'badge',
+    'badge-pill',
+    'badge-light'
+  ])
+%}
+{% spaceless %}
+  {% block content %}
+    {%- for item in element['#items'] if item.getValue()['value'] == 1 -%}
+        <div{{ attributes.addClass(classes) }}>Popular</div>
+    {%- endfor -%}
+  {% endblock %}
+{% endspaceless %}

--- a/web/themes/custom/cloudy/templates/field/field--field-popular.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--field-popular.html.twig
@@ -2,7 +2,7 @@
   set classes = classes|default([
     'badge',
     'badge-pill',
-    'badge-light'
+    'badge-popular'
   ])
 %}
 {% spaceless %}


### PR DESCRIPTION
This adds the services badge to the teaser display for services. It also adds new style to the popular badge style so when the two badges stand next to each other they are distinct from each other and that they also don't look "clickable".