### PR TITLE
POWR-2589 uninstall bootstrap_datepicker

### DIFF
--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -11,7 +11,6 @@ module:
   block: 0
   block_content: 0
   block_exclude_pages: 0
-  bootstrap_datepicker: 0
   breakpoint: 0
   chosen: 0
   chosen_field: 0


### PR DESCRIPTION
This story will be in 2 branches. This first branch uninstalls the module and is used for thoroughly testing the replacement datepicker. The widget was switched to the built-in HTML5 option in an earlier story that has already been merged, but it merits a full run through QA before completely ripping out the bootstrap datepicker.

The 2nd branch is POWR-2589-2 with a separate PR.