### PR TITLE
fix: resolve file permission error during PL build POWR-2023

### DIFF
--- a/web/themes/custom/cloudy/package-lock.json
+++ b/web/themes/custom/cloudy/package-lock.json
@@ -1258,14 +1258,13 @@
       }
     },
     "@basalt/twig-renderer": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@basalt/twig-renderer/-/twig-renderer-0.13.0.tgz",
-      "integrity": "sha512-mEKiwHPTyZvyIcwM6GtA6iG7GBXekEiJ9PnvsfgjGkIDRv/80GiHlMeZmvnAmVJa25db7HbBuh0H6P4Zmmf32g==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@basalt/twig-renderer/-/twig-renderer-0.13.1.tgz",
+      "integrity": "sha512-MM7u2EouQ/NpaMRJyy+v0t4isFYOU65ZGHTKmnz126lhqgUqtBn0D0539dnTAoUq8iwUeQu6LU3HV/4Bz3fBDw==",
       "requires": {
         "@babel/core": "^7.2.0",
         "@babel/preset-env": "^7.2.0",
         "ajv": "^6.5.2",
-        "conf": "^5.0.0",
         "execa": "^1.0.0",
         "fs-extra": "^7.0.1",
         "get-port": "^5.0.0",
@@ -1572,15 +1571,61 @@
       }
     },
     "@pattern-lab/engine-twig-php": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@pattern-lab/engine-twig-php/-/engine-twig-php-5.5.0.tgz",
-      "integrity": "sha512-Izc4ixeTedLhw67MQOTuVlubjDD98aYoaQF2AEBdH6S2uffXh6N/rqa/2mCaLWua3OeBZC9Zq7Udd6usN+1uBg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@pattern-lab/engine-twig-php/-/engine-twig-php-5.7.1.tgz",
+      "integrity": "sha512-xU18SbIiSbk99XPummsTsMCD7sVqTXe0s3CjaZENOWEU3q4XnrOxdF1xC5wBDkUvhNC+2kYIEc0kQ2H4aHMdug==",
       "requires": {
-        "@basalt/twig-renderer": "0.13.0",
-        "@pattern-lab/core": "^5.4.0",
+        "@basalt/twig-renderer": "0.13.1",
+        "@pattern-lab/core": "^5.7.0",
         "fs-extra": "0.30.0"
       },
       "dependencies": {
+        "@pattern-lab/core": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@pattern-lab/core/-/core-5.7.0.tgz",
+          "integrity": "sha512-WMNrpktxOGpiTq2cYlNMNxMicJqAeHxbkI+MOQ0pLHbLpURyJpX5cGLGJSiXhpXY7GOi2RoKfwba7rVG+QFWJA==",
+          "requires": {
+            "@pattern-lab/engine-mustache": "^5.0.0",
+            "@pattern-lab/live-server": "^5.0.0",
+            "chalk": "1.1.3",
+            "chokidar": "1.7.0",
+            "dive": "0.5.0",
+            "fs-extra": "5.0.0",
+            "glob": "7.0.0",
+            "graphlib": "2.1.1",
+            "js-beautify": "1.6.3",
+            "js-yaml": "3.13.1",
+            "lodash": "4.17.15",
+            "markdown-it": "6.0.1",
+            "node-fetch": "1.6.0",
+            "recursive-copy": "2.0.8",
+            "update-notifier": "2.2.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+              "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -1591,7 +1636,42 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+              "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+              "requires": {
+                "graceful-fs": "^4.1.6"
+              }
+            }
           }
+        },
+        "glob": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+          "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
@@ -6709,59 +6789,6 @@
         }
       }
     },
-    "conf": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-5.0.0.tgz",
-      "integrity": "sha512-lRNyt+iRD4plYaOSVTxu1zPWpaH0EOxgFIR1l3mpC/DGZ7XzhoGFMKmbl54LAgXcSu6knqWgOwdINkqm58N85A==",
-      "requires": {
-        "ajv": "^6.10.0",
-        "dot-prop": "^5.0.0",
-        "env-paths": "^2.2.0",
-        "json-schema-typed": "^7.0.0",
-        "make-dir": "^3.0.0",
-        "pkg-up": "^3.0.1",
-        "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "dot-prop": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-          "requires": {
-            "is-obj": "^2.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
-        },
-        "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "write-file-atomic": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
-        }
-      }
-    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -8710,11 +8737,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-    },
-    "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -12942,11 +12964,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-schema-typed": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -16165,14 +16182,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "requires": {
-        "find-up": "^3.0.0"
-      }
-    },
-    "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
       "requires": {
         "find-up": "^3.0.0"
       }
@@ -24815,6 +24824,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }

--- a/web/themes/custom/cloudy/package.json
+++ b/web/themes/custom/cloudy/package.json
@@ -44,7 +44,7 @@
     "@fortawesome/fontawesome-free": "^5.12.0",
     "@pattern-lab/cli": "^5.4.0",
     "@pattern-lab/core": "^5.4.0",
-    "@pattern-lab/engine-twig-php": "^5.5.0",
+    "@pattern-lab/engine-twig-php": "^5.7.1",
     "@pattern-lab/starterkit-twig-demo": "^5.0.0",
     "@pattern-lab/uikit-workshop": "^5.5.0",
     "bootstrap4-chosen": "^1.0.0-alpha.1",


### PR DESCRIPTION
Resolves [POWR-2023](https://portland.atlassian.net/browse/POWR-2023) by updating the dependency on `@pattern-lab/engine-twig-php` and it's dependency on `@basalt/twig-renderer` to [this version](https://github.com/basaltinc/twig-renderer/releases/tag/v0.13.1).

 ### To Test

 ```bash
 lando npm install
 lando npm run build:pl
 ```

 ### Details

 The permission issue error was for the user config directory (i.e. `~/.config/` which is at `/var/www/.config/`) when a sub-package of the Twig Renderer was trying to write a config file in that directory for the package's internal usage (as opposed to user config). It should of had permission to do so since it was ran as the user and that's the user's home directory. I'm not sure exactly why it didn't have the correct permission to do so, but I hypothesize that it resulted from an `npm install` being ran by a dev in Mac OS and then the `npm run build` (via `lando`) was executing in a different operating system, as a different user. That's an understandable scenario so instead of trying to tell devs to always run their commands in the same OS I went to the core package and changed how it kept it's internal config (used just for tracking ports already used) from file-based to memory-based so there's no need to even write files to that directory that     resulted in the permissions issue. (sorry for the run-on sentence) 

Related to #1132 