### PR TITLE
POWR-2490 fix: Remove drawer scrollbar on desktop

### DIFF
--- a/web/themes/custom/cloudy/src/layouts/drawer/drawer.scss
+++ b/web/themes/custom/cloudy/src/layouts/drawer/drawer.scss
@@ -1,14 +1,10 @@
-$tray-transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out, right 0.3s ease-in-out, left 0.3s ease-in-out,
-  width 0.3s ease-in-out;
+$tray-transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out,
+  right 0.3s ease-in-out, left 0.3s ease-in-out, width 0.3s ease-in-out;
 
-$overlay-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out, background 0.3s ease-in-out;
+$overlay-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out,
+  background 0.3s ease-in-out;
 
 .drawer {
-  // START styles required for iOS mobile browser NOT to overlay bottom content below floating system navbar
-  height: 100%;
-  overflow-y: scroll;
-  -webkit-overflow-scrolling: touch;
-  // END styles required for iOS mobile browsers
   background: $cloudy-color-neutral-0;
   opacity: 0;
   position: fixed;
@@ -35,7 +31,9 @@ $overlay-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out, back
     opacity: 1;
     z-index: 600;
     width: 100vw;
-    overflow: scroll;
+    height: 100%;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
 
     &.drawer--position-left {
       left: 0;


### PR DESCRIPTION
This pr removes the drawer scrollbar on desktop while preserving the padding accounting for iOS Browser UI.

**Test**
1. Visit [https://powr-2490-portlandor.pantheonsite.io/](https://powr-2490-portlandor.pantheonsite.io/)
2. Verify iOS Browser UI does not overlap the facets on mobile.
3. Verify scrollbar no longer appears on desktop.
