### PR TITLE
POWR-1723 Related document description not being used as link text

### DIFF
--- a/web/themes/custom/cloudy/templates/field/file-link.html.twig
+++ b/web/themes/custom/cloudy/templates/field/file-link.html.twig
@@ -13,7 +13,7 @@
 #}
 {% set url = file_url(file.uri.value) %}
 
-{% set text = file_display_name|default(file.filename.value) %}
+{% set text = file_display_name|default(link['#title'])|default(file.filename.value) %}
 
 {% set icon_map = {
   'application/pdf': 'fa-file-pdf',


### PR DESCRIPTION
This broke after some work that Mike did with document icons. All I had to do was add an additional default filter with the file description.