### PR TITLE
POWR-1963 feat: better grid gutters

### DIFF
--- a/web/themes/custom/cloudy/src/css/core/_bootstrap-overrides.scss
+++ b/web/themes/custom/cloudy/src/css/core/_bootstrap-overrides.scss
@@ -49,3 +49,6 @@ $chosen-sprite-retina-path: '/themes/custom/cloudy/images/chosen-sprite@2x.png';
 $hr-margin-y: 1rem;
 $hr-border-width: 3px;
 $hr-border-color: $cloudy-gray-base;
+
+// Bootstrap Grid Spacing
+$grid-gutter-width: 2rem;


### PR DESCRIPTION
Previous behaviour: All grid gutters were 30px wide.
New behaviour: Grid gutters track spacing responsiveness... on small screens the gutter is 28px (2 * 14px), on medium screens 32px (2 * 16px), and on large screens 36px (2 * 18px).