### PR TITLE
POWR-2860 link field validation

### DIFF
--- a/web/sites/default/config/field.field.node.council_document.field_efiles_link.yml
+++ b/web/sites/default/config/field.field.node.council_document.field_efiles_link.yml
@@ -23,6 +23,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
+  link_type: 16
   title: 2
 field_type: link

--- a/web/sites/default/config/field.field.node.event.field_web_conference_link.yml
+++ b/web/sites/default/config/field.field.node.event.field_web_conference_link.yml
@@ -23,6 +23,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
+  link_type: 16
   title: 1
 field_type: link


### PR DESCRIPTION
Set link fields for Efiles and webinars to accept external links only, in hopes this may cut down on validation issues for editors.