### PR TITLE
POWR-2137: FIX Firefox not properly handling flexbox items on print

### DIFF
--- a/web/themes/custom/cloudy/src/cloudy.scss
+++ b/web/themes/custom/cloudy/src/cloudy.scss
@@ -79,3 +79,8 @@
 // ** Utilities/Misc
 // --------------
 @import 'css/overrides';
+
+// --------------
+// ** Print
+// --------------
+@import 'css/print';

--- a/web/themes/custom/cloudy/src/css/_print.scss
+++ b/web/themes/custom/cloudy/src/css/_print.scss
@@ -1,0 +1,15 @@
+/*
+** Print-Specific Styles
+*/
+
+@media print {
+
+  // Targets all FireFox browsers
+  @-moz-document url-prefix() {
+    // This fixes an issue where Firefox incorrectly handles the printing of flex wrapper elements
+    .row {
+      display: block;
+    }
+  }
+
+}


### PR DESCRIPTION
**This PR provides a fix for the way that Firefox incorrectly handles the printing of flexbox wrappers.**

**To Test:**
1. **In Chrome —>** Navigate to https://powr-2137-portlandor.pantheonsite.io/bps/fix-it-fairs/events/2020/2/29/fix-it-fair-floyd-light-middle-school
2. Print preview the page to get an idea of how the general print layout should look and feel
3. **In Firefox —>** Navigate to https://powr-2137-portlandor.pantheonsite.io/bps/fix-it-fairs/events/2020/2/29/fix-it-fair-floyd-light-middle-school
1. Print preview the page —> verify the result is nearly the same as Chrome (no huge white space gaps breaking up pages)