### PR TITLE
POWR-1707 small set of sane print defaults

### DIFF
--- a/web/themes/custom/cloudy/package.json
+++ b/web/themes/custom/cloudy/package.json
@@ -38,7 +38,6 @@
     "Bootstrap",
     "Drupal"
   ],
-  "author": "@joshuami",
   "license": "MIT",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",

--- a/web/themes/custom/cloudy/src/components/_form.scss
+++ b/web/themes/custom/cloudy/src/components/_form.scss
@@ -25,7 +25,6 @@
 
   // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
   @include border-radius($input-border-radius, 0);
-
   @include box-shadow($input-box-shadow);
   @include transition($input-transition);
 
@@ -34,9 +33,6 @@
     background-color: transparent;
     border: 0;
   }
-
-  // Customize the `:focus` state to imitate native WebKit styles.
-  @include form-control-focus();
 
   // Placeholder
   &::placeholder {

--- a/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
+++ b/web/themes/custom/cloudy/src/components/breadcrumb/breadcrumb.scss
@@ -2,13 +2,14 @@
   font-size: .875rem;
   padding: $cloudy-space-3 0;
   background: none;
-  display: flex;
-  flex-wrap: wrap;
+  display: flex !important;
+  flex-wrap: wrap !important;
   margin-bottom: $cloudy-space-4;
   border-radius: .25rem;
 
   &__list {
     list-style: none;
+    width: 100%;
     margin: 0;
     padding: 0;
   }

--- a/web/themes/custom/cloudy/src/css/_overrides.scss
+++ b/web/themes/custom/cloudy/src/css/_overrides.scss
@@ -248,3 +248,26 @@ drupal-entity {
   clip: auto !important;
   white-space: normal !important;
 }
+
+@media print {
+  .container {
+    width: auto;
+  }
+  .region-global-admin,
+  .region-pre-header,
+  .region-primary-menu,
+  .region-tabs,
+  .block-portland-revision-block,
+  .portland-revision--block {
+    display: none !important;
+  }
+  .block-fixed-block-contentfooter-links {
+    display: none !important;
+  }
+  .block-views-blockback-reference-related-content-block-1 {
+    display: none !important;
+  }
+  #block-feedbacklink {
+    display: none !important;
+  }
+}

--- a/web/themes/custom/cloudy/templates/layout/page.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/page.html.twig
@@ -88,7 +88,7 @@
 ]
 %}
 
-<main id="main-content" role="main" data-swiftype-index="true">
+<main id="main-content" class="d-print-block" role="main" data-swiftype-index="true">
   {% block main_content %}
     <div class="main-content {{ not is_front ? 'container pt-4' }}">
       <div {{ content_wrapper_attribute.addClass(content_wrapper_classes) }}>
@@ -105,7 +105,7 @@
 </main>
 
 {% block footer %}
-  <footer class="site-footer text-dark">
+  <footer class="site-footer text-dark d-print-block">
     <div class="container">
       <div class="row">
         {% if page.footer_first or page.footer_second %}

--- a/web/themes/custom/cloudy/templates/layout/region--pre_content.html.twig
+++ b/web/themes/custom/cloudy/templates/layout/region--pre_content.html.twig
@@ -16,7 +16,7 @@
 #}
 
 {% if content %}
-  <section{{ attributes.addClass('pre-content','container')}}>
+  <section{{ attributes.addClass('pre-content','container','d-print-block')}}>
     {{ content }}
   </section>
 {% endif %}


### PR DESCRIPTION
Updates _overrides.scss to hide the following regions and blocks from print:

.region-global-admin
.region-pre-header
.region-primary-menu
.region-tabs
.block-portland-revision-block
.portland-revision--block
.block-fixed-block-contentfooter-links
.block-views-blockback-reference-related-content-block-1
#block-feedbacklink

Updates the _form.scss to remove a deprecated element that keeps erroring the build.

Adds a width to .breadcrumbs__list so that it displays correctly in Safari and print.

Also removed my name from the packages.json. I don't want to take credit for that monstrosity. 😉 