### PR TITLE
POWR-1902 POWR-1906 Breadcrumb Screen Reader Improvements, PL Docs

### DIFF
--- a/web/themes/custom/cloudy/pattern-lab/_patterns/01-components/breadcrumb/05-main-demo.twig
+++ b/web/themes/custom/cloudy/pattern-lab/_patterns/01-components/breadcrumb/05-main-demo.twig
@@ -4,7 +4,14 @@
   items: [
     {
     url: 'example.com',
-    text: 'breadcrumb'
+    text: 'Home'
+    },
+    {
+      url: 'example.com',
+      text: 'Lorem Ipsum'
+    },
+    {
+      text: 'Dolar Set'
     },
   ],
 } only %}

--- a/web/themes/custom/cloudy/pattern-lab/_patterns/01-components/breadcrumb/10-type-variations.twig
+++ b/web/themes/custom/cloudy/pattern-lab/_patterns/01-components/breadcrumb/10-type-variations.twig
@@ -5,7 +5,7 @@
     items: [
       {
         url: 'example.com',
-        text: 'breadcrumb'
+        text: 'Single Item'
       },
     ],
   } only %}
@@ -16,11 +16,11 @@
     items: [
       {
         url: 'example.com',
-        text: 'breadcrumb'
+        text: 'Item One'
       },
       {
         url: 'example.com',
-        text: 'breadcrumb 2'
+        text: 'Item Two'
       },
     ],
   } only %}
@@ -30,7 +30,7 @@
   {% include "@components/breadcrumb/breadcrumb.twig" with {
     items: [
       {
-        text: 'breadcrumb'
+        text: 'No URL Link'
       },
     ],
   } only %}
@@ -40,10 +40,33 @@
   {% include "@components/breadcrumb/breadcrumb.twig" with {
     items: [
       {
-        text: 'breadcrumb'
+        text: 'Item One No URL'
       },
       {
-        text: 'breadcrumb 2'
+        text: 'Item Two No URL'
+      },
+    ],
+  } only %}
+</div>
+
+<div>
+  {% include "@components/breadcrumb/breadcrumb.twig" with {
+    items: [
+      {
+        url: 'example.com',
+        text: 'Home'
+      },
+      {
+        url: 'example.com',
+        text: 'This Example is Very Long'
+      },
+      {
+        url: 'example.com',
+        text: 'Very Long Titles Can Be Stressful Upon Responsive Design'
+      },
+      {
+        url: 'example.com',
+        text: 'For Example, This Demo is Great for Testing BreadCrumb Behaviour on Mobile'
       },
     ],
   } only %}

--- a/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
+++ b/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
@@ -12,40 +12,25 @@
     margin: 0;
     padding: 0;
   }
-  
+
   &__item {
     display: inline;
     margin: 0;
     padding: 0;
-    // The separator between breadcrumbs (by default, a forward-slash: "/")
     + .breadcrumb__item {
       padding-left: .5rem;
-  
-      &::before {
-        display: inline-block; // Suppress underlining of the separator in modern browsers
-        padding-right: .5rem;
-        color: $cloudy-gray-600;
-        content: '/';
-      }
     }
-  
-    // IE9-11 hack to properly handle hyperlink underlines for breadcrumbs built
-    // without `<ul>`s. The `::before` pseudo-element generates an element
-    // *within* the .breadcrumb-item and thereby inherits the `text-decoration`.
-    //
-    // To trick IE into suppressing the underline, we give the pseudo-element an
-    // underline and then immediately remove it.
-    + .breadcrumb__item:hover::before {
-      text-decoration: underline;
-    }
-    // stylelint-disable-next-line no-duplicate-selectors
-    + .breadcrumb__item:hover::before {
-      text-decoration: none;
-    }
-  
+
     &--active {
       color: $cloudy-gray-600;
     }
+  }
+
+  &__divider {
+    display: inline-block;
+    padding-right: .5rem;
+    color: $cloudy-gray-600;
+    text-decoration: none;
   }
 }
 

--- a/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
+++ b/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
@@ -24,6 +24,10 @@
     &--active {
       color: $cloudy-gray-600;
     }
+
+    &:before {
+      content: "" !important; // Override the Classy before element, as we are not using it
+    }
   }
 
   &__divider {

--- a/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.twig
+++ b/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.twig
@@ -4,10 +4,16 @@
   {% for item in items %}
     {% if item.url %}
       <li class="breadcrumb__item">
+        {% if not loop.first %}
+          <span class="breadcrumb__divider" aria-hidden="true">/</span>
+        {% endif %}
         <a href="{{ item.url }}">{{ item.text }}</a>
       </li>
     {% else %}
       <li class="breadcrumb__item breadcrumb__item--active">
+        {% if not loop.first %}
+          <span class="breadcrumb__divider" aria-hidden="true">/</span>
+        {% endif %}
         {{ item.text }}
       </li>
     {% endif %}


### PR DESCRIPTION
POWR-1902 - Screen readers were picking up the "/" inbetween breadcrumb items. As there is not a way to hide psuedo-elements from screen readers, the "/" was turned into a span with aria-hidden. No visual changes to the breadcrumbs, but screen readers will no longer read out the "/".

POWR-1906 - Cleaned up the breadcrumb PL docs, including better content and an example of a really really long breadcrumb.

Testing POWR-1902:
1) Go to https://powr-1902-portlandor.pantheonsite.io/, then to any other page on the site
2) Use a screen reader to navigate to the breadcrumbs
3) The screen reader should read each crumb, but not the "slash" between them.

Testing POWR-1906:
1) Go to https://powr-1902-portlandor.pantheonsite.io//pattern-lab/patterns/01-components-breadcrumb/index.html
2) See the updated examples of breadcrumb. This should include a very very long example.