### PR TITLE
POWR-1556 _Overrides Audit

### DIFF
--- a/web/themes/custom/cloudy/scss/_overrides.scss
+++ b/web/themes/custom/cloudy/scss/_overrides.scss
@@ -32,15 +32,6 @@ h1 {
   line-height: $headings-line-height;
 }
 
-/* TODO: figure out where to put this */
-
-input {
-  &[type='text'],
-  &[type='search'] {
-    -webkit-appearance: none;
-  }
-}
-
 details {
   border-radius: $border-radius;
 }
@@ -59,18 +50,6 @@ a {
 
 .bg-inverse {
   background: $primary;
-}
-
-.site-footer {
-  background: $gray;
-}
-
-.menu--main li a {
-  color: $secondary;
-}
-
-.menu--account li a {
-  color: $secondary;
 }
 
 .site-name-slogan a {
@@ -143,56 +122,6 @@ a {
   color: #ffffff;
 }
 
-// Service steps
-
-ol.steps {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-
-li.step {
-  position: relative;
-  counter-increment: step-counter;
-  margin-bottom: 1rem;
-}
-
-li.step {
-  &:before {
-    content: counter(step-counter);
-    position: absolute;
-    left: 0;
-    top: 0;
-    font-size: 1.5rem;
-    border: 1px #909090 solid;
-    color: #505050;
-    font-weight: 400;
-    padding: 0.3rem 1rem;
-    border-radius: 50%;
-  }
-  > * {
-    position: relative;
-    margin-left: 4rem;
-  }
-  .step-title {
-    margin-bottom: $spacer * 1.25;
-  }
-}
-
-ol.steps dl,
-ol.steps ol,
-ol.steps ul {
-  margin-top: 0;
-  margin-bottom: 1rem;
-}
-
-ol.steps ol ol,
-ol.steps ol ul,
-ol.steps ul ol,
-ol.steps ul ul {
-  margin-bottom: 0;
-}
-
 // Homepage customizations
 
 .view-community-actions .list-group-item-action,
@@ -215,34 +144,8 @@ ol.steps ul ul {
   }
 }
 
-.block-copyright-block {
-  width: 100%;
-  min-height: 200px;
-  img {
-    float: right;
-  }
-}
-
 .view-header {
   margin-bottom: 1rem;
-}
-
-.form-inline label {
-  justify-content: left;
-}
-
-.form-inline .form-group {
-  margin-right: 1rem;
-}
-
-.form-inline .form-actions,
-.container-inline .form-actions {
-  align-items: bottom !important;
-}
-
-.block-copyright-block p {
-  float: right;
-  text-align: right;
 }
 
 .layout-main-wrapper {
@@ -260,14 +163,6 @@ ul.pagination {
 .created,
 .updated {
   color: #505050;
-}
-
-.paragraph {
-  margin-bottom: $spacer * 1.75;
-}
-
-div.paragraph--type--document {
-  margin-bottom: 1rem;
 }
 
 // External links
@@ -290,11 +185,6 @@ span.mailto::before {
     display: none;
     padding: 0;
   }
-}
-
-.navbar-brand img {
-  @extend .d-flex;
-  display: block;
 }
 
 .view-top-searches .item-list ul li:last-child {
@@ -326,19 +216,6 @@ span.mailto::before {
   display: inherit !important;
 }
 
-/* TODO: Find a better place for this override and improve color;
-issue is caused by inheriting .button */
-
-.paragraphs-dropdown-actions {
-  @extend .btn-light;
-}
-
-/* UI Dialog - changed position to fixed, because relative was causing dialog to appear
-   partially offscreen (top) on very long pages. */
-.ui-dialog {
-  position: fixed;
-}
-
 .node-preview-container {
   position: static;
   padding: ($spacer / 2) $spacer;
@@ -346,10 +223,6 @@ issue is caused by inheriting .button */
 
 .ui-datepicker {
   width: auto;
-}
-
-.list-group-item.topic {
-  padding: .75rem 1rem;
 }
 
 .path-frontpage #block-feedbacklink {

--- a/web/themes/custom/cloudy/scss/components/_dialog.scss
+++ b/web/themes/custom/cloudy/scss/components/_dialog.scss
@@ -1,4 +1,9 @@
 .ui-dialog {
+  /* UI Dialog - changed position to fixed, because relative was causing dialog to appear
+   partially offscreen (top) on very long pages. */
+  .ui-dialog {
+    position: fixed;
+  }
   .ui-dialog-titlebar {
     display: flex;
     align-items: center;

--- a/web/themes/custom/cloudy/scss/components/_form.scss
+++ b/web/themes/custom/cloudy/scss/components/_form.scss
@@ -3,8 +3,28 @@
  * Visual styles for Tweme's form components.
  */
 
+ input {
+  &[type='text'],
+  &[type='search'] {
+    -webkit-appearance: none;
+  }
+}
+
 .form--inline {
   @extend .form-inline;
+}
+
+.form-inline label {
+  justify-content: left;
+}
+
+.form-inline .form-group {
+  margin-right: 1rem;
+}
+
+.form-inline .form-actions,
+.container-inline .form-actions {
+  align-items: bottom !important;
 }
 
 select.form-select {

--- a/web/themes/custom/cloudy/scss/components/_list-group.scss
+++ b/web/themes/custom/cloudy/scss/components/_list-group.scss
@@ -12,3 +12,7 @@
 .list-group__description {
     margin: 0 0 $list-group-item-padding-y;
 }
+
+.list-group-item.topic {
+    padding: .75rem 1rem;
+  }

--- a/web/themes/custom/cloudy/scss/components/_nav.scss
+++ b/web/themes/custom/cloudy/scss/components/_nav.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.navbar-brand img {
+  @extend .d-flex;
+}
+
 .menu--editor-toolbar .nav-item a.is-active{
   background-color: $editor-toolbar-active-bg;
 }
@@ -18,6 +22,7 @@
         background-color: rgba($black, 0.15);
       }
 }
+
 
 .menu--pages a.nav-link {
   border-top: 1px solid $gray-300;

--- a/web/themes/custom/cloudy/scss/components/_paragraphs.scss
+++ b/web/themes/custom/cloudy/scss/components/_paragraphs.scss
@@ -1,4 +1,9 @@
 // widget styles
+
+.paragraph {
+  margin-bottom: $spacer * 1.75;
+}
+
 ul.paragraphs-add-dialog-list {
   input.field-add-more-submit {
     background-position: $input-btn-padding-y;
@@ -6,6 +11,10 @@ ul.paragraphs-add-dialog-list {
     padding-left: $font-size-base * 2;
     border-radius: $border-radius;
   }
+}
+
+div.paragraph--type--document {
+  margin-bottom: 1rem;
 }
 
 .js {
@@ -35,4 +44,10 @@ ul.paragraphs-add-dialog-list {
       grid-column: 3 / span 1;
     }
   }
+}
+
+/* TODO: improve color;
+issue is caused by inheriting .button */
+.paragraphs-dropdown-actions {
+  @extend .btn-light;
 }

--- a/web/themes/custom/cloudy/scss/components/_site-footer.scss
+++ b/web/themes/custom/cloudy/scss/components/_site-footer.scss
@@ -9,7 +9,7 @@
         padding: 0 $spacer;
     }
     margin: $spacer 0 0;
-    background-color: $light-gray;
+    background-color: $gray;
 }
 
 
@@ -30,3 +30,17 @@
     padding: ($spacer / 2) 0;
     margin-top: 0;
 }
+
+/* Portland seal and copyright styling */
+
+.block-copyright-block {
+    width: 100%;
+    min-height: 200px;
+    p {
+        float: right;
+        text-align: right;
+    }
+    img {
+        float: right;
+    }
+  }


### PR DESCRIPTION
Removing redundant style overrides or moving them to component scss files.

Files affected:
- _dialog
- _forms
- _list-group
- _nav
- _paragraphs
- _site-footer

To Test-

- Go to https://powr-1556-portlandor.pantheonsite.io/.

Check the homepage, services main page, bureaus and offices main page, and alerts main page at different breakpoints to ensure there is no style regression.