### PR TITLE
POWR-3726 Fix facets on group documents search view

### DIFF
--- a/web/sites/default/config/block.block.filterbydocumentmonth.yml
+++ b/web/sites/default/config/block.block.filterbydocumentmonth.yml
@@ -12,7 +12,7 @@ dependencies:
 id: filterbydocumentmonth
 theme: cloudy
 region: tools
-weight: 42
+weight: 41
 provider: null
 plugin: 'facet_block:group_document_month'
 settings:

--- a/web/sites/default/config/block.block.filterbydocumenttype.yml
+++ b/web/sites/default/config/block.block.filterbydocumenttype.yml
@@ -12,7 +12,7 @@ dependencies:
 id: filterbydocumenttype
 theme: cloudy
 region: tools
-weight: 40
+weight: 42
 provider: null
 plugin: 'facet_block:group_document_type'
 settings:

--- a/web/sites/default/config/block.block.filterbydocumentyear.yml
+++ b/web/sites/default/config/block.block.filterbydocumentyear.yml
@@ -12,7 +12,7 @@ dependencies:
 id: filterbydocumentyear
 theme: cloudy
 region: tools
-weight: 41
+weight: 40
 provider: null
 plugin: 'facet_block:group_document_year'
 settings:

--- a/web/sites/default/config/facets.facet.advisory_groups_by_parent_group.yml
+++ b/web/sites/default/config/facets.facet.advisory_groups_by_parent_group.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.advisory_groups_by_topics.yml
+++ b/web/sites/default/config/facets.facet.advisory_groups_by_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.aggregated_topic.yml
+++ b/web/sites/default/config/facets.facet.aggregated_topic.yml
@@ -27,6 +27,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.charter_code_policies_by_type.yml
+++ b/web/sites/default/config/facets.facet.charter_code_policies_by_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.child_group_advisory_groups_by_topics.yml
+++ b/web/sites/default/config/facets.facet.child_group_advisory_groups_by_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.city_section.yml
+++ b/web/sites/default/config/facets.facet.city_section.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.community_actions_on_permits.yml
+++ b/web/sites/default/config/facets.facet.community_actions_on_permits.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: true
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_completed_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.construction_completed_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_completed_offered_by.yml
+++ b/web/sites/default/config/facets.facet.construction_completed_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_completed_topic.yml
+++ b/web/sites/default/config/facets.facet.construction_completed_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_completed_type.yml
+++ b/web/sites/default/config/facets.facet.construction_completed_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_completed_year_complete.yml
+++ b/web/sites/default/config/facets.facet.construction_completed_year_complete.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_map_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.construction_map_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_map_project_status.yml
+++ b/web/sites/default/config/facets.facet.construction_map_project_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_map_topic.yml
+++ b/web/sites/default/config/facets.facet.construction_map_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_map_type.yml
+++ b/web/sites/default/config/facets.facet.construction_map_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.construction_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_offered_by.yml
+++ b/web/sites/default/config/facets.facet.construction_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_topic.yml
+++ b/web/sites/default/config/facets.facet.construction_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_type.yml
+++ b/web/sites/default/config/facets.facet.construction_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.construction_year.yml
+++ b/web/sites/default/config/facets.facet.construction_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.content_type_name.yml
+++ b/web/sites/default/config/facets.facet.content_type_name.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.contruction_map_end_year.yml
+++ b/web/sites/default/config/facets.facet.contruction_map_end_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.events_by_topic.yml
+++ b/web/sites/default/config/facets.facet.events_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.filter_by_news_month.yml
+++ b/web/sites/default/config/facets.facet.filter_by_news_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.filter_by_news_year.yml
+++ b/web/sites/default/config/facets.facet.filter_by_news_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_completed_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.group_construction_completed_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_completed_status.yml
+++ b/web/sites/default/config/facets.facet.group_construction_completed_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_completed_topic.yml
+++ b/web/sites/default/config/facets.facet.group_construction_completed_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_completed_year_completed.yml
+++ b/web/sites/default/config/facets.facet.group_construction_completed_year_completed.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.group_construction_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_topic.yml
+++ b/web/sites/default/config/facets.facet.group_construction_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_construction_year.yml
+++ b/web/sites/default/config/facets.facet.group_construction_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_liquor_application_month.yml
+++ b/web/sites/default/config/facets.facet.group_document_liquor_application_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_liquor_application_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.group_document_liquor_application_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_liquor_application_year.yml
+++ b/web/sites/default/config/facets.facet.group_document_liquor_application_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_month.yml
+++ b/web/sites/default/config/facets.facet.group_document_month.yml
@@ -10,10 +10,10 @@ dependencies:
 id: group_document_month
 name: 'Filter by Month'
 url_alias: month
-weight: 0
+weight: -1
 min_count: 1
 show_only_one_result: false
-field_identifier: field_end_date
+field_identifier: changed
 facet_source_id: 'search_api:views_page__search_group_documents__group_documents_search'
 widget:
   type: checkbox
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.group_document_neighborhood.yml
@@ -10,7 +10,7 @@ dependencies:
 id: group_document_neighborhood
 name: 'Filter by Neighborhood'
 url_alias: neighborhood
-weight: -2
+weight: 1
 min_count: 1
 show_only_one_result: false
 field_identifier: field_neighborhood
@@ -28,22 +28,30 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0
 exclude: false
 only_visible_when_facet_source_is_visible: true
 processor_configs:
-  display_value_widget_order:
-    processor_id: display_value_widget_order
+  count_limit:
+    processor_id: count_limit
     weights:
-      sort: 40
+      build: 50
+    settings:
+      minimum_items: 1
+      maximum_items: null
+  term_weight_widget_order:
+    processor_id: term_weight_widget_order
+    weights:
+      sort: 60
     settings:
       sort: ASC
-  hide_non_narrowing_result_processor:
-    processor_id: hide_non_narrowing_result_processor
+  tid_to_name:
+    processor_id: tid_to_name
     weights:
-      build: 40
+      build: 36
     settings: {  }
   translate_entity:
     processor_id: translate_entity

--- a/web/sites/default/config/facets.facet.group_document_type.yml
+++ b/web/sites/default/config/facets.facet.group_document_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_document_year.yml
+++ b/web/sites/default/config/facets.facet.group_document_year.yml
@@ -10,10 +10,10 @@ dependencies:
 id: group_document_year
 name: 'Filter by Year'
 url_alias: year
-weight: 0
+weight: -2
 min_count: 1
 show_only_one_result: false
-field_identifier: field_end_date
+field_identifier: changed
 facet_source_id: 'search_api:views_page__search_group_documents__group_documents_search'
 widget:
   type: checkbox
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_event_start_month.yml
+++ b/web/sites/default/config/facets.facet.group_event_start_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_event_start_year.yml
+++ b/web/sites/default/config/facets.facet.group_event_start_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_event_status.yml
+++ b/web/sites/default/config/facets.facet.group_event_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_event_type.yml
+++ b/web/sites/default/config/facets.facet.group_event_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_blog_published_on_month.yml
+++ b/web/sites/default/config/facets.facet.group_news_blog_published_on_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_blog_published_on_year.yml
+++ b/web/sites/default/config/facets.facet.group_news_blog_published_on_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_blog_topics.yml
+++ b/web/sites/default/config/facets.facet.group_news_blog_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_press_releases_published_on_month.yml
+++ b/web/sites/default/config/facets.facet.group_news_press_releases_published_on_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_press_releases_published_on_year.yml
+++ b/web/sites/default/config/facets.facet.group_news_press_releases_published_on_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_press_releases_topics.yml
+++ b/web/sites/default/config/facets.facet.group_news_press_releases_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_public_notices_published_on_month.yml
+++ b/web/sites/default/config/facets.facet.group_news_public_notices_published_on_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_public_notices_published_on_year.yml
+++ b/web/sites/default/config/facets.facet.group_news_public_notices_published_on_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_public_notices_topics.yml
+++ b/web/sites/default/config/facets.facet.group_news_public_notices_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_published_on_month.yml
+++ b/web/sites/default/config/facets.facet.group_news_published_on_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_published_on_year.yml
+++ b/web/sites/default/config/facets.facet.group_news_published_on_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_reports_published_on_month.yml
+++ b/web/sites/default/config/facets.facet.group_news_reports_published_on_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_reports_published_on_year.yml
+++ b/web/sites/default/config/facets.facet.group_news_reports_published_on_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_reports_topics.yml
+++ b/web/sites/default/config/facets.facet.group_news_reports_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_topics.yml
+++ b/web/sites/default/config/facets.facet.group_news_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_news_type.yml
+++ b/web/sites/default/config/facets.facet.group_news_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_event_start_month.yml
+++ b/web/sites/default/config/facets.facet.group_past_event_start_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_event_start_year.yml
+++ b/web/sites/default/config/facets.facet.group_past_event_start_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_event_status.yml
+++ b/web/sites/default/config/facets.facet.group_past_event_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_event_type.yml
+++ b/web/sites/default/config/facets.facet.group_past_event_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_meeting_event_status.yml
+++ b/web/sites/default/config/facets.facet.group_past_meeting_event_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_meeting_start_month.yml
+++ b/web/sites/default/config/facets.facet.group_past_meeting_start_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_meeting_start_year.yml
+++ b/web/sites/default/config/facets.facet.group_past_meeting_start_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_past_meetings_event_type.yml
+++ b/web/sites/default/config/facets.facet.group_past_meetings_event_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_policy_category.yml
+++ b/web/sites/default/config/facets.facet.group_policy_category.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: true
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_policy_type.yml
+++ b/web/sites/default/config/facets.facet.group_policy_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_project_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.group_project_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_project_status.yml
+++ b/web/sites/default/config/facets.facet.group_project_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_project_type.yml
+++ b/web/sites/default/config/facets.facet.group_project_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_projects_topic.yml
+++ b/web/sites/default/config/facets.facet.group_projects_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_projects_year.yml
+++ b/web/sites/default/config/facets.facet.group_projects_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_services_and_pages_actions.yml
+++ b/web/sites/default/config/facets.facet.group_services_and_pages_actions.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: true
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_services_and_pages_page_type.yml
+++ b/web/sites/default/config/facets.facet.group_services_and_pages_page_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_services_and_pages_topics.yml
+++ b/web/sites/default/config/facets.facet.group_services_and_pages_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.group_title.yml
+++ b/web/sites/default/config/facets.facet.group_title.yml
@@ -27,6 +27,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: true
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.news_by_topic.yml
+++ b/web/sites/default/config/facets.facet.news_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.news_offered_by.yml
+++ b/web/sites/default/config/facets.facet.news_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.news_type.yml
+++ b/web/sites/default/config/facets.facet.news_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.offered_by.yml
+++ b/web/sites/default/config/facets.facet.offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.offices_by_topics.yml
+++ b/web/sites/default/config/facets.facet.offices_by_topics.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.park_amenities_activities.yml
+++ b/web/sites/default/config/facets.facet.park_amenities_activities.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.park_location_type.yml
+++ b/web/sites/default/config/facets.facet.park_location_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_events_by_topic.yml
+++ b/web/sites/default/config/facets.facet.past_events_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_events_filter_by_month.yml
+++ b/web/sites/default/config/facets.facet.past_events_filter_by_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_events_filter_by_type.yml
+++ b/web/sites/default/config/facets.facet.past_events_filter_by_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_events_filter_by_year.yml
+++ b/web/sites/default/config/facets.facet.past_events_filter_by_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_events_offered_by.yml
+++ b/web/sites/default/config/facets.facet.past_events_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_meetings_by_topic.yml
+++ b/web/sites/default/config/facets.facet.past_meetings_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_meetings_by_type.yml
+++ b/web/sites/default/config/facets.facet.past_meetings_by_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_meetings_filter_by_month.yml
+++ b/web/sites/default/config/facets.facet.past_meetings_filter_by_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_meetings_filter_by_year.yml
+++ b/web/sites/default/config/facets.facet.past_meetings_filter_by_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.past_meetings_offered_by.yml
+++ b/web/sites/default/config/facets.facet.past_meetings_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.policy_category.yml
+++ b/web/sites/default/config/facets.facet.policy_category.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.policy_filter_by_bureau.yml
+++ b/web/sites/default/config/facets.facet.policy_filter_by_bureau.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.policy_type.yml
+++ b/web/sites/default/config/facets.facet.policy_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.projects_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_offered_by.yml
+++ b/web/sites/default/config/facets.facet.projects_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_status.yml
+++ b/web/sites/default/config/facets.facet.projects_status.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_topic.yml
+++ b/web/sites/default/config/facets.facet.projects_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_type.yml
+++ b/web/sites/default/config/facets.facet.projects_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.projects_year.yml
+++ b/web/sites/default/config/facets.facet.projects_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.reservations_available.yml
+++ b/web/sites/default/config/facets.facet.reservations_available.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.search_events_filter_by_month.yml
+++ b/web/sites/default/config/facets.facet.search_events_filter_by_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.search_events_filter_by_type.yml
+++ b/web/sites/default/config/facets.facet.search_events_filter_by_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.search_events_filter_by_year.yml
+++ b/web/sites/default/config/facets.facet.search_events_filter_by_year.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.services_by_action.yml
+++ b/web/sites/default/config/facets.facet.services_by_action.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: true
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.services_by_topic.yml
+++ b/web/sites/default/config/facets.facet.services_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.services_offered_by.yml
+++ b/web/sites/default/config/facets.facet.services_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.sitewide_events_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.sitewide_events_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.sitewide_events_past_meetings_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.sitewide_events_past_meetings_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.sitewide_events_past_neighborhood.yml
+++ b/web/sites/default/config/facets.facet.sitewide_events_past_neighborhood.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.upcoming_events_by_topic.yml
+++ b/web/sites/default/config/facets.facet.upcoming_events_by_topic.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: true
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.upcoming_events_filter_by_month.yml
+++ b/web/sites/default/config/facets.facet.upcoming_events_filter_by_month.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.upcoming_events_filter_by_type.yml
+++ b/web/sites/default/config/facets.facet.upcoming_events_filter_by_type.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/facets.facet.upcoming_events_offered_by.yml
+++ b/web/sites/default/config/facets.facet.upcoming_events_offered_by.yml
@@ -28,6 +28,7 @@ widget:
     hide_reset_when_no_selection: true
 query_operator: and
 use_hierarchy: false
+keep_hierarchy_parents_active: false
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/web/sites/default/config/views.view.search_group_documents.yml
+++ b/web/sites/default/config/views.view.search_group_documents.yml
@@ -1674,6 +1674,8 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+      cache:
+        type: none
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
A few minor tweaks/fixes to the year, month, and neighborhood facets. Exporting config also added a new `keep_hierarchy_parents_active: false` line to all facet config files.