### PR TITLE
POWR-2002 fix(webpack): where node_modules were being excluded from transpile

### DIFF
--- a/web/themes/custom/cloudy/templates/content/alert/node--alert--featured.html.twig
+++ b/web/themes/custom/cloudy/templates/content/alert/node--alert--featured.html.twig
@@ -1,4 +1,4 @@
 {% include 'node--alert.html.twig' with {
-  dismissible: false,
+  dismissible: true,
   timestamp: false,
 } %}

--- a/web/themes/custom/cloudy/webpack.config.js
+++ b/web/themes/custom/cloudy/webpack.config.js
@@ -46,7 +46,6 @@ module.exports = (env, argv) => ({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: babelConfig,


### PR DESCRIPTION
**This PR fixes an issue where webpack was not correctly running assets pulled from node_modules through the babel-loader (where transpiling happens).**

**To test (for local dev):**
1. Pull down MASTER, run a build, open IE and navigate to: http://portlandor.lndo.site/revenue/services/file-and-pay-your-arts-tax
1. Verify —> there are errors and tabs do not work!
1. Now, pull down this branch and run a build
1. Open IE and navigate to: http://portlandor.lndo.site/revenue/services/file-and-pay-your-arts-tax
1. Verify —> NO JS errors and tabs are working! 🎉

**To test (multi-dev):**
1. Open the multi-dev branch URL in IE11
1. Navigate to: http://portlandor.lndo.site/revenue/services/file-and-pay-your-arts-tax
1. Verify —> NO JS errors and tabs are working! 🎉