### PR TITLE
POWR-3545 Upgrade browserslist to version 4.16.5 or later to fix security vulnerability

### DIFF
--- a/tests/percy/package.json
+++ b/tests/percy/package.json
@@ -23,5 +23,8 @@
     "@percy/puppeteer": "^2.0.0",
     "jest": "^26.6.3",
     "puppeteer": "^9.0.0"
+  },
+  "resolutions": {
+    "browserslist": "^4.16.5"
   }
 }

--- a/tests/percy/yarn.lock
+++ b/tests/percy/yarn.lock
@@ -591,73 +591,73 @@
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
 
-"@percy/cli-build@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.46.tgz"
-  integrity sha512-ipGY2/8gtBUYXaItQy5PFFLiVielgQ+f7FHz4ZHhvYeW6c7ku67EwACP2hjgamCxhmOONHe5hx3E/m52nQw0Jw==
+"@percy/cli-build@^1.0.0-beta.48":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.0.0-beta.51.tgz#2c8fa74753a87a581d623cce22f42ac01d76eec7"
+  integrity sha512-TR0VIhpReBzXVliu/bTw330REMhiDPDk5T/mNFzmnlfZLjQv2XzRRvxFr9wN52xJwjgJ2gEvwOE9gl3MkO1NbA==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.46"
-    "@percy/client" "^1.0.0-beta.46"
-    "@percy/env" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/cli-command" "^1.0.0-beta.51"
+    "@percy/client" "^1.0.0-beta.51"
+    "@percy/env" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
 
-"@percy/cli-command@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.46.tgz"
-  integrity sha512-MwGSRypXOM0UHGXnM/Fc8p7pq/+2a84wzsFMYUvKhJEGsx3aTpONbNTulNRYUtPRUWkEvnxo0tb6tz7+oi/vRw==
+"@percy/cli-command@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.0.0-beta.51.tgz#c2c696a37dc456c0d3a9a0b5817a246ff299e97b"
+  integrity sha512-8DEd9NbZbEOgFL7SQOR+DjgAWw5LTv0cCHU3RMBJvJX9YfteE0FdzdyeclP74IHrhrJQ03r25v3etDRk7KEWtQ==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
     "@oclif/plugin-help" "^3.2.0"
-    "@percy/config" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/config" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
 
-"@percy/cli-config@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.46.tgz"
-  integrity sha512-VTvzupD9t+bwnXAO5J7JigWaRY5V2AxY5LZiXiRGzGjEtw0KIRVCiAYA/5xttvM4FcOjnnNzvJxmlW9kFySR6Q==
+"@percy/cli-config@^1.0.0-beta.48":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.0.0-beta.51.tgz#56313e9d8be0377f3b3d526e39b6b95a15c8e8f5"
+  integrity sha512-MxkYW3rKW4RreXnP4wVVOsdQEz8pwMmrF+94rGCJeGFKNRg1wJ+NoMEnJeBsaYda1WhJKERvUiA1CF4KYHxdKA==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1.17.0"
-    "@percy/config" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/config" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
 
-"@percy/cli-exec@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.46.tgz"
-  integrity sha512-F+apSBnvKUjUPtUu5a+UmeGIdOzjcjUiRJW1SBHp4Xpqi4fa4WWxAhm8KBBlLIDSGRsjHxoP0DEkEZibacgfmQ==
+"@percy/cli-exec@^1.0.0-beta.48":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.0.0-beta.51.tgz#6151f6c6efe666a7189bb81c4f7c2392875346ff"
+  integrity sha512-iBR61kLxXo1prjNmv/8smWm+hHAyo3RQA/ayVOpKffjhuk8rsbU6YGE4vyliDT0/mQfDVbmMTJd22FpfjDoQoA==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.46"
-    "@percy/core" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/cli-command" "^1.0.0-beta.51"
+    "@percy/core" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.46.tgz"
-  integrity sha512-Utg6s5GwZmHs9s09gWmrNQAZyEV2VrWLvNN++57fQpgemmWlaKjxmPaApVh0DQKlgDqc9Xzw+oolFZYcAvXAug==
+"@percy/cli-snapshot@^1.0.0-beta.48":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.51.tgz#6a4b4930d68ee19eb0089e79087c9d872122e6ce"
+  integrity sha512-1TdKe8BqzX6x7pag+MBY1KWRRHJYrHX5MXeeAwfBVAV9gOGsaTN4JpmK9Df+nGK5U/ugw2UTqD2hr7xirvQv6Q==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.46"
-    "@percy/config" "^1.0.0-beta.46"
-    "@percy/core" "^1.0.0-beta.46"
-    "@percy/dom" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/cli-command" "^1.0.0-beta.51"
+    "@percy/config" "^1.0.0-beta.51"
+    "@percy/core" "^1.0.0-beta.51"
+    "@percy/dom" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
     globby "^11.0.1"
     serve-handler "^6.1.3"
     yaml "^1.10.0"
 
-"@percy/cli-upload@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.46.tgz"
-  integrity sha512-Z+Fy0HXyjPx/ZlwiiZfnARGXaPNyWn+tq70TZ4oPwSFIeo/eeoNe4JfFQnAhT2Hh5I0MqnUk4kmVD9ku3heawg==
+"@percy/cli-upload@^1.0.0-beta.48":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.0.0-beta.51.tgz#13b7b739a098cd150e9bda6903aeb02bc7d7c503"
+  integrity sha512-+jiY7DOvkLORi4qPkirdSTuls8rG2r83kp3S4kzIcc+fp+eOxBgeoRTCm0nF0FkzqVRPY2SGJhTGTIdYExWm1A==
   dependencies:
-    "@percy/cli-command" "^1.0.0-beta.46"
-    "@percy/client" "^1.0.0-beta.46"
-    "@percy/config" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/cli-command" "^1.0.0-beta.51"
+    "@percy/client" "^1.0.0-beta.51"
+    "@percy/config" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
     globby "^11.0.1"
-    image-size "^0.9.1"
+    image-size "^1.0.0"
 
 "@percy/cli@^1.0.0-beta.48":
   version "1.0.0-beta.48"
@@ -671,54 +671,59 @@
     "@percy/cli-snapshot" "^1.0.0-beta.48"
     "@percy/cli-upload" "^1.0.0-beta.48"
 
-"@percy/client@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.46.tgz"
-  integrity sha512-WJWs8zneWCEp1xuFKRhHXz+rH2hGHCSYjqcfKlI8o7gkAfZEIabFoYBZBYtvaWEiL7EZrYZO3qFcSIxjC0/H6Q==
+"@percy/client@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.0.0-beta.51.tgz#32f0d6c30c0df3c4c1ac6cb0bb703b5ca6b908f1"
+  integrity sha512-CagH93J8RMOYDeEy1GnzYGdVosoMmgZ0+NZTLyflp7SvBLn4zKo+dk5t7urnOTP5Mh7xVXv/xpJQSdkmYZ2lFQ==
   dependencies:
-    "@percy/env" "^1.0.0-beta.46"
+    "@percy/env" "^1.0.0-beta.51"
 
-"@percy/config@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.46.tgz"
-  integrity sha512-pOVfdCbMG5XkAueU2v7LEqNhh2qEmFsS8SQ7Axt/jevuor/XiQOGGXShukmMPBvcrEst7nbKHYs8gcH6Bg5zMQ==
+"@percy/config@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.51.tgz#8e3e2bf6ed8b6764a9fedf408a498c81eae971a5"
+  integrity sha512-ox6VWBg9PWEEQOcXRNs3pXfD34XUdvG/Uc9p5CAUrKWKXzhOJawtbxdcSJ5dF/8AcyPO0urBSNg2vz0HgX6QXQ==
   dependencies:
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/logger" "^1.0.0-beta.51"
     ajv "^8.0.5"
     cosmiconfig "^7.0.0"
     yaml "^1.10.0"
 
-"@percy/core@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.46.tgz"
-  integrity sha512-4XtiM5gDKZZdz1CETi0HjDGJZBZdj9tfhR8hpKjpQKJA3KhYOjjuEC96lh/8jZxj/kIc2I92u1nYD6m0PTYbVQ==
+"@percy/core@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.0.0-beta.51.tgz#9e1aa35df53fa25389918262dfdf29cadf5d6403"
+  integrity sha512-t4Fqc2dy1ZrnB7ROspXRD1FbL9VUaS0srB+xv3mjg9+b8D/pRHVNUZz6j4H5fwb3PnV6EBZQzU44A8ZhPavEHA==
   dependencies:
-    "@percy/client" "^1.0.0-beta.46"
-    "@percy/config" "^1.0.0-beta.46"
-    "@percy/dom" "^1.0.0-beta.46"
-    "@percy/logger" "^1.0.0-beta.46"
+    "@percy/client" "^1.0.0-beta.51"
+    "@percy/config" "^1.0.0-beta.51"
+    "@percy/dom" "^1.0.0-beta.51"
+    "@percy/logger" "^1.0.0-beta.51"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
     progress "^2.0.3"
     rimraf "^3.0.2"
     ws "^7.4.1"
 
-"@percy/dom@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.46.tgz"
-  integrity sha512-UuDF3G2whvNo7jbhGId8bq0uE1EW2jDc+d7byYua0ksvI0gBfJza+DxleRkwXC2eWMbQcbD1kV+FXDKsYzVdEQ==
+"@percy/dom@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.0.0-beta.51.tgz#888461f7cecd1a0c53ef308ec3f221825c38e91a"
+  integrity sha512-9KDSo3DvzHoWvHdSpqGJuKgWBRuTAPi/vaPQtBNlxpHiu9MyeqNhWPbBzBWYIxbAXFACUq97w3SYKlqdJ66DLg==
 
-"@percy/env@^1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.46.tgz"
-  integrity sha512-o7iroNhR6LpoSqB0J1P6PvzGoI9QOb1m8c1Kr2AzGYMWI41f+5jkzWNi85vLok5of2yOKOUVTJczbhSSvSIkmw==
+"@percy/env@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.0.0-beta.51.tgz#49eb907e7081700a99998be2ae7898f2e3b3ccd0"
+  integrity sha512-pAt+FH7IWvwlnuPvNfaZdX3/sRQPYyJaxJUdTwynZFuBteye1Rmtpd5ZSFJ0KqYAJuG+8BlEduAFtVRalMYXkw==
   dependencies:
-    dotenv "^8.2.0"
+    dotenv "^10.0.0"
 
 "@percy/logger@^1.0.0-beta.46":
   version "1.0.0-beta.46"
   resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.46.tgz"
   integrity sha512-VZpg20YWW02QevhzQQFhnoOd3VtwkhzWfCvLmcwsTK7eyymwomX1liIgeg0fEyL1cGw+hoWyE21NX+MEXYeobw==
+
+"@percy/logger@^1.0.0-beta.51":
+  version "1.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.51.tgz#71ad80e89759bf25362c734546f25bc8ac4c37e0"
+  integrity sha512-rurUk6TxXC+aQbOM561jQ63En3cE3t19uZPRzEpOuTqcFGzR2nWyrEmjkGfWMyCh987Ir6C+0HK2VryQ94hnSg==
 
 "@percy/puppeteer@^2.0.0":
   version "2.0.0"
@@ -1287,14 +1292,14 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.14.5:
-  version "4.16.4"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz"
-  integrity sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==
+browserslist@^4.14.5, browserslist@^4.16.5:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
   dependencies:
-    caniuse-lite "^1.0.30001208"
+    caniuse-lite "^1.0.30001219"
     colorette "^1.2.2"
-    electron-to-chromium "^1.3.712"
+    electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
@@ -1366,10 +1371,10 @@ camelcase@^6.0.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001208:
-  version "1.0.30001214"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz#70f153c78223515c6d37a9fde6cd69250da9d872"
-  integrity sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==
+caniuse-lite@^1.0.30001219:
+  version "1.0.30001230"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
+  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1727,10 +1732,10 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1740,10 +1745,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.712:
-  version "1.3.719"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.719.tgz#87166fee347a46a2557f19aadb40a1d68241e61c"
-  integrity sha512-heM78GKSqrIzO9Oz0/y22nTBN7bqSP1Pla2SyU9DiSnQD+Ea9SyyN5RWWlgqsqeBLNDkSlE9J9EHFmdMPzxB/g==
+electron-to-chromium@^1.3.723:
+  version "1.3.740"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.740.tgz#e38b7d2b848f632191b643e6dabca51be2162922"
+  integrity sha512-Mi2m55JrX2BFbNZGKYR+2ItcGnR4O5HhrvgoRRyZQlaMGQULqDhoGkLWHzJoshSzi7k1PUofxcDbNhlFrDZNhg==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -2474,10 +2479,10 @@ ignore@^5.1.4:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-image-size@^0.9.1:
-  version "0.9.7"
-  resolved "https://registry.npmjs.org/image-size/-/image-size-0.9.7.tgz"
-  integrity sha512-KRVgLNZkr00YGN0qn9MlIrmlxbRhsCcEb1Byq3WKGnIV4M48iD185cprRtaoK4t5iC+ym2Q5qlArxZ/V1yzDgA==
+image-size@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.0.tgz#58b31fe4743b1cec0a0ac26f5c914d3c5b2f0750"
+  integrity sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==
   dependencies:
     queue "6.0.2"
 


### PR DESCRIPTION
This PR updates browserslist to the patched version.

I did not upgrade our theme dependencies due to complexity, and think it should be a separate story.

@joshuami let me know if you'd like me to add auditing/upgrading theme dependencies to Jira, or anything you'd like to add.