### PR TITLE
POWR-1948 LAYOUT: Group lead paragraph should not be 50% width

### DIFF
--- a/web/themes/custom/cloudy/src/layouts/group-default/group-default.twig
+++ b/web/themes/custom/cloudy/src/layouts/group-default/group-default.twig
@@ -1,7 +1,13 @@
 <div class="group-default">
   <div class="group-default__marquee">
     {{ overline }}
-    {% if marquee_primary_left|trim|length or marquee_primary_right|trim|length %}
+    {% if marquee_primary_left|trim|length and not marquee_primary_right|trim|length %}
+      <div class="row group-default__row">
+        <div class="col">
+          {{ marquee_primary_left }}
+        </div>
+      </div>
+    {% elseif marquee_primary_left|trim|length and marquee_primary_right|trim|length %}
       <div class="row group-default__row">
         <div class="col-lg-6">
           {{ marquee_primary_left }}


### PR DESCRIPTION
Previously the lead paragraph on group default layout was always in a 50% grid column on large screens, even if no featured image was present. Now the lead paragraph is in a full width column if no featured media is present.

