### PR TITLE
POWR-1881: Homepage IE flexbox issues

### DIFF
--- a/web/themes/custom/cloudy/src/css/_pages.scss
+++ b/web/themes/custom/cloudy/src/css/_pages.scss
@@ -56,3 +56,8 @@ h1.homepage-title {
     margin-top: 0;
   }
 }
+
+// IE Fix: Direct child of flex container doesn't go full width by default
+.views-element-container .row.view > .view-content {
+  width: 100%;
+}


### PR DESCRIPTION
**This PR adds a fix where IE incorrectly handles single direct children of flexbox wrappers that would, in normal conditions, expand to full width.**

Was a bit tricky to track down! :-)

**To test:**
1. Visit https://powr-1881-portlandor.pantheonsite.io/ in IE
2. Visit the same site on Chrome —> Verify the homepage 3-column section is the same