### PR TITLE
POWR-2168 Some builds fail on drush cim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ build_and_deploy: &build_and_deploy
             echo "Running database updates..."
             terminus drush portlandor.$PANTHEON_ENV -- updb -y
             echo "Importing config..."
-            terminus drush portlandor.$PANTHEON_ENV -vvv -- cim -y
+            terminus drush portlandor.$PANTHEON_ENV -- cim -y
             echo "Running cron..."
             terminus drush portlandor.$PANTHEON_ENV -- core:cron -y
             echo "Rebuilding cache..."
@@ -194,7 +194,7 @@ build_and_deploy: &build_and_deploy
             echo "Running database updates..."
             terminus drush portlandor.$PANTHEON_ENV -- updb -y
             echo "Importing config..."
-            terminus drush portlandor.$PANTHEON_ENV -vvv -- cim -y
+            terminus drush portlandor.$PANTHEON_ENV -- cim -y
             echo "Running cron..."
             terminus drush portlandor.$PANTHEON_ENV -- core:cron -y
             echo "Rebuilding cache..."


### PR DESCRIPTION
Turn off verbose output since it didn't help identify cause of `drush cim` error.