### PR TITLE
POWR-1980 build: optimize WebPack by splitting Scss & Js entry

### DIFF
--- a/web/themes/custom/cloudy/cloudy.libraries.yml
+++ b/web/themes/custom/cloudy/cloudy.libraries.yml
@@ -5,7 +5,7 @@ bootstrap:
 
 global:
   js:
-    dist/cloudy.bundle.js: {}
+    dist/cloudyJs.bundle.js: {}
   css:
     component:
       dist/cloudy.css: {}

--- a/web/themes/custom/cloudy/pattern-lab/_meta/_01-foot.twig
+++ b/web/themes/custom/cloudy/pattern-lab/_meta/_01-foot.twig
@@ -14,7 +14,7 @@
 
 {# START: Theme JS that will get loaded in Drupal as well #}
 <script src="/themes/custom/cloudy/dist/bootstrap.bundle.js"></script>
-<script src="/themes/custom/cloudy/dist/cloudy.bundle.js"></script>
+<script src="/themes/custom/cloudy/dist/cloudyJs.bundle.js"></script>
 {# END: Theme JS #}
 
 {# START: Pattern Lab only JS used for making the docs pages look & work well #}

--- a/web/themes/custom/cloudy/webpack.config.js
+++ b/web/themes/custom/cloudy/webpack.config.js
@@ -7,7 +7,8 @@ const isProd = process.env.NODE_ENV === 'production';
 
 const config = {
   entry: {
-    cloudy: ['./src/cloudy.js', './src/cloudy.scss'],
+    cloudy: './src/cloudy.scss',
+    cloudyJs: './src/cloudy.js',
     'search-field': './src/js/search-field.js',
     bootstrap: './src/js/bootstrap.js',
   },


### PR DESCRIPTION
This splits up the main cloudy entry point so there is separate entry for scss & js – making the watch re-renders much quicker!