### PR TITLE
POWR-2260 fix: site logo and footer seal alt text

### DIFF
--- a/web/sites/default/config/block.block.cloudy_copyrightblock.yml
+++ b/web/sites/default/config/block.block.cloudy_copyrightblock.yml
@@ -20,6 +20,6 @@ settings:
   start_year: '2018'
   seperator: '-'
   text:
-    value: "<h2 class=\"h6\">City of Portland, Oregon</h2>\r\n<p><img alt=\"City of Portland, Oregon. 1851\" src=\"/themes/custom/cloudy/images/city-seal.png\" /></p>\r\n<p>© Copyright [copyright_statement:dates]</p>"
+    value: "<h2 class=\"h6\">City of Portland, Oregon</h2>\r\n\r\n<p><img alt=\"Portland City Seal\" src=\"/themes/custom/cloudy/images/city-seal.png\" /></p>\r\n\r\n<p>© Copyright [copyright_statement:dates]</p>\r\n"
     format: full_html
 visibility: {  }

--- a/web/themes/custom/cloudy/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/cloudy/templates/block/block--system-branding-block.html.twig
@@ -14,7 +14,7 @@
 {% if site_logo or site_name %}
   <a href="{{ path('<front>') }}" aria-label="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" title="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" rel="home" class="navbar-brand d-flex align-items-center">
     {% if site_logo %}
-      <img src="{{ site_logo }}" alt="{{ "Image of the official City of Portland seal. The image depicts Portlandia holding her trident backdropped by mountain and river, accompanied by the text 'City of Portland, Oregon 1851'"|t }}" class="cloudy-logo img-fluid" />
+      <img src="{{ site_logo }}" alt="{{ "Official City of Portland seal. The image depicts Portlandia holding her trident backdropped by mountain and river, accompanied by the text 'City of Portland, Oregon 1851'"|t }}" class="cloudy-logo img-fluid" />
     {% endif %}
     {{ site_name }}
   </a>

--- a/web/themes/custom/cloudy/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/cloudy/templates/block/block--system-branding-block.html.twig
@@ -12,7 +12,7 @@
  */
 #}
 {% if site_logo or site_name %}
-  <a href="{{ path('<front>') }}" alt="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" title="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" rel="home" class="navbar-brand d-flex align-items-center">
+  <a href="{{ path('<front>') }}" aria-label="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" title="{{ 'Go to the official City of Portland, Oregon website homepage.'|t }}" rel="home" class="navbar-brand d-flex align-items-center">
     {% if site_logo %}
       <img src="{{ site_logo }}" alt="{{ "Image of the official City of Portland seal. The image depicts Portlandia holding her trident backdropped by mountain and river, accompanied by the text 'City of Portland, Oregon 1851'"|t }}" class="cloudy-logo img-fluid" />
     {% endif %}


### PR DESCRIPTION
This fixes the redundant alt text in the site logo and updates the footer city seal alt text.

![logo-alt-text](https://user-images.githubusercontent.com/30271981/85635119-fc411d80-b631-11ea-859d-3b7ee4b0842c.png)

**Test**
1. Visit [https://powr-2260-portlandor.pantheonsite.io/](https://powr-2260-portlandor.pantheonsite.io/)
2. Verify that site logo alt text is no longer reading "Image Image"
3. Verify footer city seal alt text has been updated to "Portland City Seal"