### PR TITLE
POWR-2746 media/document permalinks proof of concept work

### DIFF
--- a/web/modules/custom/portland/portland.tokens.inc
+++ b/web/modules/custom/portland/portland.tokens.inc
@@ -51,6 +51,11 @@ function portland_token_info()
     'description' => 'A token to display standardized page titles for Portland.gov',
   ];
 
+  $info['tokens']['portland']['group-shortname'] = [
+    'name' => t('Portland group'),
+    'description' => 'A token to display the group shortname or acronym',
+  ];
+
   return $info;
 }
 
@@ -124,6 +129,29 @@ function portland_tokens($type, $tokens, array $data = array(), array $options =
               }
               $new_title = portland_generate_extended_title_for_group_views($title, $route_match);
               $replacements[$original] = $new_title;
+            }
+          }
+          break;
+        case 'group-shortname':
+          // get group shortname
+          $route_match = \Drupal::routeMatch();
+          // Entity will be found in the route parameters.
+          if (($route = $route_match->getRouteObject()) && ($parameters = $route->getOption('parameters'))) {
+            // Determine if the current route represents an entity.
+            foreach ($parameters as $name => $options) {
+              if ($name == 'group') {
+                if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
+                  $entity = $route_match->getParameter($name);
+                  if ($entity) {
+                    $field = $entity->get('field_shortname_or_acronym');
+                    if ($field) {
+                      $value = $field->value;
+                      $replacements[$original] = $value;
+                      break;
+                    }
+                  }
+                }
+              }
             }
           }
           break;

--- a/web/modules/custom/portland/portland.tokens.inc
+++ b/web/modules/custom/portland/portland.tokens.inc
@@ -51,9 +51,9 @@ function portland_token_info()
     'description' => 'A token to display standardized page titles for Portland.gov',
   ];
 
-  $info['tokens']['portland']['group-shortname'] = [
+  $info['tokens']['portland']['group-path'] = [
     'name' => t('Portland group'),
-    'description' => 'A token to display the group shortname or acronym',
+    'description' => 'A token to display the group path',
   ];
 
   return $info;
@@ -132,7 +132,7 @@ function portland_tokens($type, $tokens, array $data = array(), array $options =
             }
           }
           break;
-        case 'group-shortname':
+        case 'group-path':
           // get group shortname
           $route_match = \Drupal::routeMatch();
           // Entity will be found in the route parameters.
@@ -143,7 +143,7 @@ function portland_tokens($type, $tokens, array $data = array(), array $options =
                 if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
                   $entity = $route_match->getParameter($name);
                   if ($entity) {
-                    $field = $entity->get('field_shortname_or_acronym');
+                    $field = $entity->get('field_group_path');
                     if ($field) {
                       $value = $field->value;
                       $replacements[$original] = $value;

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -18,7 +18,6 @@ module:
   chosen_lib: 0
   ckeditor: 0
   ckeditor_config: 0
-  clamav: 0
   cleave: 0
   color: 0
   components: 0

--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -18,6 +18,7 @@ module:
   chosen_lib: 0
   ckeditor: 0
   ckeditor_config: 0
+  clamav: 0
   cleave: 0
   color: 0
   components: 0
@@ -160,6 +161,7 @@ module:
   responsive_image: 0
   rest: 0
   rh_group: 0
+  rh_media: 0
   rh_node: 0
   rules: 0
   schemata: 0

--- a/web/sites/default/config/field.field.media.chart.image.yml
+++ b/web/sites/default/config/field.field.media.chart.image.yml
@@ -23,7 +23,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-shortname]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.chart.image.yml
+++ b/web/sites/default/config/field.field.media.chart.image.yml
@@ -23,7 +23,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]'
+  file_directory: '[portland:group-path]/img'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.document.field_document.yml
+++ b/web/sites/default/config/field.field.media.document.field_document.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]'
+  file_directory: '[portland:group-path]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.document.field_document.yml
+++ b/web/sites/default/config/field.field.media.document.field_document.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-shortname]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.image.image.yml
+++ b/web/sites/default/config/field.field.media.image.image.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]/img'
+  file_directory: '[portland:group-path]/img'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.image.image.yml
+++ b/web/sites/default/config/field.field.media.image.image.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]'
+  file_directory: '[portland:group-shortname]/img'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.image.image.yml
+++ b/web/sites/default/config/field.field.media.image.image.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-shortname]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.map.field_geo_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_geo_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]'
+  file_directory: '[portland:group-path]'
   file_extensions: 'json geojson zip'
   max_filesize: '20 MB'
   description_field: false

--- a/web/sites/default/config/field.field.media.map.field_geo_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_geo_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-shortname]'
   file_extensions: 'json geojson zip'
   max_filesize: '20 MB'
   description_field: false

--- a/web/sites/default/config/field.field.media.map.field_map_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_map_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-shortname]'
+  file_directory: '[portland:group-path]'
   file_extensions: 'pdf png jpg jpeg gif'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.map.field_map_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_map_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-shortname]'
   file_extensions: 'pdf png jpg jpeg gif'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.map.image.yml
+++ b/web/sites/default/config/field.field.media.map.image.yml
@@ -23,7 +23,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: '[portland:group-path]/img'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.node.change_set.field_change_documents.yml
+++ b/web/sites/default/config/field.field.node.change_set.field_change_documents.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: 'change-sets/[date:custom:Y]/[date:custom:m]'
+  file_directory: 'change-sets/[date:custom:Y]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: true

--- a/web/sites/default/config/field.field.node.council_document.field_documents_and_exhibits.yml
+++ b/web/sites/default/config/field.field.node.council_document.field_documents_and_exhibits.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: 'council-documents/[date:custom:Y]/[date:custom:m]'
+  file_directory: 'council-documents/[date:custom:Y]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: true

--- a/web/sites/default/config/field.field.node.council_document.field_file_impact_statement.yml
+++ b/web/sites/default/config/field.field.node.council_document.field_file_impact_statement.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: 'council-documents/[date:custom:Y]/[date:custom:m]'
+  file_directory: 'council-documents/[date:custom:Y]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/lightning_core.versions.yml
+++ b/web/sites/default/config/lightning_core.versions.yml
@@ -209,6 +209,7 @@ remove_http_headers: 1.0.0-alpha3
 responsive_image: 0.0.0
 rest: 8.6.2
 rh_group: 1.0.0-beta6
+rh_media: 1.0.0-beta6
 rh_node: 1.0.0-beta4
 rules: 0.0.0
 schemata: 0.0.0

--- a/web/sites/default/config/rabbit_hole.behavior_settings.media_type_document.yml
+++ b/web/sites/default/config/rabbit_hole.behavior_settings.media_type_document.yml
@@ -1,0 +1,11 @@
+uuid: 1ba8856f-fe58-4231-ba80-497147ff0dba
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.document
+id: media_type_document
+action: page_redirect
+allow_override: 1
+redirect: '[media:field_document:entity:url]'
+redirect_code: 301

--- a/web/sites/default/config/user.role.authenticated.yml
+++ b/web/sites/default/config/user.role.authenticated.yml
@@ -41,6 +41,7 @@ permissions:
   - 'delete own location content'
   - 'edit own location content'
   - 'rabbit hole bypass group'
+  - 'rabbit hole bypass media'
   - 'rabbit hole bypass node'
   - 'revert city_service revisions'
   - 'revert construction_project revisions'


### PR DESCRIPTION
**This work is being done in branch POWR-2368-1 and the associated multidev environment.**

This branch/PR does the following:

* Creates a group-path token that is used to create group-based files subdirectories
  * _Works with multi-segment group path values such as "omf/toc"_
* Updates file fields in media and content entities to save files in group-based subdirectories
* Updates image fields in media and content entities to save files in subdirectory "[group-path]/img"
* Enables the Rabbit Hole Media (rh_media) submodule
* Configures Rabbit Hole for documents to use the media entity default path as the permalink for the file, for anonymous users only