### PR TITLE
POWR-1904 header navbar container alignment

### DIFF
--- a/web/themes/custom/cloudy/src/components/_header.scss
+++ b/web/themes/custom/cloudy/src/components/_header.scss
@@ -28,7 +28,7 @@
 }
 
 .navbar {
-  padding: 0 $cloudy-space-6;
+  padding: 0;
   .navbar-brand {
     img {
       max-width: 280px;

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -44,8 +44,8 @@
 
 {% block header %}
   <header id="header" class="header" aria-label="{{ 'Site header'|t}}" role="banner">
-    <nav class="navbar navbar-light navbar-expand-xl" id="navbar-main">
-      <div class="container">
+    <div class="container">
+      <nav class="navbar navbar-light navbar-expand-xl" id="navbar-main">
         {{ page.header }}
         {% if page.primary_menu or page.header_form %}
           <button class="navbar-toggler navbar-toggler-right border-0" type="button" data-toggle="collapse" data-target="#CollapsingNavbar" aria-controls="CollapsingNavbar" aria-expanded="false" aria-label="{{ 'Toggle navigation'|t }}">{{ 'Menu'|t }}</button>
@@ -59,8 +59,8 @@
             {% endif %}
           </div>
         {% endif %}
-      </div>
-    </nav>
+      </nav>
+    </div>
   </header>
 {% endblock %}
 


### PR DESCRIPTION
Fixes the nesting of container/layout element in the header so header content respects the same step-wise container behavior as main content (the header content has the same left/right alignment as the rest of the page). This should be addressed across all breakpoints. See the below "After" image for a sense how this should look.

Testing:
1) Go to https://powr-1904-portlandor.pantheonsite.io/
2) Test across all browser widths that the left-hand edge of the header logo aligns with the left-hand edge of the content. See below for guidance 

## Before (broken)

<img width="859" alt="Screenshot 2020-01-29 13 47 44" src="https://user-images.githubusercontent.com/16548879/73400567-3e8e4a80-429e-11ea-88d1-5afbbbb02f48.png">

## After (fixed)

<img width="694" alt="Screenshot 2020-01-29 13 46 07" src="https://user-images.githubusercontent.com/16548879/73400568-3e8e4a80-429e-11ea-9ec0-18e00a6a584c.png">



