### PR TITLE
[Don't Merge Yet] POWR-2288 — REFACTOR: header (part 1 of 2) 

### DIFF
--- a/web/sites/default/config/block.block.searchapipagesearchblockform.yml
+++ b/web/sites/default/config/block.block.searchapipagesearchblockform.yml
@@ -24,6 +24,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "<front>\r\n/search\r\n/search/*\r\n/404"
+    pages: "/search\r\n/search/*\r\n/404"
     negate: true
     context_mapping: {  }

--- a/web/sites/default/config/views.view.alerts.yml
+++ b/web/sites/default/config/views.view.alerts.yml
@@ -676,6 +676,7 @@ display:
       css_class: always-show
       defaults:
         css_class: false
+      enabled: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/themes/custom/cloudy/cloudy.theme
+++ b/web/themes/custom/cloudy/cloudy.theme
@@ -94,7 +94,7 @@ function cloudy_preprocess_form(&$vars) {
   // add role="search" to site search form
   if ($vars['element']['#form_id'] == 'search_api_page_block_form') {
     $vars['attributes']['role'] = 'search';
-    $vars['attributes']['class'] = 'input-group form-inline d-flex justify-content-center';
+    $vars['attributes']['class'] = 'input-group form-inline d-flex justify-content-center form-inline--search-block';
     $vars['attributes']['title'] = 'Search';
   }
 }
@@ -108,6 +108,7 @@ function cloudy_preprocess_input__textfield(&$vars) {
     // The search input at top-right corner
     else if( $vars["attributes"]['id'] === 'edit-keys--2' || $vars["attributes"]['id'] === 'edit-keys--3' ) {
         $vars["attributes"]['type'] = 'search';
+        $vars["attributes"]['placeholder'] = 'Search';
         $vars["attributes"]['size'] = '21';
     }
 }

--- a/web/themes/custom/cloudy/cloudy.theme
+++ b/web/themes/custom/cloudy/cloudy.theme
@@ -106,7 +106,7 @@ function cloudy_preprocess_input__textfield(&$vars) {
         $vars["attributes"]['class'] = ['form-search', 'form-autocomplete'];
     }
     // The search input at top-right corner
-    else if($vars["attributes"]['id'] === 'edit-keys--2') {
+    else if( $vars["attributes"]['id'] === 'edit-keys--2' || $vars["attributes"]['id'] === 'edit-keys--3' ) {
         $vars["attributes"]['type'] = 'search';
         $vars["attributes"]['size'] = '21';
     }
@@ -135,7 +135,7 @@ function cloudy_theme_suggestions_field_alter(array &$suggestions, array $variab
 
 /**
  * Implements template_preprocess_time()
- * 
+ *
  * Prepares variables for time templates.
  *
  * Default template: time.html.twig.
@@ -148,7 +148,7 @@ function cloudy_theme_suggestions_field_alter(array &$suggestions, array $variab
  */
 function cloudy_preprocess_time(&$variables) {
   $date_formatter = \Drupal::service('date.formatter');
-  
+
   // If timestamp is just a date (i.e. no time component), format datetime attribute as a date
   if (preg_match('/\d+, \d{4}$/', $variables['text'])) {
     $timestamp = strtotime($variables['text']);

--- a/web/themes/custom/cloudy/src/components/_header.scss
+++ b/web/themes/custom/cloudy/src/components/_header.scss
@@ -55,7 +55,7 @@
           $cloudy-color-blue-500,
           $cloudy-color-blue-500
       );
-      padding: 0.875rem 0;
+      padding: $cloudy-space-2 0;
     }
   }
 }

--- a/web/themes/custom/cloudy/src/components/_header.scss
+++ b/web/themes/custom/cloudy/src/components/_header.scss
@@ -41,17 +41,22 @@
     border-radius: 0;
     padding: $cloudy-space-6;
     line-height: $cloudy-space-6;
-    color: $cloudy-color-neutral-900;
+    color: $cloudy-color-blue-500;
   }
-  .navbar-nav .nav-link {
-    color: $cloudy-color-neutral-900;
-    @include links(
-      $cloudy-color-neutral-900,
-      $cloudy-color-neutral-900,
-      $cloudy-color-neutral-900,
-      $cloudy-color-neutral-900
-    );
-    padding: 0.875rem 0;
+  .navbar-nav {
+    .nav-item {
+      font-weight: 600;
+    }
+    .nav-link {
+      color: $cloudy-color-blue-500;
+      @include links(
+          $cloudy-color-blue-500,
+          $cloudy-color-blue-500,
+          $cloudy-color-blue-500,
+          $cloudy-color-blue-500
+      );
+      padding: 0.875rem 0;
+    }
   }
 }
 
@@ -64,7 +69,7 @@
         background: $cloudy-color-neutral-100;
       }
       &.active {
-        background-color: $cloudy-color-neutral-100;
+        color: $cloudy-color-blue-800;
       }
     }
   }

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -123,7 +123,7 @@ h1.homepage-title {
   .search-api-page-block-form {
     .input-group {
       align-items: stretch;
-      margin-bottom: $cloudy-space-4;
+      margin: $cloudy-space-2 0 $cloudy-space-4 0;
       @include media-breakpoint-up(xl) {
         margin: 0 0 0 $cloudy-space-3;
       }

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -123,6 +123,7 @@ h1.homepage-title {
   .search-api-page-block-form {
     .input-group {
       align-items: stretch;
+      margin-bottom: $cloudy-space-4;
       @include media-breakpoint-up(xl) {
         margin: 0 0 0 $cloudy-space-3;
       }

--- a/web/themes/custom/cloudy/src/components/_search.scss
+++ b/web/themes/custom/cloudy/src/components/_search.scss
@@ -123,14 +123,14 @@ h1.homepage-title {
   .search-api-page-block-form {
     .input-group {
       align-items: stretch;
-      background-color: $cloudy-color-neutral-100;
-      margin: 0 0 0 $cloudy-space-3;
+      @include media-breakpoint-up(xl) {
+        margin: 0 0 0 $cloudy-space-3;
+      }
     }
     .form-search,
     .form-autocomplete {
       margin: 0;
       min-width: 15rem;
-      background-color: $cloudy-color-neutral-100;
       font-size: 1rem;
       color: $cloudy-color-neutral-900;
       height: auto;
@@ -140,6 +140,30 @@ h1.homepage-title {
     .form-autocomplete {
       @extend .form-control;
     }
+    .form-inline--search-block {
+      border: 2px solid #000;
+      border-radius: 6px;
+      .form-actions {
+        border-top-left-radius: 6px;
+        border-bottom-left-radius: 6px;
+        order: 1;
+        overflow: hidden;
+      }
+      .js-form-type-search-api-autocomplete {
+        border-top-right-radius: 6px;
+        border-bottom-right-radius: 6px;
+        order: 2;
+        overflow: hidden;
+        input.form-autocomplete {
+          padding-left: 0;
+          font-weight: 600;
+        }
+      }
+      .form-submit {
+        background: $cloudy-color-neutral-0;
+        border: none;
+      }
+    }
     .form-item {
       ::placeholder {
         /* Chrome, Firefox, Opera, Safari 10.1+ */
@@ -147,21 +171,21 @@ h1.homepage-title {
         opacity: 1; /* Firefox */
       }
       input:focus::placeholder {
-        color: $cloudy-color-neutral-0;
+        color: transparent;
       }
       :-ms-input-placeholder {
         /* Internet Explorer 10-11 */
         color: $cloudy-color-neutral-900;
       }
       input:focus:-ms-input-placeholder {
-        color: $cloudy-color-neutral-0;
+        color: transparent;
       }
       ::-ms-input-placeholder {
         /* Microsoft Edge */
         color: $cloudy-color-neutral-900;
       }
       input:focus::-ms-input-placeholder {
-        color: $cloudy-color-neutral-0;
+        color: transparent;
       }
     }
   }


### PR DESCRIPTION
**This PR adds the following to the global header/navbar:**
- The Search block to the homepage with new simplified styling
- Adjusts the link color and font weight for normal and active links
- Cleans up the mobile menu item spacing
- Cleans up the mobile presentation of the search input
- Removes the /alerts page (by disabling the page view)

**To test:**
1. Navigate to https://powr-2288-portlandor.pantheonsite.io/
1. Verify you see the new styling/presentation of the global header/navbar outlined above
1. Shrink your browser and verify the mobile spacing between menu items and around the search input is improved
1. Attempt to navigate to https://powr-2288-portlandor.pantheonsite.io/alerts —> verify the page is gone
