### PR TITLE
POWR-2839 Removed group-path custom token

### DIFF
--- a/web/modules/custom/portland/portland.tokens.inc
+++ b/web/modules/custom/portland/portland.tokens.inc
@@ -51,11 +51,6 @@ function portland_token_info()
     'description' => 'A token to display standardized page titles for Portland.gov',
   ];
 
-  $info['tokens']['portland']['group-path'] = [
-    'name' => t('Portland group'),
-    'description' => 'A token to display the group path',
-  ];
-
   return $info;
 }
 
@@ -132,7 +127,6 @@ function portland_tokens($type, $tokens, array $data = array(), array $options =
             }
           }
           break;
-        case 'group-path':
           // get group shortname
           $route_match = \Drupal::routeMatch();
           // Entity will be found in the route parameters.

--- a/web/modules/custom/portland/portland.tokens.inc
+++ b/web/modules/custom/portland/portland.tokens.inc
@@ -127,28 +127,6 @@ function portland_tokens($type, $tokens, array $data = array(), array $options =
             }
           }
           break;
-          // get group shortname
-          $route_match = \Drupal::routeMatch();
-          // Entity will be found in the route parameters.
-          if (($route = $route_match->getRouteObject()) && ($parameters = $route->getOption('parameters'))) {
-            // Determine if the current route represents an entity.
-            foreach ($parameters as $name => $options) {
-              if ($name == 'group') {
-                if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
-                  $entity = $route_match->getParameter($name);
-                  if ($entity) {
-                    $field = $entity->get('field_group_path');
-                    if ($field) {
-                      $value = $field->value;
-                      $replacements[$original] = $value;
-                      break;
-                    }
-                  }
-                }
-              }
-            }
-          }
-          break;
       }
     }
   }

--- a/web/sites/default/config/field.field.media.chart.image.yml
+++ b/web/sites/default/config/field.field.media.chart.image.yml
@@ -23,7 +23,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]/img'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.document.field_document.yml
+++ b/web/sites/default/config/field.field.media.document.field_document.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'txt pdf doc docx xls xlsx ppt pptx'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.image.image.yml
+++ b/web/sites/default/config/field.field.media.image.image.yml
@@ -25,7 +25,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]/img'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''

--- a/web/sites/default/config/field.field.media.map.field_geo_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_geo_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'json geojson zip'
   max_filesize: '20 MB'
   description_field: false

--- a/web/sites/default/config/field.field.media.map.field_map_file.yml
+++ b/web/sites/default/config/field.field.media.map.field_map_file.yml
@@ -23,7 +23,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'pdf png jpg jpeg gif'
   max_filesize: ''
   description_field: false

--- a/web/sites/default/config/field.field.media.map.image.yml
+++ b/web/sites/default/config/field.field.media.map.image.yml
@@ -23,7 +23,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[portland:group-path]/img'
+  file_directory: '[date:custom:Y]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''


### PR DESCRIPTION
Media entity file uploads now all use a year subdirectory. Custom group-path token was removed.