### PR TITLE
ci: increase deploy timeout allowed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ build_and_deploy: &build_and_deploy
     - run:
         name: Deploy to Pantheon
         when: on_success
+        no_output_timeout: 15m # allow 15 minutes instead of 10 minute default for script to complete
         command: |
           export PATH=/tmp/vendor/bin:/var/www/html/vendor/bin:$PATH && cd /var/www/html
           # Don't check the repo host key


### PR DESCRIPTION
This will fix the [deploy failing here](https://circleci.com/gh/eGovPDX/portlandor/8782?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) by giving more time for the deploy to complete (10 minutes => 15 minutes).