### PR TITLE
POWR-3380 fix dashboard_user missing context error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -253,6 +253,9 @@
             },
             "drupal/bulk_user_registration": {
                 "POWR-3262 Bulk update existing users": "patches/powr-3262-bulk-update_existing_users.patch"
+            },
+            "drupal/page_manager": {
+                "'Required contexts without a value: node' when editing menu": "https://www.drupal.org/files/issues/page_manager.page_access_wsod_fix.patch"
             }
         },
         "merge-plugin": {


### PR DESCRIPTION
Used a patch to resolve error. I was unable to figure out why Sitewide Editor role had the problem but none other, and was unable to really understand the issue, but the patch fixes it.

Patch: https://www.drupal.org/files/issues/page_manager.page_access_wsod_fix.patch
Issue page: https://www.drupal.org/project/page_manager/issues/2837833