### PR TITLE
POWR-3806 - fix construction and project Geo Map fields to show point marker tool

### DIFF
--- a/web/sites/default/config/core.entity_form_display.group.project.default.yml
+++ b/web/sites/default/config/core.entity_form_display.group.project.default.yml
@@ -441,7 +441,7 @@ content:
         readonly: 0
       toolbar:
         position: topright
-        drawMarker: '1'
+        marker: defaultMarker
         drawPolyline: '1'
         drawRectangle: '1'
         drawPolygon: '1'
@@ -449,11 +449,11 @@ content:
         dragMode: '1'
         removalMode: '1'
         drawCircle: false
-        drawCircleMarker: false
         cutPolygon: 0
       reset_map:
         position: topright
         control: 0
+      path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
       geocoder:
         settings:
           position: topright
@@ -462,79 +462,12 @@ content:
             arcgisonline:
               weight: '0'
               checked: 0
-            bingmaps:
-              weight: '0'
-              checked: 0
-            file:
-              weight: '0'
-              checked: 0
-            freegeoip:
-              weight: '0'
-              checked: 0
-            gpxfile:
-              weight: '0'
-              checked: 0
-            geojsonfile:
-              weight: '0'
-              checked: 0
-            geoplugin:
-              weight: '0'
-              checked: 0
-            geoip:
-              weight: '0'
-              checked: 0
-            geonames:
-              weight: '0'
-              checked: 0
-            googlemaps:
-              weight: '0'
-              checked: 0
-            googlemaps_business:
-              weight: '0'
-              checked: 0
-            hostip:
-              weight: '0'
-              checked: 0
-            ipinfodb:
-              weight: '0'
-              checked: 0
-            kmlfile:
-              weight: '0'
-              checked: 0
-            mapquest:
-              weight: '0'
-              checked: 0
-            maxmind:
-              weight: '0'
-              checked: 0
-            nominatim:
-              weight: '0'
-              checked: 0
-            opencage:
-              weight: '0'
-              checked: 0
-            openstreetmap:
-              weight: '0'
-              checked: 0
-            portlandmaps:
-              weight: '0'
-              checked: 0
-            random:
-              weight: '0'
-              checked: 0
-            tomtom:
-              weight: '0'
-              checked: 0
-            yandex:
-              weight: '0'
-              checked: 0
           min_terms: '4'
           delay: '800'
           zoom: '16'
           options: ''
           popup: 0
         control: 0
-      path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
     third_party_settings: {  }
   field_group_menu_toggle:
     weight: 21

--- a/web/sites/default/config/core.entity_form_display.node.construction_project.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.construction_project.default.yml
@@ -336,7 +336,7 @@ content:
         readonly: 0
       toolbar:
         position: topright
-        drawMarker: '1'
+        marker: defaultMarker
         drawPolyline: '1'
         drawRectangle: '1'
         drawPolygon: '1'
@@ -344,11 +344,11 @@ content:
         dragMode: '1'
         removalMode: '1'
         drawCircle: false
-        drawCircleMarker: false
         cutPolygon: 0
       reset_map:
         position: topright
         control: 0
+      path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
       geocoder:
         settings:
           position: topright
@@ -357,79 +357,12 @@ content:
             arcgisonline:
               weight: '0'
               checked: 0
-            bingmaps:
-              weight: '0'
-              checked: 0
-            file:
-              weight: '0'
-              checked: 0
-            freegeoip:
-              weight: '0'
-              checked: 0
-            gpxfile:
-              weight: '0'
-              checked: 0
-            geojsonfile:
-              weight: '0'
-              checked: 0
-            geoplugin:
-              weight: '0'
-              checked: 0
-            geoip:
-              weight: '0'
-              checked: 0
-            geonames:
-              weight: '0'
-              checked: 0
-            googlemaps:
-              weight: '0'
-              checked: 0
-            googlemaps_business:
-              weight: '0'
-              checked: 0
-            hostip:
-              weight: '0'
-              checked: 0
-            ipinfodb:
-              weight: '0'
-              checked: 0
-            kmlfile:
-              weight: '0'
-              checked: 0
-            mapquest:
-              weight: '0'
-              checked: 0
-            maxmind:
-              weight: '0'
-              checked: 0
-            nominatim:
-              weight: '0'
-              checked: 0
-            opencage:
-              weight: '0'
-              checked: 0
-            openstreetmap:
-              weight: '0'
-              checked: 0
-            portlandmaps:
-              weight: '0'
-              checked: 0
-            random:
-              weight: '0'
-              checked: 0
-            tomtom:
-              weight: '0'
-              checked: 0
-            yandex:
-              weight: '0'
-              checked: 0
           min_terms: '4'
           delay: '800'
           zoom: '16'
           options: ''
           popup: 0
         control: 0
-      path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
     third_party_settings:
       conditional_fields:
         f062462a-48a8-4216-a595-109d4ec2608f:


### PR DESCRIPTION
I'm not sure which module is responsible for the config settings here (Geofield, the Geocoder plugin for Geofield, or Leaflet), but the config structure changed and Drupal didn't recognize the existing config as being out of date. I fonzied it and got it working--changed the default market setting to something else, then changed it back. After that the point marker tool appeared, and the config changed. Or maybe the node field display settings just needed to be re-saved. Anyway, it's working now.