### PR TITLE
POWR-2853 Revert faux-permalink functionality for documents

### DIFF
--- a/web/sites/default/config/core.extension.yml
+++ b/web/sites/default/config/core.extension.yml
@@ -159,7 +159,6 @@ module:
   responsive_image: 0
   rest: 0
   rh_group: 0
-  rh_media: 0
   rh_node: 0
   rules: 0
   schemata: 0

--- a/web/sites/default/config/rabbit_hole.behavior_settings.media_type_document.yml
+++ b/web/sites/default/config/rabbit_hole.behavior_settings.media_type_document.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - media.type.document
 id: media_type_document
-action: page_redirect
+action: display_page
 allow_override: 1
 redirect: '[media:field_document:entity:url]'
 redirect_code: 301

--- a/web/themes/custom/cloudy/templates/field/field--media--field-document.html.twig
+++ b/web/themes/custom/cloudy/templates/field/field--media--field-document.html.twig
@@ -1,18 +1,12 @@
 {% extends 'field.html.twig' %}
 {% block content %}
-  {%- for item in items -%}
-    <div{{ item.attributes.addClass(item_classes) }}>
-      {% if ('administrator' in user.getroles()) and (element['#view_mode'] == 'full') %}
-        {% set url = file_url(item.content['#file'].uri.value) %}
-      {% else %}
-        {% set url = path('entity.media.canonical', {'media': element['#object'].mid.value }) %}
-      {% endif %}
-      {% include 'file-link.html.twig' with {
-        url: url,
+	{%- for item in items -%}
+		<div{{item.attributes.addClass(item_classes)}}>
+			{% include 'file-link.html.twig' with {
         file: item.content['#file'],
         file_display_name: element['#object'].name.value,
         mime_type: element['#object'].field_mime_type.value,
       } %}
-    </div>
-  {%- endfor -%}
+		</div>
+	{%- endfor -%}
 {% endblock %}

--- a/web/themes/custom/cloudy/templates/field/file-link.html.twig
+++ b/web/themes/custom/cloudy/templates/field/file-link.html.twig
@@ -11,9 +11,7 @@
  * @see template_preprocess_file_link()
  */
 #}
-
-{# if url wasn't provided by field--media--field-document.html.twig parent template, then use the file url #}
-{% set url = url ? url : file_url(file.uri.value) %}
+{% set url = file_url(file.uri.value) %}
 
 {% set text = file_display_name|default(link['#title'])|default(file.filename.value) %}
 
@@ -21,56 +19,43 @@
   'application/pdf': {
     icon: 'fa-file-pdf',
     desc: 'Download PDF file',
-    ext: 'PDF',
   },
   'application/msword': {
     icon: 'fa-file-word',
     desc: 'Download Word file',
-    ext: 'DOC',
   },
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
     icon: 'fa-file-word',
     desc: 'Download Word file',
-    ext: 'DOCX',
   },
   'application/vnd.ms-excel': {
     icon: 'fa-file-excel',
     desc: 'Download Excel file',
-    ext: 'XLS',
   },
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
     icon: 'fa-file-excel',
     desc: 'Download Excel file',
-    ext: 'XLSX',
   },
   'application/vnd.ms-powerpoint': {
     icon: 'fa-file-powerpoint',
     desc: 'Download PowerPoint',
-    ext: 'PPT',
   },
   'application/vnd.openxmlformats-officedocument.presentationml.presentation': {
     icon: 'fa-file-powerpoint',
     desc: 'Download PowerPoint file',
-    ext: 'PPTX',
-  },
-  'text/plain': {
-    icon: 'fa-file-alt',
-    desc: 'Download text file',
-    ext: 'TXT',
   },
 } %}
 
 {% set icon_name = icon_map[mime_type].icon ?? 'fa-file-alt' %}
 {% set file_desc = icon_map[mime_type].desc ?? 'Download file' %}
-{% set file_ext = icon_map[mime_type].ext ?? '' %}
 
 <div class="inline-flex">
-  <a href="{{ url }}" {% if url != file_url(file.uri.value) %}class="document--download" data-file-ext="{{ file_ext }}"{% endif %}>
-    <span class="sr-only">{{ file_desc }}</span>
-    {% include '@elements/icon/fa.twig' with {
+	<a href="{{ url }}">
+		<span class="sr-only">{{ file_desc }}</span>
+		{% include '@elements/icon/fa.twig' with {
       name: icon_name,
     } only %}
-    {{ text }}
-  </a>
-  <span class="ml-2 text-nowrap">{{ file_size_string(file.filesize.value) }}</span>
+		{{ text }}
+	</a>
+	<span class="ml-2 text-nowrap">{{ file_size_string(file.filesize.value) }}</span>
 </div>


### PR DESCRIPTION
* Remove Rabbit Hole settings on media document
* Uninstall Rabbit Hole media submodule (files are part of parent RH module and do not need to be removed in a follow-up deploy)
* Revert changes to 2 template files