### PR TITLE
POWR-1909 Search Bar Height

### DIFF
--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -174,11 +174,11 @@ select.form-select:focus {
       border-left: 1px solid $cloudy-gray-base;
       border-right: 1px solid $cloudy-gray-base;
       border-radius: $border-radius-tight;
+      align-items: stretch;
     }
     .form-search,
     .form-action,
     .form-autocomplete {
-      height: 3.3rem;
       padding: $cloudy-space-2 $cloudy-space-4;
       @include font-size($input-font-size-lg);
       line-height: $input-line-height-lg;

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -112,6 +112,9 @@ h1.homepage-title {
 
 .header {
   .search-api-page-block-form {
+    .input-group {
+      align-items: stretch;
+    }
     .form-search,
     .form-autocomplete {
       margin: 0 0 0 $cloudy-space-3;
@@ -119,6 +122,7 @@ h1.homepage-title {
       background-color: $cloudy-gray-base;
       font-size: 1rem;
       color: $cloudy-black-base;
+      height: auto;
     }
     .form-search,
     .form-action,

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -114,6 +114,7 @@ h1.homepage-title {
   .search-api-page-block-form {
     .input-group {
       align-items: stretch;
+      background-color: $cloudy-gray-200;
     }
     .form-search,
     .form-autocomplete {

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -114,11 +114,12 @@ h1.homepage-title {
   .search-api-page-block-form {
     .input-group {
       align-items: stretch;
-      background-color: $cloudy-gray-200;
+      background-color: $cloudy-gray-base;
+      margin: 0 0 0 $cloudy-space-3;
     }
     .form-search,
     .form-autocomplete {
-      margin: 0 0 0 $cloudy-space-3;
+      margin: 0;
       min-width: 15rem;
       background-color: $cloudy-gray-base;
       font-size: 1rem;


### PR DESCRIPTION
On both the homepage search bar and header search bar, the css was declaring an explicit height of the inner white text input area, instead of allowing the input area to fill the space. On the homepage, this was causing a rounding error with pixels (the inner text area was 68.78px, which on some hi rescreens would add a line of blue pixels).

Testing:
1. Go to the https://powr-1909-portlandor.pantheonsite.io/
2. Make sure the homepage search bar looks correct (no blue line above or below the text input) across all screen widths (this is best tested on a hi res screen)
3. Go to a page that includes the search bar in the header. The search bar input area should be the same height and flush with the magnifier glass icon.
4. Check other instances of the search bar, such as https://powr-1909-portlandor.pantheonsite.io/search, this should look the same as before.