### PR TITLE
powr-2002 Use Babel to transpile spread & rest operators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,7 +153,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "process-timeout": 0
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"

--- a/web/themes/custom/cloudy/babel.config.js
+++ b/web/themes/custom/cloudy/babel.config.js
@@ -6,5 +6,8 @@ module.exports = {
         "useBuiltIns": false,
       }
     ]
+  ],
+  "plugins": [
+      "@babel/plugin-proposal-object-rest-spread"
   ]
 };

--- a/web/themes/custom/cloudy/templates/content/alert/node--alert--featured.html.twig
+++ b/web/themes/custom/cloudy/templates/content/alert/node--alert--featured.html.twig
@@ -1,4 +1,4 @@
 {% include 'node--alert.html.twig' with {
-  dismissible: false,
+  dismissible: true,
   timestamp: false,
 } %}

--- a/web/themes/custom/cloudy/webpack.config.js
+++ b/web/themes/custom/cloudy/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = (env, argv) => ({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        // exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: babelConfig,


### PR DESCRIPTION
- Adds plugin-proposal-object-rest-spread to Babel config to transpile spread and rest operators.
- Removes Babel exclusion for /node_modules so that it transpiles Bootstrap libraries.