### PR TITLE
POWR-2436 - Notice related to portland_file_replace on add new media

### DIFF
--- a/web/modules/custom/portland/modules/portland_file_replace/portland_file_replace.module
+++ b/web/modules/custom/portland/modules/portland_file_replace/portland_file_replace.module
@@ -45,8 +45,8 @@ function portland_file_replace_form_media_form_alter(&$form, FormStateInterface 
   $media = $form_state->getFormObject()->getEntity();
   
   // only modify the form if the file field already has a value, and only for media types with file source
-  $default_value = $form['field_document']['widget'][0]['#default_value'];
-  if (array_key_exists("target_id", $default_value)) {
+  $default_value = array_key_exists("field_document", $form) ?? $form['field_document']['widget'][0]['#default_value'];
+  if ($default_value && array_key_exists("target_id", $default_value)) {
     $mediaType = \Drupal::entityTypeManager()->getStorage('media_type')->load($media->bundle());
     if (!$mediaType->getSource() instanceof File) {
       return;

--- a/web/sites/default/config/field.field.media.chart.field_display_groups.yml
+++ b/web/sites/default/config/field.field.media.chart.field_display_groups.yml
@@ -22,7 +22,7 @@ entity_type: media
 bundle: chart
 label: 'Displayed in'
 description: 'Add all groups in which this media should appear. The first group in the list will be added automatically as the "owner" of the media.'
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Added a null ref check to fix the error, and also discovered that field_display_groups is not required on Chart media type. Not populating this field would cause a media item to be inaccessible to a group editor.