### PR TITLE
POWR-3467 Add reference to Charter Commission on City Charter page

### DIFF
--- a/web/sites/default/config/views.view.city_charter.yml
+++ b/web/sites/default/config/views.view.city_charter.yml
@@ -567,20 +567,7 @@ display:
         query: false
         empty: false
         header: false
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>The City Charter list is under construction. As the charter is migrated from <a href="https://www.portlandoregon.gov/citycode/28148">PortlandOregon.gov</a>, they will be listed here by chapter.</p>'
-            format: full_html
-          plugin_id: text
+      empty: {  }
       header:
         area:
           id: area
@@ -592,7 +579,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<p>The City Auditor is responsible for maintaining the official copy of the Portland City Code and Charter which is kept in the Office of the City Auditor in the Council Clerk/Contracts Division in City Hall Room 130.</p>\r\n<p>The online version is provided for informational purposes only and should not be relied upon as the official Code or Charter. Quarterly <a href=\"http://efiles.portlandoregon.gov/Record?q=recAnyWord%3A%22city+code+folder%22+And+recAnyWord%3A%22minus%22&sortBy=recCreatedOn-\">City Code updates</a> and <a href=\"http://efiles.portlandoregon.gov/Record?q=recContainer%3A4896378&nb=true&sortBy=recCreatedOn-\">City Charter updates</a> are published by the Council Clerk/Contracts staff and are available to download from Efiles.</p>"
+            value: "<p>The City Auditor is responsible for maintaining the official copy of the Portland City Code and Charter which is kept in the Office of the City Auditor in the Council Clerk/Contracts Division in City Hall Room 130.</p>\r\n<p>The online version is provided for informational purposes only and should not be relied upon as the official Code or Charter. Quarterly <a href=\"http://efiles.portlandoregon.gov/Record?q=recAnyWord%3A%22city+code+folder%22+And+recAnyWord%3A%22minus%22&sortBy=recCreatedOn-\">City Code updates</a> and <a href=\"http://efiles.portlandoregon.gov/Record?q=recContainer%3A4896378&nb=true&sortBy=recCreatedOn-\">City Charter updates</a> are published by the Council Clerk/Contracts staff and are available to download from Efiles.</p>\r\n<p>Every 10 years, the City Council convenes a <a href=\"/omf/charter-review-commission\">Charter Commission</a> to review and recommend amendments to the Charter.</p>"
             format: simplified_editor_with_media_embed
           plugin_id: text
     cache_metadata:


### PR DESCRIPTION
This wording is from the summary of the Charter Commission group. Also removed the unused migration message.