### PR TITLE
POWR-2430: Last element in drawer does not trigger on mobile

### DIFF
--- a/web/themes/custom/cloudy/src/components/_form.scss
+++ b/web/themes/custom/cloudy/src/components/_form.scss
@@ -525,9 +525,7 @@ div.compact > div {
 // Facets
 .facets-widget {
   &-checkbox {
-    // Added more space to bottom padding to address iphone issue
-    // Needs is margin or padding on the bottom of the drawer instead
-    padding: $cloudy-space-4 $cloudy-space-4 $cloudy-space-8 $cloudy-space-4;
+    padding: $cloudy-space-4;
     background: $cloudy-color-neutral-100;
     ul {
       list-style: none;

--- a/web/themes/custom/cloudy/src/layouts/drawer/drawer.scss
+++ b/web/themes/custom/cloudy/src/layouts/drawer/drawer.scss
@@ -4,8 +4,12 @@ $tray-transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out, right 0.
 $overlay-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out, background 0.3s ease-in-out;
 
 .drawer {
+  // START styles required for iOS mobile browser NOT to overlay bottom content below floating system navbar
+  height: 100%;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  // END styles required for iOS mobile browsers
   background: $cloudy-color-neutral-0;
-  height: 100vh;
   opacity: 0;
   position: fixed;
   top: 0;
@@ -15,18 +19,18 @@ $overlay-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out, back
   h2 {
     @include type-style($cloudy-heading-3);
   }
-  
+
   @include transition($tray-transition);
-  
+
   &--position-left {
     left: -100vw;
     order: -1;
   }
-  
+
   &--position-right {
     right: -100vw;
   }
-  
+
   &.is-active {
     opacity: 1;
     z-index: 600;


### PR DESCRIPTION
This PR fixes an issue where on iOS Safari — the native browser adds a bottom floating navbar which, if not handled properly, hides content below.

**Testing/UAT:**
1. On iPhone sim OR a native iPhone, navigate to —> https://powr-2430-portlandor.pantheonsite.io/news
1. Toggle the filter
1. Scroll down to the very last item in the filter
1. Click the "Show more" toggle —> Verify —> user is able to toggle more/less items