### PR TITLE
POWR-1750 - Media losing group content relationship when created inline

### DIFF
--- a/web/modules/custom/portland/modules/portland_groups/portland_groups.module
+++ b/web/modules/custom/portland/modules/portland_groups/portland_groups.module
@@ -75,15 +75,16 @@ function _portland_groups_assign_media_to_group($entity) {
 
   // get group identified in first delta in field_display_groups
   $group_id = $entity->get('field_display_groups')->getValue()[0]['target_id'];
-  $group = \Drupal\group\Entity\Group::load($group_id);
+  if (!is_null($group_id)) {
+    $group = \Drupal\group\Entity\Group::load($group_id);
 
-  $media_group = \Drupal\group\Entity\GroupContent::create([
-    'gid' => $group_id,
-    'entity_id' => $entity->id(),
-    'type' => $group->getGroupType()->id() . '-group_' . $entity->getEntityTypeId() . '-' . $entity->bundle(),
-  ]);
-  $media_group->save();
-
+    $media_group = \Drupal\group\Entity\GroupContent::create([
+      'gid' => $group_id,
+      'entity_id' => $entity->id(),
+      'type' => $group->getGroupType()->id() . '-group_' . $entity->getEntityTypeId() . '-' . $entity->bundle(),
+    ]);
+    $media_group->save();
+  }
 }
 
 // NOTE: at this time we're not filtering Display in Groups autocomplete optiopns

--- a/web/modules/custom/portland/modules/portland_groups/portland_groups.module
+++ b/web/modules/custom/portland/modules/portland_groups/portland_groups.module
@@ -53,6 +53,39 @@ function _portland_groups_inline_entity_populate_field_display_groups(&$form, &$
   }
 }
 
+/**
+ * Implements hook_media_insert
+ */
+function portland_groups_media_insert($entity) {
+  _portland_groups_assign_media_to_group($entity);
+}
+
+/**
+ * Manually assigns a media entity to a group as group content.
+ * The group is identified by the first delta in the media's field_display_groups.
+ * This should only happen in the context of an inline entity form.
+ */
+function _portland_groups_assign_media_to_group($entity) {
+
+  // only do this for inline entity brower
+  $current_path = \Drupal::service('path.current')->getPath();
+  if (substr($current_path, 0, 23) != "/entity-browser/iframe/") {
+    return;
+  }
+
+  // get group identified in first delta in field_display_groups
+  $group_id = $entity->get('field_display_groups')->getValue()[0]['target_id'];
+  $group = \Drupal\group\Entity\Group::load($group_id);
+
+  $media_group = \Drupal\group\Entity\GroupContent::create([
+    'gid' => $group_id,
+    'entity_id' => $entity->id(),
+    'type' => $group->getGroupType()->id() . '-group_' . $entity->getEntityTypeId() . '-' . $entity->bundle(),
+  ]);
+  $media_group->save();
+
+}
+
 // NOTE: at this time we're not filtering Display in Groups autocomplete optiopns
 // based on group membership, but we might want to in the near future. This function
 // creates an array of options that's suitable for passing to a select list.

--- a/web/sites/default/config/core.entity_form_display.media.audio.media_browser.yml
+++ b/web/sites/default/config/core.entity_form_display.media.audio.media_browser.yml
@@ -18,18 +18,35 @@ dependencies:
   module:
     - content_moderation
     - maxlength
-    - path
+    - text
+    - video_embed_field
 id: media.audio.media_browser
 targetEntityType: media
 bundle: audio
 mode: media_browser
 content:
-  field_media_in_library:
-    type: boolean_checkbox
+  field_caption:
+    type: text_textfield
     weight: 2
     region: content
     settings:
-      display_label: true
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_display_groups:
+    type: entity_reference_autocomplete
+    weight: 4
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_video_embed_field:
+    type: video_embed_field_textfield
+    weight: 1
+    region: content
+    settings: {  }
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
@@ -48,32 +65,19 @@ content:
       maxlength:
         maxlength_js: 60
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-  path:
-    type: path
+  preview:
     weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
-  preview:
-    weight: 1
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 4
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
 hidden:
   created: true
-  field_caption: true
   field_creator: true
-  field_display_groups: true
   field_license: true
-  field_media_video_embed_field: true
+  field_media_in_library: true
   field_source: true
   field_title: true
   field_transcript: true
+  path: true
+  status: true
   uid: true

--- a/web/sites/default/config/core.entity_form_display.media.document.media_browser.yml
+++ b/web/sites/default/config/core.entity_form_display.media.document.media_browser.yml
@@ -16,7 +16,24 @@ dependencies:
     - workflows.workflow.media
   module:
     - content_moderation
-    - path
+    - field_group
+    - file
+    - link
+third_party_settings:
+  field_group:
+    group_details:
+      children: {  }
+      parent_name: ''
+      weight: 7
+      format_type: details
+      format_settings:
+        id: ''
+        classes: ''
+        description: 'Choose one of the following options for linking to the document'
+        open: true
+        required_fields: true
+      label: 'Document storage'
+      region: hidden
 _core:
   default_config_hash: X8KEO5iV-XcsBLSyLEMOMv3sw-WxXeIdWnZZ1btyyVU
 id: media.document.media_browser
@@ -24,16 +41,47 @@ targetEntityType: media
 bundle: document
 mode: media_browser
 content:
-  field_media_in_library:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 1
-    third_party_settings: {  }
+  field_display_groups:
+    type: entity_reference_autocomplete
+    weight: 5
     region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_document:
+    type: file_generic
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_document_type:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_efiles_link:
+    type: link_default
+    weight: 3
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_summary:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 6
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -45,26 +93,11 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 100
-    region: content
-    third_party_settings: {  }
 hidden:
   created: true
-  field_display_groups: true
-  field_document: true
-  field_document_type: true
-  field_efiles_link: true
   field_file_size: true
+  field_media_in_library: true
   field_mime_type: true
-  field_summary: true
+  path: true
+  status: true
   uid: true

--- a/web/sites/default/config/core.entity_form_display.media.image.media_browser.yml
+++ b/web/sites/default/config/core.entity_form_display.media.image.media_browser.yml
@@ -18,36 +18,28 @@ dependencies:
     - field.field.media.image.image
     - image.style.max_540w
     - media.type.image
-    - workflows.workflow.media
   module:
-    - content_moderation
     - field_group
     - focal_point
     - lightning_media
-    - path
     - text
 third_party_settings:
   field_group:
     group_details:
-      children:
-        - group_attribution
+      children: {  }
       parent_name: ''
-      weight: 1
+      weight: 19
       format_type: accordion
       format_settings:
         id: ''
         classes: ''
         effect: none
       label: Details
-      region: content
+      region: hidden
     group_attribution:
-      children:
-        - field_creator
-        - field_title
-        - field_source
-        - field_license
-      parent_name: group_details
-      weight: 20
+      children: {  }
+      parent_name: ''
+      weight: 6
       format_type: accordion_item
       format_settings:
         id: ''
@@ -56,7 +48,7 @@ third_party_settings:
         required_fields: false
         description: ''
       label: Attribution
-      region: content
+      region: hidden
 _core:
   default_config_hash: iVmRBD7y3Gmddt29sSx9DwwH6Q4UaROqMu7FLyy_bvQ
 id: media.image.media_browser
@@ -66,15 +58,7 @@ mode: media_browser
 content:
   field_caption:
     type: text_textfield
-    weight: 3
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_creator:
-    type: string_textfield
-    weight: 7
+    weight: 2
     region: content
     settings:
       size: 60
@@ -82,38 +66,16 @@ content:
     third_party_settings: {  }
   field_display_groups:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_license:
-    type: options_select
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_source:
-    type: string_textfield
-    weight: 9
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_title:
-    type: string_textfield
-    weight: 8
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   image:
     type: image_focal_point
-    weight: 2
+    weight: 1
     settings:
       preview_image_style: max_540w
       preview_link: true
@@ -124,12 +86,6 @@ content:
         file_links: false
         remove_button: false
     region: content
-  moderation_state:
-    type: moderation_state_default
-    weight: 5
-    settings: {  }
-    region: content
-    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0
@@ -138,18 +94,18 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
-  path:
-    type: path
-    weight: 6
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   created: true
+  field_creator: true
   field_file_size: true
   field_image_height: true
   field_image_width: true
+  field_license: true
   field_media_in_library: true
   field_mime_type: true
+  field_source: true
+  field_title: true
+  moderation_state: true
+  path: true
   status: true
   uid: true

--- a/web/sites/default/config/core.entity_form_display.media.map.media_browser.yml
+++ b/web/sites/default/config/core.entity_form_display.media.map.media_browser.yml
@@ -4,8 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.media_browser
+    - entity_browser.browser.featured_image
+    - field.field.media.map.field_display_groups
     - field.field.media.map.field_geo_file
     - field.field.media.map.field_map_embed
+    - field.field.media.map.field_map_file
     - field.field.media.map.field_map_type
     - field.field.media.map.field_media_in_library
     - field.field.media.map.field_summary
@@ -13,33 +16,76 @@ dependencies:
     - media.type.map
     - workflows.workflow.media
   module:
-    - conditional_fields
     - content_moderation
+    - entity_browser
     - file
-    - path
+    - media_embed_field
 id: media.map.media_browser
 targetEntityType: media
 bundle: map
 mode: media_browser
 content:
+  field_display_groups:
+    type: entity_reference_autocomplete
+    weight: 7
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_geo_file:
     third_party_settings:
       conditional_fields: {  }
-    weight: 26
+    weight: 5
     settings:
       progress_indicator: throbber
     type: file_generic
     region: content
-  field_media_in_library:
-    type: boolean_checkbox
-    weight: 1
+  field_map_embed:
+    type: media_embed_field_textfield
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_map_file:
+    type: file_generic
+    weight: 4
     region: content
     settings:
-      display_label: true
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_map_type:
+    type: options_select
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_summary:
+    type: string_textfield
+    weight: 6
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  image:
+    type: entity_browser_file
+    weight: 2
+    settings:
+      entity_browser: featured_image
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      preview_image_style: max_540w
+      field_widget_edit: true
+      field_widget_replace: false
+      view_mode: default
+    region: content
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 4
+    weight: 8
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -51,29 +97,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  path:
-    type: path
-    weight: 2
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   preview:
     weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
 hidden:
   created: true
-  field_map_embed: true
-  field_map_type: true
-  field_summary: true
+  field_media_in_library: true
   group_content: true
-  image: true
+  path: true
+  status: true
   uid: true

--- a/web/sites/default/config/core.entity_form_display.media.video.media_browser.yml
+++ b/web/sites/default/config/core.entity_form_display.media.video.media_browser.yml
@@ -17,7 +17,8 @@ dependencies:
     - workflows.workflow.media
   module:
     - content_moderation
-    - path
+    - text
+    - video_embed_field
 _core:
   default_config_hash: Wft8ifOMAlgFjAvTyWmpKS_RnTcBkckjM2u90vzd7cM
 id: media.video.media_browser
@@ -25,16 +26,40 @@ targetEntityType: media
 bundle: video
 mode: media_browser
 content:
-  field_media_in_library:
-    type: boolean_checkbox
-    weight: 1
-    settings:
-      display_label: true
-    third_party_settings: {  }
+  field_caption:
+    type: text_textfield
+    weight: 3
     region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_display_groups:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_video_embed_field:
+    type: video_embed_field_textfield
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_transcript:
+    type: text_textarea
+    weight: 4
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 6
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -46,32 +71,18 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
-  path:
-    type: path
-    weight: 30
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   preview:
-    weight: 101
+    weight: 2
+    region: content
     settings: {  }
-    third_party_settings: {  }
-    region: content
-  status:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 100
-    region: content
     third_party_settings: {  }
 hidden:
   created: true
-  field_caption: true
   field_creator: true
-  field_display_groups: true
   field_license: true
-  field_media_video_embed_field: true
+  field_media_in_library: true
   field_source: true
   field_title: true
-  field_transcript: true
+  path: true
+  status: true
   uid: true

--- a/web/sites/default/config/entity_browser.browser.audio_video_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.audio_video_browser_embed.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.media
   module:
+    - entity_browser_entity_form
     - views
 name: audio_video_browser_embed
 label: 'Audio/video browser (embed)'
@@ -29,3 +30,23 @@ widgets:
     weight: 1
     label: 'View audio/video'
     id: view
+  5c740b08-6f03-401f-9fd6-f4a7096ba1cc:
+    settings:
+      entity_type: media
+      bundle: video
+      form_mode: default
+      submit_text: 'Save video'
+    uuid: 5c740b08-6f03-401f-9fd6-f4a7096ba1cc
+    weight: 2
+    label: 'Add video'
+    id: entity_form
+  3c521bcc-3a39-4638-919a-87f604822764:
+    settings:
+      entity_type: media
+      bundle: audio
+      form_mode: default
+      submit_text: 'Save audio'
+    uuid: 3c521bcc-3a39-4638-919a-87f604822764
+    weight: 3
+    label: 'Add audio'
+    id: entity_form

--- a/web/sites/default/config/entity_browser.browser.audio_video_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.audio_video_browser_embed.yml
@@ -34,7 +34,7 @@ widgets:
     settings:
       entity_type: media
       bundle: video
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save video'
     uuid: 5c740b08-6f03-401f-9fd6-f4a7096ba1cc
     weight: 2
@@ -44,7 +44,7 @@ widgets:
     settings:
       entity_type: media
       bundle: audio
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save audio'
     uuid: 3c521bcc-3a39-4638-919a-87f604822764
     weight: 3

--- a/web/sites/default/config/entity_browser.browser.document_browser.yml
+++ b/web/sites/default/config/entity_browser.browser.document_browser.yml
@@ -34,7 +34,7 @@ widgets:
     settings:
       entity_type: media
       bundle: document
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save document'
     uuid: de679257-e9f7-403c-bcfc-3012e20cd752
     weight: 2

--- a/web/sites/default/config/entity_browser.browser.document_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.document_browser_embed.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.media
   module:
+    - entity_browser_entity_form
     - views
 name: document_browser_embed
 label: 'Document browser (embed)'
@@ -29,3 +30,13 @@ widgets:
     weight: 1
     label: 'View documents'
     id: view
+  c173c8f9-e795-413d-a5a5-79dd98ea5660:
+    settings:
+      entity_type: media
+      bundle: document
+      form_mode: default
+      submit_text: 'Save document'
+    uuid: c173c8f9-e795-413d-a5a5-79dd98ea5660
+    weight: 2
+    label: 'Add document'
+    id: entity_form

--- a/web/sites/default/config/entity_browser.browser.document_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.document_browser_embed.yml
@@ -34,7 +34,7 @@ widgets:
     settings:
       entity_type: media
       bundle: document
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save document'
     uuid: c173c8f9-e795-413d-a5a5-79dd98ea5660
     weight: 2

--- a/web/sites/default/config/entity_browser.browser.featured_image.yml
+++ b/web/sites/default/config/entity_browser.browser.featured_image.yml
@@ -34,7 +34,7 @@ widgets:
     settings:
       entity_type: media
       bundle: image
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save image'
     uuid: 72cb43cc-2482-446a-9248-7a3580e2f73e
     weight: 2

--- a/web/sites/default/config/entity_browser.browser.image_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.image_browser_embed.yml
@@ -39,7 +39,7 @@ widgets:
     settings:
       entity_type: media
       bundle: image
-      form_mode: default
+      form_mode: media_browser
       submit_text: 'Save image'
     uuid: 39811e2f-aeb7-494a-afe1-e83060b1fb80
     weight: 2

--- a/web/sites/default/config/entity_browser.browser.image_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.image_browser_embed.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.media
   module:
+    - entity_browser_entity_form
     - views
 name: image_browser_embed
 label: 'Image browser (embed)'
@@ -34,3 +35,13 @@ widgets:
     weight: 1
     label: 'View images'
     id: view
+  39811e2f-aeb7-494a-afe1-e83060b1fb80:
+    settings:
+      entity_type: media
+      bundle: image
+      form_mode: default
+      submit_text: 'Save image'
+    uuid: 39811e2f-aeb7-494a-afe1-e83060b1fb80
+    weight: 2
+    label: 'Add image'
+    id: entity_form

--- a/web/sites/default/config/entity_browser.browser.map_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.map_browser_embed.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.media
   module:
+    - entity_browser_entity_form
     - views
 name: map_browser_embed
 label: 'Map browser (embed)'
@@ -27,5 +28,15 @@ widgets:
       auto_select: false
     uuid: e2e5d085-cba3-4216-b240-92fcc5f3126e
     weight: 1
-    label: 'View map'
+    label: 'View maps'
     id: view
+  2db0bb51-ca17-4795-a875-e9f86e01360c:
+    settings:
+      entity_type: media
+      bundle: map
+      form_mode: default
+      submit_text: 'Save map'
+    uuid: 2db0bb51-ca17-4795-a875-e9f86e01360c
+    weight: 2
+    label: 'Add map'
+    id: entity_form

--- a/web/sites/default/config/entity_browser.browser.map_browser_embed.yml
+++ b/web/sites/default/config/entity_browser.browser.map_browser_embed.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.media
   module:
-    - entity_browser_entity_form
     - views
 name: map_browser_embed
 label: 'Map browser (embed)'
@@ -30,13 +29,3 @@ widgets:
     weight: 1
     label: 'View maps'
     id: view
-  2db0bb51-ca17-4795-a875-e9f86e01360c:
-    settings:
-      entity_type: media
-      bundle: map
-      form_mode: default
-      submit_text: 'Save map'
-    uuid: 2db0bb51-ca17-4795-a875-e9f86e01360c
-    weight: 2
-    label: 'Add map'
-    id: entity_form

--- a/web/sites/default/config/entity_browser.browser.media_browser.yml
+++ b/web/sites/default/config/entity_browser.browser.media_browser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - views.view.media
   module:
+    - lightning_media
     - views
 _core:
   default_config_hash: kT3o2OhRMWgZX6kGxRYSsItntaw241e3UwpGCD3RpJE
@@ -36,3 +37,23 @@ widgets:
     weight: -10
     label: Library
     id: view
+  3d899f39-437b-4bb3-970e-b4373ec41df3:
+    settings:
+      submit_text: Place
+      target_bundles: {  }
+      form_mode: media_browser
+      return_file: false
+      upload_validators: {  }
+    uuid: 3d899f39-437b-4bb3-970e-b4373ec41df3
+    weight: 2
+    label: Upload
+    id: file_upload
+  4252e4d3-2cd9-45fc-adde-5d594c6eeea9:
+    settings:
+      submit_text: Place
+      target_bundles: {  }
+      form_mode: media_browser
+    uuid: 4252e4d3-2cd9-45fc-adde-5d594c6eeea9
+    weight: 3
+    label: 'Create embed'
+    id: embed_code

--- a/web/sites/default/config/entity_browser.browser.video_browser.yml
+++ b/web/sites/default/config/entity_browser.browser.video_browser.yml
@@ -22,7 +22,7 @@ widgets:
   5a397660-ac57-4a68-b5cc-6ac64e7bfffd:
     settings:
       view: media
-      view_display: video_browser
+      view_display: entity_browser_4
       submit_text: 'Select video'
       auto_select: false
     uuid: 5a397660-ac57-4a68-b5cc-6ac64e7bfffd

--- a/web/sites/default/config/views.view.media.yml
+++ b/web/sites/default/config/views.view.media.yml
@@ -900,19 +900,6 @@ display:
           empty: false
           content: '@total items found, displaying @start - @end'
           plugin_id: result
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: '<p>You must first add media to your group to place it using a media embed button.</p>'
-            format: full_html
-          plugin_id: text
       footer: {  }
       empty:
         area_text_custom:


### PR DESCRIPTION
* Implements hook_entity_insert to manually add a new media entity to a group if it is created in the context of an inline entity form. Works with all media types.
* Reverts temporary changes to entity browsers as workaround while bug was fixed.