### PR TITLE
POWR-1796: Hotfix Search Result "Program" heading level to h2

### DIFF
--- a/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
@@ -41,7 +41,6 @@ third_party_settings:
       disable_css: false
       entity_classes: all_classes
       settings:
-        label: ''
         wrappers:
           first: div
           second: div
@@ -149,24 +148,24 @@ content:
             lbw-el: ''
             lbw-cl: ''
             lbw-at: ''
-            ow: true
-            ow-el: h2
+            ow-el: ''
             ow-cl: ''
             ow-at: ''
             fis-el: ''
             fis-cl: ''
             fis-at: ''
-            fi-el: ''
+            fi: true
+            fi-el: h2
             fi-cl: ''
             fi-at: ''
             suffix: ''
             lbw: false
             lb-col: false
+            ow: false
             ow-def-at: false
             ow-def-cl: false
             fis: false
             fis-def-at: false
-            fi: false
             fi-def-at: false
 hidden:
   changed: true

--- a/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.group.program.search_result.yml
@@ -41,6 +41,7 @@ third_party_settings:
       disable_css: false
       entity_classes: all_classes
       settings:
+        label: ''
         wrappers:
           first: div
           second: div
@@ -148,24 +149,24 @@ content:
             lbw-el: ''
             lbw-cl: ''
             lbw-at: ''
-            ow-el: ''
+            ow: true
+            ow-el: h2
             ow-cl: ''
             ow-at: ''
             fis-el: ''
             fis-cl: ''
             fis-at: ''
-            fi: true
-            fi-el: h3
+            fi-el: ''
             fi-cl: ''
             fi-at: ''
             suffix: ''
             lbw: false
             lb-col: false
-            ow: false
             ow-def-at: false
             ow-def-cl: false
             fis: false
             fis-def-at: false
+            fi: false
             fi-def-at: false
 hidden:
   changed: true


### PR DESCRIPTION
This is a hotfix for the heading level of "program" search results. This patches the DS module approach with the correct configuration. PR POWR-1795 and its follow up integration with Drupal should provide a long term correction in which all search result cards will use the same template, removing the possibility of configuration drift between the rendering of various content type search results.