### PR TITLE
POWR-3886 Final neighborhood contacts migration

### DIFF
--- a/web/modules/custom/portland_migrations/README.md
+++ b/web/modules/custom/portland_migrations/README.md
@@ -407,13 +407,13 @@ lando terminus drush portlandor.powr-[ID] -- migrate:import civic_neighborhood_m
 
 ##### Local
 ```
-lando drush migrate:import civic_neighborhood_contacts
-lando drush migrate:import civic_neighborhood_contacts_relationships
+lando drush migrate:import civic_neighborhood_contacts_v2
+lando drush migrate:import civic_neighborhood_contacts_relationships_v2
 ```
 ##### On Pantheon
 ```
-lando terminus drush portlandor.powr-[ID] -- migrate:import civic_neighborhood_contacts
-lando terminus drush portlandor.powr-[ID] -- migrate:import civic_neighborhood_contacts_relationships
+lando terminus drush portlandor.powr-[ID] -- migrate:import civic_neighborhood_contacts_v2
+lando terminus drush portlandor.powr-[ID] -- migrate:import civic_neighborhood_contacts_relationships_v2
 ```
 
 #### Civic Life Neighborhoods

--- a/web/modules/custom/portland_migrations/migrations/auditor_blog.yml
+++ b/web/modules/custom/portland_migrations/migrations/auditor_blog.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/auditor_blog_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/auditor_blog_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/auditor_blog_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/bds_news.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_news.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/bds_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/bds_news_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_news_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/bds_plans_examiner.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_plans_examiner.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/bds_plans_examiner.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/bds_plans_examiner_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_plans_examiner_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/bds_service_updates.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_service_updates.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/bds_service_updates.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/bds_service_updates_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/bds_service_updates_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/category_documents.yml
+++ b/web/modules/custom/portland_migrations/migrations/category_documents.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/category_documents.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
   constants:
     migration_directory: public://migrations/

--- a/web/modules/custom/portland_migrations/migrations/category_documents_group_content.yml
+++ b/web/modules/custom/portland_migrations/migrations/category_documents_group_content.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/category_documents.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   type:

--- a/web/modules/custom/portland_migrations/migrations/city_charter_articles.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_articles.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_charter_articles.csv
   header_row_count: 1
-  keys:
+  ids:
     - id
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_charter_articles_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_articles_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - id
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/city_charter_chapters.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_chapters.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_charter_chapters.csv
   header_row_count: 1
-  keys:
+  ids:
     - number
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_charter_chapters_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_chapters_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - number
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/city_charter_sections.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_sections.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_charter_sections.csv
   header_row_count: 1
-  keys:
+  ids:
     - id
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_charter_sections_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_charter_sections_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - id
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/city_code_chapters.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_chapters.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_code_chapters.csv
   header_row_count: 1
-  keys:
+  ids:
     - id
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_code_chapters_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_chapters_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - id
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/city_code_sections.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_sections.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_code_sections.csv
   header_row_count: 1
-  keys:
+  ids:
     - id
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_code_sections_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_sections_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - id
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/city_code_titles.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_titles.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/city_code_titles.csv
   header_row_count: 1
-  keys:
+  ids:
     - title
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/city_code_titles_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/city_code_titles_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - title
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/civic_neighborhood_contacts.yml
+++ b/web/modules/custom/portland_migrations/migrations/civic_neighborhood_contacts.yml
@@ -1,11 +1,11 @@
-id: civic_neighborhood_contacts
+id: civic_neighborhood_contacts_v2
 label: 'Civic Life Neighborhood Contacts'
 migration_group: civic_neighborhood_contacts
 source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/civic_neighborhood_contacts.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTACT_ID_UNIQUE
 process:
   uid:
@@ -35,6 +35,9 @@ process:
   field_address/locality: CITY
   field_address/administrative_area: STATE_ABBR
   field_address/postal_code: ZIP
+  field_display_groups:
+      plugin: default_value
+      default_value: 234
 destination:
   plugin: 'entity:node'
   default_bundle: contact

--- a/web/modules/custom/portland_migrations/migrations/civic_neighborhood_contacts_relationships.yml
+++ b/web/modules/custom/portland_migrations/migrations/civic_neighborhood_contacts_relationships.yml
@@ -1,11 +1,11 @@
-id: civic_neighborhood_contacts_relationships
+id: civic_neighborhood_contacts_relationships_v2
 label: 'Civic Life Neighborhood Contacts Relationships'
 migration_group: civic_neighborhood_contacts
 source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/civic_neighborhood_contacts.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTACT_ID_UNIQUE
 process:
   tid:
@@ -14,7 +14,7 @@ process:
     source: NEIGHBORHOOD_NAME
   field_contact:
     plugin: migration_lookup
-    migration: civic_neighborhood_contacts
+    migration: civic_neighborhood_contacts_v2
     source: CONTACT_ID_UNIQUE
     no_stub: true
     multivalued_append: true

--- a/web/modules/custom/portland_migrations/migrations/civic_neighborhood_meetings.yml
+++ b/web/modules/custom/portland_migrations/migrations/civic_neighborhood_meetings.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/civic_neighborhood_meetings.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/civic_neighborhood_meetings_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/civic_neighborhood_meetings_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/civic_neighborhoods.yml
+++ b/web/modules/custom/portland_migrations/migrations/civic_neighborhoods.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/civic_neighborhoods.csv
   header_row_count: 1
-  keys:
+  ids:
     - neighborhood_id
   constants:
     neighborhood_type: 'neighborhood'

--- a/web/modules/custom/portland_migrations/migrations/eudaly_news.yml
+++ b/web/modules/custom/portland_migrations/migrations/eudaly_news.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/eudaly_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/eudaly_news_group_content.yml
+++ b/web/modules/custom/portland_migrations/migrations/eudaly_news_group_content.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/eudaly_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   type:

--- a/web/modules/custom/portland_migrations/migrations/eudaly_news_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/eudaly_news_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/park_amenities.yml
+++ b/web/modules/custom/portland_migrations/migrations/park_amenities.yml
@@ -7,7 +7,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/park_amenities.csv
   header_row_count: 1
-  keys:
+  ids:
     - PropertyID
 process:
   nid:

--- a/web/modules/custom/portland_migrations/migrations/park_documents.yml
+++ b/web/modules/custom/portland_migrations/migrations/park_documents.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/park_documents.csv
   header_row_count: 1
-  keys:
+  ids:
     - PolPdfsId
 process:
   nid:

--- a/web/modules/custom/portland_migrations/migrations/park_photos.yml
+++ b/web/modules/custom/portland_migrations/migrations/park_photos.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/park_photos.csv
   header_row_count: 1
-  keys:
+  ids:
     - PhotoID
 process:
   nid:

--- a/web/modules/custom/portland_migrations/migrations/parks.yml
+++ b/web/modules/custom/portland_migrations/migrations/parks.yml
@@ -13,7 +13,7 @@ source:
   constants:
     portlandmaps_layer: 'https://www.portlandmaps.com/arcgis/rest/services/Public/Parks_Misc/MapServer/2'
     portlandmaps_id_prefix: 'PropertyID='
-  keys:
+  ids:
     - PropertyID
 
 process:

--- a/web/modules/custom/portland_migrations/migrations/parks_news.yml
+++ b/web/modules/custom/portland_migrations/migrations/parks_news.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/parks_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/parks_news_group_content.yml
+++ b/web/modules/custom/portland_migrations/migrations/parks_news_group_content.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/parks_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   type:

--- a/web/modules/custom/portland_migrations/migrations/parks_news_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/parks_news_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/parks_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/parks_redirects.yml
@@ -11,7 +11,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - PropertyID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/pbot_news.yml
+++ b/web/modules/custom/portland_migrations/migrations/pbot_news.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/pbot_news.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/pbot_news_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/pbot_news_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/policies.yml
+++ b/web/modules/custom/portland_migrations/migrations/policies.yml
@@ -6,7 +6,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/policies.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/policies_categories.yml
+++ b/web/modules/custom/portland_migrations/migrations/policies_categories.yml
@@ -8,7 +8,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/policies_categories.csv
   header_row_count: 1
-  keys:
+  ids:
     - CATEGORY
 process:
   vid:

--- a/web/modules/custom/portland_migrations/migrations/policies_categories_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/policies_categories_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/taxonomy/term/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CATEGORY
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/policies_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/policies_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/policies_types.yml
+++ b/web/modules/custom/portland_migrations/migrations/policies_types.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/policies_types.csv
   header_row_count: 1
-  keys:
+  ids:
     - TYPE_NAME
 process:
   vid:

--- a/web/modules/custom/portland_migrations/migrations/ppb_directives.yml
+++ b/web/modules/custom/portland_migrations/migrations/ppb_directives.yml
@@ -6,7 +6,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/ppb_directives.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/ppb_directives_categories.yml
+++ b/web/modules/custom/portland_migrations/migrations/ppb_directives_categories.yml
@@ -8,7 +8,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/ppb_directives_categories.csv
   header_row_count: 1
-  keys:
+  ids:
     - CATEGORY
 process:
   vid:

--- a/web/modules/custom/portland_migrations/migrations/ppb_directives_categories_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/ppb_directives_categories_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/taxonomy/term/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CATEGORY
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/ppb_directives_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/ppb_directives_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/wheeler_blog.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_blog.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/wheeler_blog.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/wheeler_blog_group_content.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_blog_group_content.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/wheeler_blog.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   type:

--- a/web/modules/custom/portland_migrations/migrations/wheeler_blog_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_blog_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/migrations/wheeler_press_releases.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_press_releases.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/wheeler_press_releases.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   uid:

--- a/web/modules/custom/portland_migrations/migrations/wheeler_press_releases_group_content.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_press_releases_group_content.yml
@@ -5,7 +5,7 @@ source:
   plugin: csv
   path: modules/custom/portland_migrations/sources/wheeler_press_releases.csv
   header_row_count: 1
-  keys:
+  ids:
     - CONTENT_ID
 process:
   type:

--- a/web/modules/custom/portland_migrations/migrations/wheeler_press_releases_redirects.yml
+++ b/web/modules/custom/portland_migrations/migrations/wheeler_press_releases_redirects.yml
@@ -10,7 +10,7 @@ source:
     redirect_prefix: 'internal:/node/'
     uid_admin: 1
     status_code: 301
-  keys:
+  ids:
     - CONTENT_ID
 destination:
   plugin: 'entity:redirect'

--- a/web/modules/custom/portland_migrations/sources/civic_neighborhood_contacts.csv
+++ b/web/modules/custom/portland_migrations/sources/civic_neighborhood_contacts.csv
@@ -1,512 +1,513 @@
-"DUMMY_COL","GROUP_NAME","NEIGHBORHOOD_NAME","COALITION_ACRONYM","FIRST_NAME","LAST_NAME","ADDRESS","CITY","STATE_ABBR","ZIP","HOME_PHONE","WORK_PHONE","EMAIL","CONTACT_NAME","CONTACT_ID","CONTACT_ID_UNIQUE","DATE_MODIFIED"
-,"Chair/Co-Chair/President","Alameda","NECN","Steve","Backer",,"Portland",,,,,"stevebacker@gmail.com","Steve Backer","37752","906048","10/30/2012 10:19"
-,"Chair/Co-Chair/President","Alameda","NECN","Robert","McConville",,"Portland","OR",,,,"rfmcconville@gmail.com","Robert McConville","42008","1008192","3/5/2021 17:41"
-,"Chair/Co-Chair/President","Alameda","NECN","Travis","Weedman",,"Portland","OR",,,,"travis@weedmandesignpartners.com","Travis Weedman","42009","1008216","3/5/2021 17:53"
-,"Secretary","Alameda","NECN","Mariah","Dulah",,"Portland","OR","97212",,,,"Mariah Dulah","32227","290043","6/12/2018 13:58"
-,"Treasurer/Finance Committee Chair","Alameda","NECN","Charles","Rice",,"Portland","OR",,,,,"Charles Rice","37480","1236840","6/12/2018 13:59"
-,"Treasurer/Finance Committee Chair","Alameda","NECN","Charles","Rice",,"Portland","OR","97212",,,,"Charles Rice","4073","134409","6/12/2018 13:55"
-,"City Required Notice Contact/Co-Contact","Alameda","NECN","AlamedaNA","RequiredNoticeContact","2806 NE Bryce","Portland","OR","97212",,,"stevebacker@gmail.com","AlamedaNA RequiredNoticeContact","41112","1603368","3/9/2021 13:15"
-,"General correspondance","Alameda","NECN","AlamedaNA","GeneralCorrespondenceContact","2806 NE Bryce","Portland","OR","97212",,,"scottarider@gmail.com; alamedapdx@gmail.com","AlamedaNA GeneralCorrespondenceContact","41113","904486","6/12/2018 14:02"
-,"Chair/Co-Chair/President","Arbor Lodge","NPNS","Andrea","Matthews","2209 N. Schofield","Portland","OR","97217",,,"arborlodgeandrea@gmail.com","Andrea Matthews","41968","1007232","11/3/2020 15:07"
-,"Vice Chair/Vice President","Arbor Lodge","NPNS","Susan","Harris",,"Portland","OR",,,,"susangh345@gmail.com","Susan Harris","42022","1050550","3/22/2021 21:07"
-,"Secretary","Arbor Lodge","NPNS","Tommy","Styles",,"Portland","OR",,,,"tommy@tommystyles.com","Tommy Styles","41984","377856","12/16/2020 12:09"
-,"Land Use/Planning Committee Chair/Co-Chair","Arbor Lodge","NPNS","Dan","Craver",,"Portland","OR",,,,"landuse@arborlodgeneighborhood.com","Dan Craver","41686","1750812","11/2/2020 15:36"
-,"City Required Notice Contact/Co-Contact","Arbor Lodge","NPNS","ArborLodgeNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N Schofield","Portland","OR","97217",,,"landuse@arborlodgeneighborhood.com","ArborLodgeNA RequiredNoticeContact","40922","1595958","5/30/2017 14:37"
-,"General correspondance","Arbor Lodge","NPNS","ArborLodgeNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St","Portland","OR","97217",,,"board@arborlodgeneighborhood.com","ArborLodgeNA GeneralCorrespondenceContact","40923","900306","11/28/2017 15:11"
-,"Chair/Co-Chair/President","Ardenwald-Johnson Creek","SEUL","Matt","Rinker",,"Milwaukie","OR","97222",,,,"Matt Rinker","26947","646728","1/23/2019 13:20"
-,"Vice Chair/Vice President","Ardenwald-Johnson Creek","SEUL","Jeff","Davis",,"Milwaukie","OR","97222",,,,"Jeff Davis","33463","836575","1/23/2019 13:23"
-,"Treasurer/Finance Committee Chair","Ardenwald-Johnson Creek","SEUL","Mark","Taylor",,"Milwaukie","OR","97222",,,,"Mark Taylor","41441","1367553","9/26/2017 17:21"
-,"Land Use/Planning Committee Chair/Co-Chair","Ardenwald-Johnson Creek","SEUL","Lisa","Gunion-Rinker",,"Portland","OR","97222",,,"astrantialgr@gmail.com","Lisa Gunion-Rinker","30013","1260546","3/7/2018 13:45"
-,"City Required Notice Contact/Co-Contact","Ardenwald-Johnson Creek","SEUL","ArdenwaldJohnsonCrkNA","RequiredNoticeContact",,"Portland","OR",,,,,"ArdenwaldJohnsonCrkNA RequiredNoticeContact","41038","1600482","3/10/2017 10:33"
-,"General correspondance","Ardenwald-Johnson Creek","SEUL","ArdenwaldJohnsonCrkNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"ArdenwaldJohnsonCrkNA GeneralCorrespondenceContact","41039","902858","3/10/2017 10:33"
-,"Chair/Co-Chair/President","Argay","EPCO","Doug","Cook","PO Box 20635","Portland","OR","97294-0635",,,"doug.cook12@gmail.com","Doug Cook","39980","959520","12/17/2015 12:17"
-,"Vice Chair/Vice President","Argay","EPCO","Craig","Tolonen",,"Portland","OR",,,,"argayvpcraig@centurylink.net","Craig Tolonen","39981","999525","12/17/2015 12:21"
-,"Treasurer/Finance Committee Chair","Argay","EPCO","Bill","Lindekugel","14535 NE Rose Parkway","Portland","OR","97230",,,,"Bill Lindekugel","39313","1297329","7/14/2015 14:04"
-,"City Required Notice Contact/Co-Contact","Argay","EPCO","ArgayTerraceNA","RequiredNoticeContact",,"Portland","OR",,,,,"ArgayTerraceNA RequiredNoticeContact","41088","1602432","3/10/2017 12:17"
-,"General correspondance","Argay","EPCO","ArgayTerraceNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"ArgayTerraceNA GeneralCorrespondenceContact","41089","903958","3/10/2017 12:18"
-,"Chair/Co-Chair/President","Arlington Heights","NWNW","Kathy","Goeddel","c/o NWNW, 2257 NW Raleigh","Portland","OR","97210",,,"president@arlingtonheightspdx.org","Kathy Goeddel","39410","945840","12/6/2018 15:32"
-,"Chair/Co-Chair/President","Arlington Heights","NWNW","Kristi","Wuttig",,"Portland","OR",,,,"president@arlingtonheightspdx.org","Kristi Wuttig","41814","1003536","12/6/2018 15:38"
-,"Secretary","Arlington Heights","NWNW","Jim","Cameron",,"Portland","OR",,,,"planning@arlingtonheightspdx.org","Jim Cameron","41992","377928","1/14/2021 12:11"
-,"Treasurer/Finance Committee Chair","Arlington Heights","NWNW","Richard","Turner",,"Portland","OR",,,,"treasurer@arlingtonheightspdx.org","Richard Turner","41526","1370358","12/6/2018 15:33"
-,"Land Use/Planning Committee Chair/Co-Chair","Arlington Heights","NWNW","Kathy","Goeddel","c/o NWNW, 2257 NW Raleigh","Portland","OR","97210",,,"president@arlingtonheightspdx.org","Kathy Goeddel","39410","1655220","12/6/2018 15:32"
-,"Land Use/Planning Committee Chair/Co-Chair","Arlington Heights","NWNW","Jim","Cameron",,"Portland","OR",,,,"planning@arlingtonheightspdx.org","Jim Cameron","41992","1763664","1/14/2021 12:11"
-,"City Required Notice Contact/Co-Contact","Arlington Heights","NWNW","AHNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@arlingtonheightspdx.org","AHNA Required/General/CertifiedContact","40619","1584141","11/30/2016 18:39"
-,"General correspondance","Arlington Heights","NWNW","AHNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@arlingtonheightspdx.org","AHNA Required/General/CertifiedContact","40619","893618","11/30/2016 18:39"
-,"Land Use/Planning Committee Chair/Co-Chair","Arnold Creek","SWNI","Nancy","Mattson",,"Portland","OR",,,,"contact@arnoldcreek.org","Nancy Mattson","42040","1765680","4/28/2021 14:55"
-,"City Required Notice Contact/Co-Contact","Arnold Creek","SWNI","Arnold","Creek",,,"OR",,,,"contact@arnoldcreek.org","Arnold Creek","40980","1598220","5/25/2021 7:16"
-,"General correspondance","Arnold Creek","SWNI","Arnold","Creek",,,"OR",,,,"contact@arnoldcreek.org","Arnold Creek","40981","901582","5/25/2021 7:18"
-,"City Required Notice Contact/Co-Contact","Ashcreek","SWNI","AshcreekNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@ashcreekna.org","AshcreekNA RequiredNoticeContact","40983","1598337","8/7/2017 14:05"
-,"General correspondance","Ashcreek","SWNI","AshcreekNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@ashcreekna.org","AshcreekNA GeneralCorrespondenceContact","40984","901648","8/7/2017 14:08"
-,"Chair/Co-Chair/President","Beaumont-Wilshire","CNN","Tim","Gillespie","c/o CNN 4415 NE 87th Ave","Portland","OR","97220","(503) 287-6272",,"president@bwnapdx.org","Tim Gillespie","41962","1007088","1/5/2021 14:59"
-,"Vice Chair/Vice President","Beaumont-Wilshire","CNN","Andrew","Rinke","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"info@bwnapdx.org","Andrew Rinke","41963","1049075","5/24/2021 11:41"
-,"Secretary","Beaumont-Wilshire","CNN","Barbara","Strunk","c/o CNN, 4415 NE 87th Ave.","Portland","OR","97220","(503) 284-7502",,"secretary@bwnapdx.org","Barbara Strunk","41194","370746","12/15/2020 13:50"
-,"Treasurer/Finance Committee Chair","Beaumont-Wilshire","CNN","Karla","Lenox","c/o CNN, 4415 NE 87th Ave","Portland","OR","97220",,,"treasurer@bwnapdx.org","Karla Lenox","39171","1292643","3/22/2021 13:15"
-,"City Required Notice Contact/Co-Contact","Beaumont-Wilshire","CNN","Beaumont-Wilshire","NeighborhoodAssociation","c/o The Postal Station, 2000 NE 42nd Ave., Ste. #394","Portland","OR","97213-1397",,,"info@bwnapdx.org","Beaumont-Wilshire NeighborhoodAssociation","40952","1597128","3/22/2021 13:23"
-,"General correspondance","Beaumont-Wilshire","CNN","Beaumont-Wilshire","NeighborhoodAssociation","c/o The Postal Station, 2000 NE 42nd Ave., Ste. #394","Portland","OR","97213-1397",,,"info@bwnapdx.org","Beaumont-Wilshire NeighborhoodAssociation","40953","900966","3/22/2021 13:24"
-,"Chair/Co-Chair/President","Boise","NECN","Howard","Patterson",,"Portland","OR",,,,"boisena@gmail.com","Howard Patterson","41982","1007568","11/17/2020 18:51"
-,"Treasurer/Finance Committee Chair","Boise","NECN","Karis","Stoudamire",,"Portland","OR","97227",,,"karis@stoudamire.com","Karis Stoudamire","29076","959508","1/27/2011 9:58"
-,"Land Use/Planning Committee Chair/Co-Chair","Boise","NECN","Boise","Landuse",,"Portland","OR",,,,"boiselanduse@gmail.com","Boise Landuse","40183","1687686","5/3/2016 9:27"
-,"City Required Notice Contact/Co-Contact","Boise","NECN","BoiseNA","RequiredNoticeContact","c/o Kay Newell of Sunlan Lighting 3901 N. Mississippi Ave","Portland","OR","97227",,,,"BoiseNA RequiredNoticeContact","41115","1603485","3/13/2017 13:18"
-,"General correspondance","Boise","NECN","BoiseNA","GeneralCorrespondenceContact","c/o Kay Newell of Sunlan Lighting 3901 N. Mississippi Ave,","Portland","OR","97227",,,,"BoiseNA GeneralCorrespondenceContact","41116","904552","3/13/2017 13:20"
-,"Chair/Co-Chair/President","Brentwood-Darlington","SEUL","Shannon","Kane",,"Portland","OR",,,,,"Shannon Kane","41213","989112","12/9/2019 14:05"
-,"Chair/Co-Chair/President","Brentwood-Darlington","SEUL","Chelsea","Powers",,"Portland","OR","97206",,,,"Chelsea Powers","40632","975168","12/5/2016 14:14"
-,"Secretary","Brentwood-Darlington","SEUL","Stephenie","Frederickson",,,"OR",,,,"bdlanduse@gmail.com","Stephenie Frederickson","39413","354717","11/10/2020 14:01"
-,"Treasurer/Finance Committee Chair","Brentwood-Darlington","SEUL","Lynn","Reck",,"Portland","OR",,,,,"Lynn Reck","34496","1138368","12/9/2019 14:11"
-,"Land Use/Planning Committee Chair/Co-Chair","Brentwood-Darlington","SEUL","Stephenie","Frederickson",,,"OR",,,,"bdlanduse@gmail.com","Stephenie Frederickson","39413","1655346","11/10/2020 14:01"
-,"City Required Notice Contact/Co-Contact","Brentwood-Darlington","SEUL","BrentwoodDarlingtonNA","RequiredNoticeContact","7211 SE 62ND AVE","Portland","OR","97206",,,"bdlanduse@gmail.com","BrentwoodDarlingtonNA RequiredNoticeContact","40974","1597986","12/9/2019 14:12"
-,"General correspondance","Brentwood-Darlington","SEUL","BrentwoodDarlingtonNA","GeneralCorrespondenceContact","7211 SE 62nd Ave","Portland","OR","97206",,,,"BrentwoodDarlingtonNA GeneralCorrespondenceContact","40975","901450","11/10/2020 13:49"
-,"Chair/Co-Chair/President","Bridgeton","NPNS","Tom","Hickey","2209 N. Schofield","Portland","OR","97217",,,"hickeyt+bna.pdx@gmail.com","Tom  Hickey","41452","994848","10/16/2018 14:01"
-,"Secretary","Bridgeton","NPNS","Bridget","Bayer",,"Portland","OR",,,"(503) 290-4377","bridget@historicparkrose.com","Bridget Bayer","3660","32940","12/4/2017 14:53"
-,"Treasurer/Finance Committee Chair","Bridgeton","NPNS","Matthew","Whitney","2209 N. Schofield","Portland","OR","97217",,"(503) 823-4524","mattwhitney@comcast.net","Matthew Whitney","2798","92334","7/16/2015 14:17"
-,"City Required Notice Contact/Co-Contact","Bridgeton","NPNS","BridgetonNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield","Portland","OR","97217",,,"epmolander@gmail.com","BridgetonNA RequiredNoticeContact","40925","1596075","5/30/2017 14:22"
-,"General correspondance","Bridgeton","NPNS","BridgetonNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"hickeyt+bna.pdx@gmail.com","BridgetonNA GeneralCorrespondenceContact","40926","900372","10/17/2018 15:18"
-,"Land Use/Planning Committee Chair/Co-Chair","Bridlemile","SWNI","Claire","Coleman-Evans","6260 SW Hamilton Way","Portland","OR","97221",,,"eclaire27@comcast.net","Claire Coleman-Evans","36920","1550640","4/14/2021 17:56"
-,"City Required Notice Contact/Co-Contact","Bridlemile","SWNI","Claire","Coleman-Evans","6260 SW Hamilton Way","Portland","OR","97221",,,"eclaire27@comcast.net","Claire Coleman-Evans","36920","1439880","4/14/2021 17:56"
-,"General correspondance","Bridlemile","SWNI","BridlemileNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-bridlemile@swni.org","BridlemileNA GeneralCorrespondenceContact","40987","901714","8/7/2017 14:25"
-,"Chair/Co-Chair/President","Brooklyn","SEUL","Josh","Hetrick",,"Portland","OR",,,,"chair@brooklyn-neighborhood.org","Josh Hetrick","40449","970776","4/2/2021 18:28"
-,"Vice Chair/Vice President","Brooklyn","SEUL","Guy","Berliner",,"Portland","OR",,,,"board@brooklyn-neighborhood.org","Guy Berliner","37782","944550","4/2/2021 18:31"
-,"Secretary","Brooklyn","SEUL","John","Karabaic",,"Portland","OR",,,,"board@brooklyn-neighborhood.org","John Karabaic","41467","373203","4/2/2021 18:38"
-,"Treasurer/Finance Committee Chair","Brooklyn","SEUL","Tim","Walsh",,"Portland","OR",,,,"board@brooklyn-neighborhood.org","Tim Walsh","17573","579909","4/2/2021 18:39"
-,"Land Use/Planning Committee Chair/Co-Chair","Brooklyn","SEUL","Josh","Hetrick",,"Portland","OR",,,,"chair@brooklyn-neighborhood.org","Josh Hetrick","40449","1698858","4/2/2021 18:28"
-,"City Required Notice Contact/Co-Contact","Brooklyn","SEUL","BrooklynActionCorps","RequiredNoticeContact",,"Portland","OR",,,,,"BrooklynActionCorps RequiredNoticeContact","41042","1600638","3/10/2017 10:37"
-,"General correspondance","Brooklyn","SEUL","BrooklynActionCorps","GeneralCorrespondenceContact",,"Portland","OR",,,,,"BrooklynActionCorps GeneralCorrespondenceContact","41043","902946","3/10/2017 10:39"
-,"Chair/Co-Chair/President","Buckman","SEUL","Stephen","Fisher",,"Portland","OR",,,,"s3fisher@mac.com","Stephen Fisher","40450","970800","1/28/2021 11:49"
-,"Chair/Co-Chair/President","Buckman","SEUL","Susan","Lindsay",,"Portland","OR","97214",,,,"Susan Lindsay","1686","40464","1/26/2017 21:00"
-,"Land Use/Planning Committee Chair/Co-Chair","Buckman","SEUL","Josh","Baker",,"Portland","OR",,,,"buckmanlandusepdx@gmail.com","Josh Baker","40454","1699068","1/28/2021 11:50"
-,"Land Use/Planning Committee Chair/Co-Chair","Buckman","SEUL","Nick","Olson",,"Portland","OR",,,,"buckmanlandusepdx@gmail.com","Nick Olson","41998","1763916","1/28/2021 11:52"
-,"City Required Notice Contact/Co-Contact","Buckman","SEUL","Buckman Community Association","RequiredNoticeContact","3534 SE Main St.","Portland","OR","97214",,,,"Buckman Community Association RequiredNoticeContact","41045","1600755","12/28/2018 11:36"
-,"General correspondance","Buckman","SEUL","BuckmanCmtyAsso","GeneralCorrespondenceContact",,"Portland","OR",,,,,"BuckmanCmtyAsso GeneralCorrespondenceContact","41046","903012","3/10/2017 10:45"
-,"Chair/Co-Chair/President","Cathedral Park","NPNS","Jon","Smart",,"Portland","OR",,,"(503) 303-0990","chair@cathedralparkpdx.org","Jon Smart","41635","999240","6/23/2020 13:59"
-,"Secretary","Cathedral Park","NPNS","Nico","Smith",,"Portland","OR",,,,"smithofnico@gmail.com","Nico Smith","41579","374211","12/19/2017 13:21"
-,"Land Use/Planning Committee Chair/Co-Chair","Cathedral Park","NPNS","Steve","Capoccia",,"Portland","OR",,,,"cpna.landuse@gmail.com","Steve Capoccia","41795","1755390","3/25/2020 16:41"
-,"City Required Notice Contact/Co-Contact","Cathedral Park","NPNS","CathedralParkNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St","Portland","OR","97217",,,"scapoccia21@gmail.com","CathedralParkNA RequiredNoticeContact","40928","1596192","10/17/2018 15:20"
-,"General correspondance","Cathedral Park","NPNS","CathedralParkNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St","Portland","OR","97217",,,"chair@cathedralparkpdx.org","CathedralParkNA GeneralCorrespondenceContact","40929","900438","5/20/2021 14:43"
-,"Chair/Co-Chair/President","Centennial","EPCO","Daniel","Bramske",,"Portland","OR",,,,"dbramske@EMAarchitecture.com","Daniel Bramske","41896","1005504","9/6/2019 11:11"
-,"Secretary","Centennial","EPCO","Gayle","Palmer",,"Portland","OR",,,,,"Gayle Palmer","41897","377073","9/6/2019 11:10"
-,"Treasurer/Finance Committee Chair","Centennial","EPCO","Jessica","Edholm",,"Portland","OR",,,,,"Jessica Edholm","41898","1382634","9/6/2019 11:10"
-,"City Required Notice Contact/Co-Contact","Centennial","EPCO","CentennialCmtyAsso","RequiredNoticeContact",,"Portland","OR",,,,,"CentennialCmtyAsso RequiredNoticeContact","41091","1602549","3/10/2017 12:21"
-,"General correspondance","Centennial","EPCO","CentennialCmtyAsso","GeneralCorrespondenceContact",,"Portland","OR",,,,,"CentennialCmtyAsso GeneralCorrespondenceContact","41092","904024","3/10/2017 12:21"
-,"Secretary","Collins View","SWNI","Maryellen","Read",,"Portland","OR",,,,"maryellenread@gmail.com","Maryellen Read","39253","353277","4/15/2021 17:56"
-,"Land Use/Planning Committee Chair/Co-Chair","Collins View","SWNI","Maryellen","Read",,"Portland","OR",,,,"maryellenread@gmail.com","Maryellen Read","39253","1648626","4/15/2021 17:56"
-,"City Required Notice Contact/Co-Contact","Collins View","SWNI","CollinsViewNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@collinsview.org","CollinsViewNA RequiredNoticeContact","40989","1598571","8/14/2017 12:43"
-,"General correspondance","Collins View","SWNI","CollinsViewNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@collinsview.org","CollinsViewNA GeneralCorrespondenceContact","40990","901780","8/14/2017 12:45"
-,"Chair/Co-Chair/President","Concordia","NECN","Astrid","Furstner",,"Portland","OR",,,,"astrid.b.furstner@gmail.com","Astrid Furstner","41934","1006416","1/6/2020 11:32"
-,"Vice Chair/Vice President","Concordia","NECN","Garlynn","Woodsong","5267 NE 29th Ave.","Portland","OR","97211","(503) 936-9873",,"landuse@concordiapdx.org","Garlynn Woodsong","38663","966575","8/16/2017 9:24"
-,"Secretary","Concordia","NECN","Steve","Elder","4910 NE 34th Ave","Portland","OR","97211",,,"east2@concordiapdx.org","Steve Elder","22885","205965","1/10/2020 15:04"
-,"Treasurer/Finance Committee Chair","Concordia","NECN","Heather","Pashley",,"Portland","OR",,,,"Treasurer@concordiapdx.org","Heather Pashley","41344","1364352","8/15/2017 15:45"
-,"Land Use/Planning Committee Chair/Co-Chair","Concordia","NECN","Garlynn","Woodsong","5267 NE 29th Ave.","Portland","OR","97211","(503) 936-9873",,"landuse@concordiapdx.org","Garlynn Woodsong","38663","1623846","8/16/2017 9:24"
-,"City Required Notice Contact/Co-Contact","Concordia","NECN","Garlynn","Woodsong","5267 NE 29th Ave.","Portland","OR","97211","(503) 936-9873",,"landuse@concordiapdx.org","Garlynn Woodsong","38663","1507857","8/16/2017 9:24"
-,"General correspondance","Concordia","NECN","Astrid","Furstner","PO Box 11194","Portland","OR","97211","(503) 290-6871",,"Chair@concordiapdx.org","Astrid Furstner","41119","904618","1/6/2020 11:48"
-,"Chair/Co-Chair/President","Creston-Kenilworth","SEUL","Rachel","Davies",,"Portland","OR",,,,"ckna.chair@gmail.com","Rachel Davies","34631","831144","12/16/2020 13:27"
-,"Secretary","Creston-Kenilworth","SEUL","Charles (Charley)","Brody",,"Portland","OR",,,,"charles.brody@gmail.com","Charles (Charley) Brody","41196","370764","12/16/2020 13:30"
-,"Treasurer/Finance Committee Chair","Creston-Kenilworth","SEUL","Darian","Davies",,"Portland","OR",,,,"daviesfamily@comcast.net","Darian Davies","36254","1196382","12/21/2020 19:13"
-,"Land Use/Planning Committee Chair/Co-Chair","Creston-Kenilworth","SEUL","Seth","Otto",,"Portland","OR",,,,"ckna.landchair@gmail.com","Seth Otto","40260","1690920","12/16/2020 13:21"
-,"City Required Notice Contact/Co-Contact","Creston-Kenilworth","SEUL","Creston-KenilworthNA","RequiredNoticeContact",,"Portland","OR",,,,,"Creston-KenilworthNA RequiredNoticeContact","41048","1600872","3/10/2017 10:49"
-,"General correspondance","Creston-Kenilworth","SEUL","Creston-KenilworthNA","GeneralCorrespondenceContact","3586 SE 26th Ave","Portland","OR","97202",,,,"Creston-KenilworthNA GeneralCorrespondenceContact","41049","903078","12/12/2018 14:23"
-,"Chair/Co-Chair/President","Crestwood","SWNI","Tony","Hansen","10450 SW 55th Ave.","Portland","OR","97219","(503) 317-3914",,"atonehansen@gmail.com","Tony Hansen","31465","755160","4/15/2021 17:04"
-,"Vice Chair/Vice President","Crestwood","SWNI","Marianne","Fitzgerald","10537 SW 64th Drive","Portland","OR","97219","(503) 246-1847",,"fitzgerald.marianne@gmail.com","Marianne Fitzgerald","12439","310975","2/8/2017 13:10"
-,"Secretary","Crestwood","SWNI","Charles","Mosley",,"Portland","OR",,,,"chasm61@gmail.com","Charles Mosley","42039","378351","4/15/2021 17:09"
-,"Treasurer/Finance Committee Chair","Crestwood","SWNI","Charles","Mosley",,"Portland","OR",,,,"chasm61@gmail.com","Charles Mosley","42039","1387287","4/15/2021 17:09"
-,"General correspondance","Crestwood","SWNI","Tony","Hansen","10450 SW 55th Ave.","Portland","OR","97219","(503) 317-3914",,"atonehansen@gmail.com","Tony Hansen","31465","692230","4/15/2021 17:04"
-,"Chair/Co-Chair/President","Cully","CNN","Josh","Heumann@gmail.com","c/o CNN 4415 NE 87th Ave","Portland","OR","97220","(503) 853-0771",,"heumann@gmail.com","Josh Heumann@gmail.com","41862","1004688","9/30/2020 13:10"
-,"Secretary","Cully","CNN","Maria","Grzanka","4415 NE 87th Ave","Portland","OR","97220",,,,"Maria Grzanka","42044","378396","4/21/2021 13:17"
-,"Treasurer/Finance Committee Chair","Cully","CNN","Vena","Rainwater","4415 NE 87th Ave","Portland","OR","97220",,,,"Vena Rainwater","42045","1387485","4/21/2021 13:18"
-,"Land Use/Planning Committee Chair/Co-Chair","Cully","CNN","David","Sweet","4759 NE Going St.","Portland","OR","97218","(503) 493-9434",,"cullyguy@gmail.com","David Sweet","2983","125286","12/13/2016 16:42"
-,"City Required Notice Contact/Co-Contact","Cully","CNN","CullyAN","RequiredNoticeContact","4415 NE 87th Ave.","Portland","OR","97220",,,"cully@cullyneighbors.org","CullyAN RequiredNoticeContact","40692","1586988","1/4/2017 14:08"
-,"General correspondance","Cully","CNN","CullyAN","GeneralCorrespondenceContact","4415 NE 87th Ave.","Portland","OR","97220",,,"cully@cullyneighbors.org","CullyAN GeneralCorrespondenceContact","40693","895246","1/4/2017 14:10"
-,"Chair/Co-Chair/President","East Columbia","NPNS","Gary","Kunz",,"Portland","OR",,,,"garymkunz@comcast.net","Gary Kunz","39297","943128","11/3/2020 15:20"
-,"Treasurer/Finance Committee Chair","East Columbia","NPNS","Karen","Myers","2018 NE Blue Heron Dr.","Portland","OR","97211","(503) 240-4418","(503) 853-6239","rrmyers2018@msn.com","Karen Myers","31749","1047717","1/14/2009 0:00"
-,"Land Use/Planning Committee Chair/Co-Chair","East Columbia","NPNS","Maryhelen","Kincaid","2030 NE Blue Heron DR","Portland","OR","97211-1680",,,"jamasu88@msn.com","Maryhelen Kincaid","39305","1650810","5/3/2016 13:41"
-,"City Required Notice Contact/Co-Contact","East Columbia","NPNS","EastColumbiaNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"garykunz@comcast.net","EastColumbiaNA RequiredNoticeContact","40931","1596309","9/18/2017 12:43"
-,"General correspondance","East Columbia","NPNS","EastColumbiaNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"garykunz@comcast.net","EastColumbiaNA GeneralCorrespondenceContact","40932","900504","9/18/2017 12:43"
-,"Chair/Co-Chair/President","Eastmoreland","SEUL","Rod","Merrick",,"Portland","OR","97202",,,"president@eastmorelandpdx.org","Rod Merrick","16881","405144","3/19/2018 13:14"
-,"Vice Chair/Vice President","Eastmoreland","SEUL","Matthew","Timberlake",,"Portland","OR",,,,"vicepresident@eastmorelandpdx.org","Matthew Timberlake","39449","986225","2/10/2020 12:44"
-,"Secretary","Eastmoreland","SEUL","Dina","Adkins",,"Portland","OR",,,,"secretary@eastmorelandpdx.org","Dina Adkins","41746","375714","2/10/2020 12:50"
-,"Treasurer/Finance Committee Chair","Eastmoreland","SEUL","David","Dowell",,"Portland","OR",,,,"treasurer@eastmorelandpdx.org","David Dowell","41324","1363692","5/10/2021 16:16"
-,"Land Use/Planning Committee Chair/Co-Chair","Eastmoreland","SEUL","Rod","Merrick",,"Portland","OR","97202",,,"president@eastmorelandpdx.org","Rod Merrick","16881","709002","3/19/2018 13:14"
-,"City Required Notice Contact/Co-Contact","Eastmoreland","SEUL","EastmorelandNA","RequiredNoticeContact","3627 SE Cooper St.","Portland","OR","97202",,,"president@eastmorelandpdx.org","EastmorelandNA RequiredNoticeContact","40977","1598103","5/6/2021 16:34"
-,"General correspondance","Eastmoreland","SEUL","EastmorelandNA","GeneralCorrespondenceContact","PO Box 82520","Portland","OR","97282",,,,"EastmorelandNA GeneralCorrespondenceContact","40978","901516","11/15/2017 15:19"
-,"Chair/Co-Chair/President","Eliot","NECN","Jimmy","Wilson",,"Portland","OR",,,,"chair@eliotneighborhood.org","Jimmy  Wilson","41926","1006224","12/16/2019 14:03"
-,"Chair/Co-Chair/President","Eliot","NECN","Allan","Rudwick","228 NE Morris St","Portland","OR","97212","(503) 703-3910",,"chair@eliotneighborhood.org","Allan Rudwick","2049","49176","12/16/2019 14:04"
-,"Secretary","Eliot","NECN","Jennifer","Wilcox",,"Portland","OR",,,,"jennifer.wilcox@cascadiabhc.org","Jennifer Wilcox","41927","377343","12/16/2019 14:06"
-,"Treasurer/Finance Committee Chair","Eliot","NECN","Jim","Hlava",,"Portland","OR",,,,"jim.hlava@cascadiabhc.org  treasurer@eliotneighborhood.org","Jim Hlava","7827","258291","12/16/2019 14:11"
-,"Land Use/Planning Committee Chair/Co-Chair","Eliot","NECN","Brad","Baker",,"Portland","OR",,,,"lutcchair@eliotneighborhood.org info@eliotneighborhood.org","Brad  Baker","41907","1760094","12/17/2019 17:39"
-,"Land Use/Planning Committee Chair/Co-Chair","Eliot","NECN","Jonathan","Konkol",,"Portland","OR","97212",,,"info@eliotneighborhood.org","Jonathan Konkol","37121","1559082","12/17/2019 17:39"
-,"City Required Notice Contact/Co-Contact","Eliot","NECN","EliotNA","RequiredNoticeContact","C/o Jimmy Wilson 634 ne church st. Portland Or 97211","Portland","OR","97212",,,,"EliotNA RequiredNoticeContact","41121","1603719","12/19/2019 10:25"
-,"City Required Notice Contact/Co-Contact","Far Southwest","SWNI","FarSWNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@farswpdx.org","FarSWNA RequiredNoticeContact","40995","1598805","8/7/2017 14:48"
-,"General correspondance","Far Southwest","SWNI","FarSWNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@farswpdx.org","FarSWNA GeneralCorrespondenceContact","40996","901912","8/7/2017 14:50"
-,"Chair/Co-Chair/President","Forest Park","NWNW","Carol","Chesarek",,"Portland","OR","97231",,,"president@forestparkneighbors.org","Carol Chesarek","22626","543024","12/18/2017 19:14"
-,"Vice Chair/Vice President","Forest Park","NWNW","Susan","Andrews",,"Portland","OR",,,,"sgoldfield@aol.com","Susan Andrews","41153","1028825","3/22/2017 13:31"
-,"Treasurer/Finance Committee Chair","Forest Park","NWNW","Les","Blaize","9630 NW Skyline Blvd.","Portland","OR","97231","(503) 286-2206",,"lblaize@q.com","Les Blaize","2218","73194","3/25/2016 9:36"
-,"Land Use/Planning Committee Chair/Co-Chair","Forest Park","NWNW","Jerry","Grossnickle","13510 NW Old Germantown Rd","Portland","OR","97231","(503) 289-3046",,"landuse@forestparkneighbors.org","Jerry Grossnickle","33849","1421658","10/4/2019 11:18"
-,"City Required Notice Contact/Co-Contact","Forest Park","NWNW","FPNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@forestparkneighbors.org","FPNA Required/General/CertifiedContact","40620","1584180","11/30/2016 18:45"
-,"General correspondance","Forest Park","NWNW","FPNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@forestparkneighbors.org","FPNA Required/General/CertifiedContact","40620","893640","11/30/2016 18:45"
-,"Chair/Co-Chair/President","Foster-Powell","SEUL","Sean","McClintock",,,"OR",,,,"chair@fosterpowell.com","Sean McClintock","40138","963312","11/10/2020 13:08"
-,"Secretary","Foster-Powell","SEUL","Katie","Ash",,"Portland","OR",,,,"secretary@fosterpowell.com","Katie Ash","40313","362817","11/10/2020 13:10"
-,"Treasurer/Finance Committee Chair","Foster-Powell","SEUL","Bruce","Obog",,"Portland","OR",,,,"treasurer@fosterpowell.com","Bruce Obog","41299","1362867","11/10/2020 13:12"
-,"Land Use/Planning Committee Chair/Co-Chair","Foster-Powell","SEUL","Joseph","Liu",,"Portland","OR",,,,"land.use@fosterpowell.com","Joseph Liu","39555","1661310","12/1/2020 13:48"
-,"City Required Notice Contact/Co-Contact","Foster-Powell","SEUL","Foster-Powell Neighborhood Association","c/o SE Uplift","3534 SE Main St","Portland","OR","97214",,,"contact@fosterpowell.com","Foster-Powell Neighborhood Association c/o SE Uplift","41052","1601028","11/10/2020 13:20"
-,"General correspondance","Foster-Powell","SEUL","Foster-Powell Neighborhood Association","c/o SE Uplift","3534 SE Main St","Portland","OR","97214",,,"contact@fosterpowell.com","Foster-Powell Neighborhood Association c/o SE Uplift","41053","903166","11/10/2020 13:21"
-,"Chair/Co-Chair/President","Glenfair","EPCO","Yoana","Molina",,"Portland","OR",,,,"chair@glenfairneighborhood.org","Yoana  Molina","41835","1004040","3/18/2019 16:48"
-,"City Required Notice Contact/Co-Contact","Glenfair","EPCO","GlenfairNA","RequiredNoticeContact","c/o EPCO, 1017 NE 117th Ave","Portland","OR","97220",,,,"GlenfairNA RequiredNoticeContact","41094","1602666","3/18/2019 15:23"
-,"General correspondance","Glenfair","EPCO","GlenfairNA","GeneralCorrespondenceContact","c/o EPCO , 1017 NE 117th Ave","Portland","OR","97220",,,,"GlenfairNA GeneralCorrespondenceContact","41095","904090","3/18/2019 15:23"
-,"Chair/Co-Chair/President","Goose Hollow","NWNW","Tracy","Prince",,,,,,,"vice-chair@goosehollow.org","Tracy Prince","26442","634608","11/28/2017 13:17"
-,"Vice Chair/Vice President","Goose Hollow","NWNW","Jerry","Powell","1926 SW Madison St.","Portland","OR","97205-1718",,"(503) 222-7173","planning@goosehollow.org","Jerry Powell","1212","30300","5/15/2015 13:34"
-,"Secretary","Goose Hollow","NWNW","Eva","Kutas",,"Portland","OR",,,,"secretary@goosehollow.org","Eva Kutas","41935","377415","1/17/2020 16:29"
-,"Treasurer/Finance Committee Chair","Goose Hollow","NWNW","Bridget","Bimrose","1535 SW Clay St. #216","Portland","OR","97201","(503) 853-2362",,"bridgetbimrose@gmail.com","Bridget Bimrose","41790","1379070","10/9/2018 20:09"
-,"Land Use/Planning Committee Chair/Co-Chair","Goose Hollow","NWNW","Jerry","Powell","1926 SW Madison St.","Portland","OR","97205-1718",,"(503) 222-7173","planning@goosehollow.org","Jerry Powell","1212","50904","5/15/2015 13:34"
-,"Land Use/Planning Committee Chair/Co-Chair","Goose Hollow","NWNW","Scott","Schaffer",,"Portland","OR","97201",,,"planning@goosehollow.org","Scott Schaffer","33483","1406286","1/17/2020 16:32"
-,"City Required Notice Contact/Co-Contact","Goose Hollow","NWNW","GHFL","Required/General/CertifiedContact","2257 NW Raleigh St","Portland","OR","97210",,"(503) 823-4288","board@goosehollow.org","GHFL Required/General/CertifiedContact","40621","1584219","12/2/2016 13:42"
-,"General correspondance","Goose Hollow","NWNW","GHFL","Required/General/CertifiedContact","2257 NW Raleigh St","Portland","OR","97210",,"(503) 823-4288","board@goosehollow.org","GHFL Required/General/CertifiedContact","40621","893662","12/2/2016 13:42"
-,"Chair/Co-Chair/President","Grant Park","CNN","Ron","Laster","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"printresults@aol.com","Ron Laster","2936","70464","9/30/2020 12:28"
-,"Vice Chair/Vice President","Grant Park","CNN","Ron","Laster","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"printresults@aol.com","Ron Laster","2936","73400","9/30/2020 12:28"
-,"Treasurer/Finance Committee Chair","Grant Park","CNN","Ron","Laster","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"printresults@aol.com","Ron Laster","2936","96888","9/30/2020 12:28"
-,"City Required Notice Contact/Co-Contact","Grant Park","CNN","GrantParkNA","RequiredNoticeContact","4415 NE 87th Ave","Portland","OR","97220",,,,"GrantParkNA RequiredNoticeContact","40956","1597284","4/21/2021 13:25"
-,"General correspondance","Grant Park","CNN","GrantParkNA","GeneralCorrespondenceContact","4415 NE 87th Ave","Portland","OR","97220",,,,"GrantParkNA GeneralCorrespondenceContact","40957","901054","4/21/2021 13:26"
-,"Chair/Co-Chair/President","Hayden Island","NPNS","Marty","Slapikas",,"Portland","OR",,,,"slapikasm@msn.com","Marty Slapikas","41970","1007280","5/17/2021 12:41"
-,"Treasurer/Finance Committee Chair","Hayden Island","NPNS","Patricia","Buescher",,"Portland","OR",,,,"PB@furzwo.com","Patricia Buescher","42050","1387650","5/17/2021 12:33"
-,"Land Use/Planning Committee Chair/Co-Chair","Hayden Island","NPNS","Marty","Slapikas",,"Portland","OR",,,,"slapikasm@msn.com","Marty Slapikas","41970","1762740","5/17/2021 12:41"
-,"City Required Notice Contact/Co-Contact","Hayden Island","NPNS","HINooN","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St","Portland","OR","97217",,,"slapikasm@msn.com","HINooN RequiredNoticeContact","40934","1596426","5/17/2021 12:43"
-,"General correspondance","Hayden Island","NPNS","HINooN","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"slapikasm@msncom","HINooN GeneralCorrespondenceContact","40935","900570","5/17/2021 12:45"
-,"City Required Notice Contact/Co-Contact","Hayhurst","SWNI","HayhurstNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-hayhurst@swni.org","HayhurstNA RequiredNoticeContact","40998","1598922","8/7/2017 15:01"
-,"General correspondance","Hayhurst","SWNI","HayhurstNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-hayhurst@swni.org","HayhurstNA GeneralCorrespondenceContact","40999","901978","8/7/2017 15:03"
-,"Chair/Co-Chair/President","Hazelwood","EPCO","Arlene","Kimura",,"Portland","OR","97230",,,"arlene.kimura@gmail.com","Arlene Kimura","1492","35808","3/10/2015 12:05"
-,"Treasurer/Finance Committee Chair","Hazelwood","EPCO","Iris","Newhouse",,"Portland","OR","97220",,,"newhouseiris@gmail.com","Iris Newhouse","31847","1050951","9/25/2015 12:40"
-,"Land Use/Planning Committee Chair/Co-Chair","Hazelwood","EPCO","Arlene","Kimura",,"Portland","OR","97230",,,"arlene.kimura@gmail.com","Arlene Kimura","1492","62664","3/10/2015 12:05"
-,"City Required Notice Contact/Co-Contact","Hazelwood","EPCO","HazelwoodNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"arlene.kimura@gmail.com","HazelwoodNA RequiredNoticeContact","41097","1602783","3/23/2017 9:19"
-,"General correspondance","Hazelwood","EPCO","HazelwoodNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"arlene.kimura@gmail.com","HazelwoodNA GeneralCorrespondenceContact","41098","904156","3/23/2017 9:20"
-,"Vice Chair/Vice President","Healy Heights","Non-Coalition","Mason","Van Buren","4273 SW Council Crest Dr.","Portland","OR","97239","(503) 223-1864",,"masonvanburen@comcast.net","Mason Van Buren","31725","793125","12/16/2008 0:00"
-,"Treasurer/Finance Committee Chair","Healy Heights","Non-Coalition","Sarah","Ferguson",,,,,"(503) 233-4087",,,"Sarah Ferguson","37235","1228755","3/19/2012 13:53"
-,"City Required Notice Contact/Co-Contact","Healy Heights","Non-Coalition","HealyHeightsNA","RequiredNoticeContact",,"Portland","OR",,,,,"HealyHeightsNA RequiredNoticeContact","41032","1600248","3/10/2017 9:22"
-,"General correspondance","Healy Heights","Non-Coalition","HealyHeightsNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"HealyHeightsNA GeneralCorrespondenceContact","41033","902726","3/10/2017 9:23"
-,"City Required Notice Contact/Co-Contact","Hillsdale","SWNI","HillsdaleNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@hna-pdx.com","HillsdaleNA RequiredNoticeContact","41001","1599039","1/5/2018 10:03"
-,"General correspondance","Hillsdale","SWNI","HillsdaleNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@hna-pdx.com","HillsdaleNA GeneralCorrespondenceContact","41002","902044","11/6/2017 12:25"
-,"Chair/Co-Chair/President","Hillside","NWNW","Jim","Olsson",,"Portland","OR",,,,"president@hillsidena.org","Jim Olsson","41983","1007592","11/30/2020 15:39"
-,"Vice Chair/Vice President","Hillside","NWNW","Kevin","Kohnstamm","3002 NW Luray Circus","Portland","OR","97210",,,"kevin.kohnstamm@comcast.net","Kevin Kohnstamm","41200","1030000","12/1/2017 15:50"
-,"Treasurer/Finance Committee Chair","Hillside","NWNW","Scott","Miller",,"Portland","OR",,,,"scott@holthomes.com","Scott Miller","41352","1364616","8/11/2017 17:09"
-,"Land Use/Planning Committee Chair/Co-Chair","Hillside","NWNW","Kevin","Kohnstamm","3002 NW Luray Circus","Portland","OR","97210",,,"kevin.kohnstamm@comcast.net","Kevin Kohnstamm","41200","1730400","12/1/2017 15:50"
-,"City Required Notice Contact/Co-Contact","Hillside","NWNW",,"Hillside NA Required/GeneralContact","2257 NW Raleigh St.","Portland","OR","97210",,,"president@hillsidena.org","Hillside NA","40631","1584609","12/3/2020 13:31"
-,"City Required Notice Contact/Co-Contact","Hillside","NWNW","Kevin","Kohnstamm","3002 NW Luray Circus","Portland","OR","97210",,,"kevin.kohnstamm@comcast.net","Kevin Kohnstamm","41200","1606800","12/1/2017 15:50"
-,"General correspondance","Hillside","NWNW",,"Hillside NA Required/GeneralContact","2257 NW Raleigh St.","Portland","OR","97210",,,"president@hillsidena.org","Hillside NA","40631","893882","12/3/2020 13:31"
-,"Vice Chair/Vice President","Hollywood","CNN","Steve","Colburn","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"stevecolburn3@gmail.com","Steve Colburn","41822","1045550","3/16/2021 12:18"
-,"Secretary","Hollywood","CNN","Peter","Sysyn","4415 NE 87th Ave","Portland","OR","97220","(971) 266-8667",,"psysyn1@gmail.com","Peter Sysyn","42017","378153","3/16/2021 12:34"
-,"Treasurer/Finance Committee Chair","Hollywood","CNN","Ian","Timm","P.O. BOX 13308","Portland","OR","97213","(503) 288-9822",,"istimm@pacifier.com","Ian Timm","5413","178629","10/1/2020 13:24"
-,"Land Use/Planning Committee Chair/Co-Chair","Hollywood","CNN","Jo","Schaefer",,"Portland","OR","97220","(503) 351-7271",,"jaschaef@comcast.net","Jo Schaefer","30920","1298640","1/6/2021 11:41"
-,"City Required Notice Contact/Co-Contact","Hollywood","CNN","HollywoodNA","RequiredNoticeContact","4415 NE 87th Ave","Portland","OR","97220",,,,"HollywoodNA RequiredNoticeContact","40959","1597401","4/21/2021 13:29"
-,"General correspondance","Hollywood","CNN","HollywoodNA","GeneralCorrespondenceContact","4415 NE 87th Ave","Portland","OR","97220",,,,"HollywoodNA GeneralCorrespondenceContact","40960","901120","4/21/2021 13:29"
-,"Chair/Co-Chair/President","Homestead","SWNI","Ed","Fischer","3404 SW 13th Ave.","Portland","OR","97239",,,"edfischer8@gmail.com","Ed Fischer","37778","906672","4/14/2021 18:15"
-,"Vice Chair/Vice President","Homestead","SWNI","Jackie","Phillips","4205 SW View Point Terrace","Portland","OR","97239","(503) 449-9687",,"Inning2@comcast.net","Jackie Phillips","2487","62175","4/14/2021 18:19"
-,"Secretary","Homestead","SWNI","Lee","Buhler","127 SW Hamilton St.","Portland","OR","97239","(503) 227-0160",,"leebuhler@gmail.com","Lee Buhler","5947","53523","4/14/2021 18:27"
-,"Treasurer/Finance Committee Chair","Homestead","SWNI","Aaron","Clemons","3435 SW 12th Ave.","Portland","OR","97219-2457","(503) 234-9357",,"clemonsa@comcast.net","Aaron Clemons","38644","1275252","4/14/2021 18:31"
-,"Land Use/Planning Committee Chair/Co-Chair","Homestead","SWNI","Milt","Jones",,"Portland","OR",,,,"mjones@miltjones.com","Milt Jones","37779","1586718","4/15/2021 17:59"
-,"City Required Notice Contact/Co-Contact","Homestead","SWNI","HomesteadNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"land-use@homesteadna.org","HomesteadNA RequiredNoticeContact","41004","1599156","11/6/2017 18:47"
-,"General correspondance","Homestead","SWNI","Elizabeth","Hinds","2545 SW Terwilliger Blvd, Apt 1221","Portland","OR","97201","(503) 808-7458",,"hindseliz@gmail.com","Elizabeth Hinds","42035","924770","4/14/2021 18:56"
-,"General correspondance","Homestead","SWNI","Michael","Harrison","3181 SW Sam Jackson Park Road","Portland","OR","97239","(503) 381-8539",,"harmicha@ohsu.edu","Michael Harrison","2177","47894","4/15/2021 16:34"
-,"Chair/Co-Chair/President","Hosford-Abernethy","SEUL","Christopher","Eycamp",,"Portland","OR",,,,"chair@handpdx.org","Christopher Eycamp","41855","1004520","4/30/2019 8:22"
-,"Vice Chair/Vice President","Hosford-Abernethy","SEUL","Mark","Linehan",,"Portland","OR",,,,"mhl@mlinehan.us","Mark Linehan","41735","1043375","6/22/2018 8:08"
-,"Secretary","Hosford-Abernethy","SEUL","Jill","Riebesehl",,"Portland","OR","97202",,,,"Jill Riebesehl","41473","373257","10/23/2017 16:35"
-,"Treasurer/Finance Committee Chair","Hosford-Abernethy","SEUL","Jonathan","Adams",,"Portland","OR","97202",,,,"Jonathan Adams","40389","1332837","9/6/2016 15:52"
-,"Land Use/Planning Committee Chair/Co-Chair","Hosford-Abernethy","SEUL","Michael","Wade",,"Portland","OR",,,,"wade.michael@comcast.net","Michael Wade","17566","737772","1/23/2019 14:03"
-,"City Required Notice Contact/Co-Contact","Hosford-Abernethy","SEUL","HAND","RequiredNoticeContact","c/o SE Uplift, 3534 SE Main St.","Portland","OR","97214",,,"chair@handpdx.org","HAND RequiredNoticeContact","41055","1601145","10/17/2017 12:29"
-,"General correspondance","Hosford-Abernethy","SEUL","HAND","GeneralCorrespondenceContact","2101 SE Tibbetts","Portland","OR","97202",,,,"HAND GeneralCorrespondenceContact","41056","903232","6/22/2018 10:53"
-,"Chair/Co-Chair/President","Humboldt","NECN","Kymberly","Jeka",,"Portland","OR",,,,"HNAnews@gmail.com","Kymberly Jeka","37470","899280","7/7/2020 12:46"
-,"Vice Chair/Vice President","Humboldt","NECN","John","Ollis",,"Portland","OR",,,,"solchild@gmail.com","John Ollis","41806","1045150","7/7/2020 12:47"
-,"Secretary","Humboldt","NECN","Alicia","Richards",,"Portland","OR",,,,"aliciarichards60@gmail.com","Alicia Richards","41807","376263","11/14/2018 13:47"
-,"Land Use/Planning Committee Chair/Co-Chair","Humboldt","NECN","John","Ollis",,"Portland","OR",,,,"solchild@gmail.com","John Ollis","41806","1755852","7/7/2020 12:47"
-,"City Required Notice Contact/Co-Contact","Humboldt","NECN","HumboldtNA","RequiredNoticeContact","c/o Northeast Coalition of Neighborhoods, 4815 NE 7th Ave","Portland","OR","97211",,,,"HumboldtNA RequiredNoticeContact","41124","1603836","3/13/2017 13:14"
-,"General correspondance","Humboldt","NECN","HumboldtNA","GeneralCorrespondenceContact","c/o Northeast Coalition of Neighborhoods, 4815 NE 7th Ave","Portland","OR","97211",,,,"HumboldtNA GeneralCorrespondenceContact","41125","904750","3/13/2017 13:14"
-,"Chair/Co-Chair/President","Irvington","NECN","Steven","Cole",,"Portland","OR","97212",,,"stevencole86@gmail.com","Steven Cole","37518","900432","3/18/2014 10:09"
-,"Chair/Co-Chair/President","Irvington","NECN","Peter","O'Neil",,"Portland","OR",,,,"poneil@realtytrust.com","Peter O'Neil","37604","902496","1/23/2017 15:21"
-,"Secretary","Irvington","NECN","Doug","Cooke",,"Portland","OR",,,,"secretary@irvingtonpdx.com","Doug Cooke","41690","375210","7/29/2019 15:45"
-,"Treasurer/Finance Committee Chair","Irvington","NECN","Jim","Barta",,,,,"(503) 544-2429",,"jbarta@securasite.net","Jim Barta","33665","1110945","10/27/2011 11:59"
-,"Land Use/Planning Committee Chair/Co-Chair","Irvington","NECN","Dean","Gisvold","2225 NE 15th Ave","Portland","OR","97212",,,"deang@mcewengisvold.com","Dean Gisvold","23085","969570","6/25/2007 0:00"
-,"City Required Notice Contact/Co-Contact","Irvington","NECN","IrvingtonCmtyAsso","RequiredNoticeContact","PO Box 12102,","Portland","OR","97212",,,,"IrvingtonCmtyAsso RequiredNoticeContact","41127","1603953","3/13/2017 13:26"
-,"General correspondance","Irvington","NECN","IrvingtonCmtyAsso","GeneralCorrespondenceContact","PO Box 12102","Portland","OR","97212",,,,"IrvingtonCmtyAsso GeneralCorrespondenceContact","41128","904816","3/13/2017 13:27"
-,"Chair/Co-Chair/President","Kenton","NPNS","Tyler","Roppe","2209 N. Schofield","Portland","OR","97217",,,"knachair@gmail.com","Tyler Roppe","40251","966024","7/6/2016 11:57"
-,"Chair/Co-Chair/President","Kenton","NPNS","Terrance","Moses","7735 N Brandon Ave.","Portland","OR","97217","(503) 490-2598",,"knachair@gmail.com","Terrance Moses","40647","975528","11/3/2020 17:59"
-,"Treasurer/Finance Committee Chair","Kenton","NPNS","Angela","Moos",,"Portland","OR","97217",,,"amoos49@comcast.net","Angela Moos","32381","1068573","5/12/2011 9:57"
-,"City Required Notice Contact/Co-Contact","Kenton","NPNS","KentonNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St","Portland","OR","97217",,,"knalanduse@gmail.com","KentonNA RequiredNoticeContact","40937","1596543","5/30/2017 14:19"
-,"General correspondance","Kenton","NPNS","KentonNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"knachair@gmail.com","KentonNA GeneralCorrespondenceContact","40938","900636","5/30/2017 14:20"
-,"Chair/Co-Chair/President","Kerns","SEUL","Jay","Harris",,"Portland","OR",,,,"rhythmmon@mindspring.com","Jay Harris","20908","501792","5/26/2021 13:05"
-,"Vice Chair/Vice President","Kerns","SEUL","Dave","Weaver",,"Portland","OR",,,,"dave@webais.com","Dave  Weaver","41181","1029525","5/26/2021 13:05"
-,"Secretary","Kerns","SEUL","Gretchen","Hollands",,"Portland","OR",,,,"wghollands@comcast.net","Gretchen Hollands","41730","375570","5/26/2021 13:06"
-,"Treasurer/Finance Committee Chair","Kerns","SEUL","Jay","Harris",,"Portland","OR",,,,,"Jay Harris","41474","1368642","8/14/2019 16:45"
-,"Land Use/Planning Committee Chair/Co-Chair","Kerns","SEUL","Jesse","Lopez",,,"OR",,,,"yosoyjay@gmail.com","Jesse Lopez","41229","1731618","5/26/2021 13:10"
-,"City Required Notice Contact/Co-Contact","Kerns","SEUL","Kerns NA","RequiredNoticeContact",,"Portland","OR",,,,"yosoyjay@gmail.com","Kerns NA RequiredNoticeContact","41058","1601262","11/18/2019 13:15"
-,"General correspondance","Kerns","SEUL","KernsNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"KernsNA GeneralCorrespondenceContact","41059","903298","3/10/2017 11:24"
-,"Chair/Co-Chair/President","King","NECN","John","Rooney",,"Portland","OR",,,,"johnr.kingnapdx@gmail.com","John Rooney","41958","1006992","9/4/2020 13:31"
-,"Chair/Co-Chair/President","King","NECN","Laverne","Martin",,"Portland","OR",,,,"laverne.kingnapdx@gmail.com","Laverne Martin","41959","1007016","9/4/2020 13:34"
-,"Secretary","King","NECN","John","Kim",,"Portland","OR",,,,"johnk.kingnapdx@gmail.com","John Kim","41913","377217","10/30/2019 10:58"
-,"Treasurer/Finance Committee Chair","King","NECN","Libby","Deal",,"Portland","OR",,,,"libby.kingnapdx@gmail.com","Libby Deal","41719","1376727","10/30/2019 10:57"
-,"City Required Notice Contact/Co-Contact","King","NECN","Libby","Deal",,"Portland","OR",,,,"libby.kingnapdx@gmail.com","Libby Deal","41719","1627041","10/30/2019 10:57"
-,"City Required Notice Contact/Co-Contact","King","NECN","KingNA","RequiredNoticeContact","4815 NE 7th Ave","Portland","OR","97211",,,"kingnapdx@gmail.com","KingNA RequiredNoticeContact","41130","1604070","1/9/2020 12:18"
-,"General correspondance","King","NECN","KingNA","GeneralCorrespondenceContact","4815 NE 7th Ave","Portland","OR","97211",,,,"KingNA GeneralCorrespondenceContact","41131","904882","3/13/2017 13:28"
-,"Chair/Co-Chair/President","Laurelhurst","SEUL","Jeff","Martin",,"Portland","OR","97232",,,,"Jeff Martin","17502","420048","11/18/2019 13:26"
-,"Vice Chair/Vice President","Laurelhurst","SEUL","Vince","Sliwoski",,"Portland","OR","97232",,,,"Vince Sliwoski","41283","1032075","11/18/2019 13:22"
-,"Secretary","Laurelhurst","SEUL","Jim","Edelson",,"Portland","OR","97232",,,,"Jim Edelson","27717","249453","12/5/2016 15:04"
-,"Treasurer/Finance Committee Chair","Laurelhurst","SEUL","Mike","Dublinsky",,"Portland","OR",,,,,"Mike Dublinsky","40340","1331220","8/8/2016 13:08"
-,"Land Use/Planning Committee Chair/Co-Chair","Laurelhurst","SEUL","Peter","Meijer",,"Portland","OR",,,,"info@pmapdx.com","Peter Meijer","1272","53424","11/10/2020 13:55"
-,"Land Use/Planning Committee Chair/Co-Chair","Laurelhurst","SEUL","Amy","Smith",,"Portland","OR",,,,"asmith@lrsarchitects.com","Amy Smith","40337","1694154","11/10/2020 13:54"
-,"City Required Notice Contact/Co-Contact","Laurelhurst","SEUL","Amy","Smith",,"Portland","OR",,,,"asmith@lrsarchitects.com","Amy Smith","41061","1601379","11/10/2020 13:56"
-,"City Required Notice Contact/Co-Contact","Laurelhurst","SEUL","Peter","Meijer",,"Portland","OR",,,,"info@pmapdx.com","Peter Meijer","41976","1637064","11/10/2020 13:58"
-,"General correspondance","Laurelhurst","SEUL","LaurelhurstNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"LaurelhurstNA GeneralCorrespondenceContact","41062","903364","3/10/2017 11:27"
-,"Chair/Co-Chair/President","Lents","EPCO","Sabina","Urdes","c/o EPCO, 1017 NE 117th Ave","Portland","OR","97220",,,"sabina.lents.na@gmail.com","Sabina Urdes","41616","998784","10/22/2018 16:03"
-,"Chair/Co-Chair/President","Lents","EPCO","Jean","Fang",,"Portland","OR",,,,,"Jean Fang","42029","1008696","3/31/2021 13:59"
-,"Secretary","Lents","EPCO","Morgin","Carpenter",,"Portland","OR",,,,,"Morgin Carpenter","42028","378252","3/31/2021 13:57"
-,"Treasurer/Finance Committee Chair","Lents","EPCO","Gerald","Adkins",,"Portland","OR",,,,,"Gerald Adkins","42027","1386891","3/31/2021 13:56"
-,"Land Use/Planning Committee Chair/Co-Chair","Lents","EPCO","Jenniffer","Breedlove","c/o EPCO, 1017 NE 117th Ave.","Portland","OR","97220",,,"jennifer.marie.b@outlook.com","Jenniffer Breedlove","40911","1718262","1/30/2020 9:11"
-,"City Required Notice Contact/Co-Contact","Lents","EPCO","LentsNA","RequiredNoticeContact2","c/o EPCO, 1017 NE 117th Ave","Portland","OR",,,,"lentsneighborhood@gmail.com","LentsNA RequiredNoticeContact2","40912","1595568","10/22/2018 16:15"
-,"General correspondance","Lents","EPCO","LentsNA","GeneralCorrespondenceContact","c/o EPCO, 1017 NE 117th Ave.","Portland","OR","97220",,,"lentsneighborhood@gmail.com","LentsNA GeneralCorrespondenceContact","40913","900086","3/31/2021 14:11"
-,"Chair/Co-Chair/President","Linnton","NWNW","Richard","Barker",,"Portland","OR",,,,"chair@linntonna.org","Richard Barker","41566","997584","12/30/2020 12:23"
-,"Vice Chair/Vice President","Linnton","NWNW","Aleeya","Kim",,"Portland","OR",,,,"aleeyakim76@gmail.com","Aleeya Kim","41218","1030450","5/12/2017 14:14"
-,"Secretary","Linnton","NWNW","John","Maxwell",,"Portland","OR",,,,"johnsgreenearth@gmail.com","John  Maxwell","41715","375435","5/4/2018 14:29"
-,"Treasurer/Finance Committee Chair","Linnton","NWNW","Kate","McCaslin",,"Portland","OR",,,,"jeannekate68@gmail.com","Kate  McCaslin","41906","1382898","10/4/2019 11:13"
-,"Land Use/Planning Committee Chair/Co-Chair","Linnton","NWNW","Richard","Barker",,"Portland","OR",,,,"chair@linntonna.org","Richard Barker","41566","1745772","12/30/2020 12:23"
-,"City Required Notice Contact/Co-Contact","Linnton","NWNW","LinntonNA","RequiredNoticeContact","2257 NW Raleigh St.","Portland","OR","97210",,,"Chair@linntonna.org","LinntonNA RequiredNoticeContact","40602","1583478","11/23/2016 13:39"
-,"General correspondance","Linnton","NWNW","LinntonNA","GeneralCorrespondenceContact","2257 NW Raleigh St.","Portland","OR","97210",,"(503) 823-4288","Chair@linntonna.org","LinntonNA GeneralCorrespondenceContact","40603","893266","11/23/2016 13:48"
-,"Chair/Co-Chair/President","Lloyd District","NECN","Jeremy","Taylor",,"Portland","OR",,,,"jeremy@temple-baptist.com","Jeremy Taylor","41878","1005072","6/27/2019 13:00"
-,"Secretary","Lloyd District","NECN","Emily","Mandic",,"Portland","OR",,,,"emandic@americanassests.com","Emily Mandic","41879","376911","6/27/2019 13:03"
-,"Treasurer/Finance Committee Chair","Lloyd District","NECN","Ryan","Walters",,"Portland","OR",,,,"rwalters@columbiabank.com","Ryan Walters","41880","1382040","6/27/2019 13:05"
-,"Land Use/Planning Committee Chair/Co-Chair","Lloyd District","NECN","Ziggy","Lopuszynski","P.O. Box 6762","Portland","OR","97228",,,"zlopuszynski@cpportland.com","Ziggy Lopuszynski","40311","1693062","1/28/2019 10:57"
-,"City Required Notice Contact/Co-Contact","Lloyd District","NECN","LLoydDistrictCmtyAsso","RequireNoticeContact","PO Box 6762","Portland","OR","97228-6762",,,,"LLoydDistrictCmtyAsso RequireNoticeContact","41035","1600365","6/27/2018 13:31"
-,"General correspondance","Lloyd District","NECN","LloydDistrictCmtyAsso","GeneralCorrespondenceContact","PO Box 6762","Portland","OR","97228-6762",,,,"LloydDistrictCmtyAsso GeneralCorrespondenceContact","41036","902792","6/27/2018 15:06"
-,"Chair/Co-Chair/President","Madison South","CNN","Dave","Smith","8310 NE Brazee","Portland","OR",,"(503) 254-7790",,"Dave.Smith@portlandoregon.gov","Dave Smith","34415","825960","12/5/2016 15:53"
-,"Vice Chair/Vice President","Madison South","CNN","Stacy","Bancroft","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"will@lumberyardmtb.com","Stacy Bancroft","40637","1015925","1/6/2021 12:29"
-,"Secretary","Madison South","CNN","Lisa","Walsh",,"Portland","OR","97220","(503) 805-1496",,"secretary@madisonsouth.org","Lisa Walsh","32063","288567","3/30/2009 0:00"
-,"Treasurer/Finance Committee Chair","Madison South","CNN","Ronda","Johnson","4415 NE 87th Ave","Portland","OR","97220",,"(503) 823-2780","rondaj@cnncoalition.org","Ronda Johnson","41988","1385604","1/6/2021 11:57"
-,"Land Use/Planning Committee Chair/Co-Chair","Madison South","CNN","Ben","Cutler","c/o CNN, 4415 NE 87th Ave.","Portland","OR","97220",,,"benjamin.a.cutler@gmail.com","Ben Cutler","40378","1695876","4/5/2021 12:06"
-,"City Required Notice Contact/Co-Contact","Madison South","CNN","MadisonSouthNA","RequiredNoticeContact","4415 NE 87th Ave.","Portland","OR","97220",,,,"MadisonSouthNA RequiredNoticeContact","40625","1584375","12/1/2016 15:32"
-,"General correspondance","Madison South","CNN","MadisonSouthNA","GeneralCorrespondenceContact","4415 NE 87th Ave.","Portland","OR","97220",,,,"MadisonSouthNA GeneralCorrespondenceContact","40626","893772","12/1/2016 15:33"
-,"Chair/Co-Chair/President","Maplewood","SWNI","Claire","Carder","6156 SW Nevada Ct.","Portland","OR","97219","(503) 977-3683","(503) 880-6503","scherzcarder@comcast.net","Claire Carder","22582","541968","4/15/2021 17:50"
-,"Secretary","Maplewood","SWNI","Joan","Frazer",,,,,,,"joan@spiretech.com","Joan Frazer","32585","293265","5/3/2021 10:00"
-,"Treasurer/Finance Committee Chair","Maplewood","SWNI","Jim","Scherzinger",,"Portland","OR",,,,"scherzcom@comcast.net","Jim Scherzinger","24526","809358","4/15/2021 17:45"
-,"Land Use/Planning Committee Chair/Co-Chair","Maplewood","SWNI","Claire","Carder","6156 SW Nevada Ct.","Portland","OR","97219","(503) 977-3683","(503) 880-6503","scherzcarder@comcast.net","Claire Carder","22582","948444","4/15/2021 17:50"
-,"City Required Notice Contact/Co-Contact","Maplewood","SWNI","MaplewoodNA","RequiredNoticeContact",,"Portland","OR",,,,"contact@maplewoodna.org","MaplewoodNA RequiredNoticeContact","41007","1599273","5/3/2021 10:08"
-,"General correspondance","Maplewood","SWNI","MaplewoodNA","GeneralCorrespondenceContact",,"Portland","OR",,,,"contact@maplewoodna.org","MaplewoodNA GeneralCorrespondenceContact","41008","902176","5/3/2021 10:07"
-,"City Required Notice Contact/Co-Contact","Markham","SWNI","MarkhamNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@markhamneighborhood.com","MarkhamNA RequiredNoticeContact","41010","1599390","8/7/2017 16:10"
-,"General correspondance","Markham","SWNI","MarkhamNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@markhamneighborhood.com","MarkhamNA GeneralCorrespondenceContact","41011","902242","8/7/2017 16:11"
-,"City Required Notice Contact/Co-Contact","Marshall Park","SWNI","MarshallParkNA","RequiredNoticeContact","Michael Charles, 9415 SW 18th Place","Portland","OR","97219",,,"marshallparkna@yahoo.com","MarshallParkNA RequiredNoticeContact","41014","1599546","4/14/2021 9:26"
-,"General correspondance","Marshall Park","SWNI","MarshallParkNA","GeneralCorrespondenceContact","Michael Charles, 9415 SW 18th Place","Portland","OR","97219-2457",,,"marshallparkna@yahoo.com","MarshallParkNA GeneralCorrespondenceContact","41015","902330","4/14/2021 9:27"
-,"Vice Chair/Vice President","Mill Park","EPCO","Trevor","Hopper","1840 SE 117th","Portland","OR","97216","(503) 703-7744",,"mill.park.pdx.chair@gmail.com","Trevor Hopper","35605","890125","5/24/2016 10:25"
-,"Treasurer/Finance Committee Chair","Mill Park","EPCO","Violet","Pascoe","2019 SE 117th Ave.","Portland","OR","97216","(503) 408-2367",,"pascoeviolet@yahoo.com","Violet Pascoe","38638","1275054","6/19/2014 14:58"
-,"Land Use/Planning Committee Chair/Co-Chair","Mill Park","EPCO","Trevor","Hopper","1840 SE 117th","Portland","OR","97216","(503) 703-7744",,"mill.park.pdx.chair@gmail.com","Trevor Hopper","35605","1495410","5/24/2016 10:25"
-,"City Required Notice Contact/Co-Contact","Mill Park","EPCO","MillParkNA","RequiredNoticeContact","1840 SE 117th","Portland","OR","97216","(503) 703-7744",,"mill.park.pdx.chair@gmail.com","MillParkNA RequiredNoticeContact","41100","1602900","1/26/2018 13:24"
-,"General correspondance","Mill Park","EPCO","MillParkNA","GeneralCorrespondenceContact","1840 SE 117th","Portland","OR","97216","(503) 703-7744",,"mill.park.pdx.chair@gmail.com","MillParkNA GeneralCorrespondenceContact","41101","904222","1/26/2018 13:25"
-,"Chair/Co-Chair/President","Montavilla","SEUL","Louise","Hoff",,"Portland","OR",,,,"louise@montavillapdx.org","Louise Hoff","41999","1007976","1/28/2021 12:08"
-,"Vice Chair/Vice President","Montavilla","SEUL","Alice","King",,"Portland","OR",,,,"alice@montavillapdx.org","Alice King","42000","1050000","1/28/2021 12:10"
-,"Secretary","Montavilla","SEUL","Jacob","Loeb",,"Portland","OR",,,,"jacob@montavillapdx.org","Jacob Loeb","41511","373599","1/28/2021 12:13"
-,"Treasurer/Finance Committee Chair","Montavilla","SEUL","Peter","Emerson",,"Portland","OR",,,,"peter@montavillapdx.org","Peter Emerson","42001","1386033","1/28/2021 12:14"
-,"Land Use/Planning Committee Chair/Co-Chair","Montavilla","SEUL","Adam","Wilson",,"Portland","OR","97216",,,"adam@montavillapdx.org","Adam Wilson","41510","1743420","2/9/2021 11:09"
-,"City Required Notice Contact/Co-Contact","Montavilla","SEUL","Montavilla","NeighborhoodAssociation",,"Portland","OR","97216",,,"notifications@montavillapdx.org","Montavilla NeighborhoodAssociation","41064","1601496","2/10/2021 15:10"
-,"General correspondance","Montavilla","SEUL","Montavilla","NeighborhoodAssociation","c/o SE Uplift, 3534 SE Main St.","Portland","OR","97214",,,"hello@montavillapdx.org","Montavilla NeighborhoodAssociation","41065","903430","3/17/2017 13:30"
-,"Chair/Co-Chair/President","Mt. Scott-Arleta","SEUL","Matchu","Williams",,"Portland","OR","97214",,,"MSANAchair@gmail.com","Matchu Williams","40350","968400","12/11/2020 15:24"
-,"Secretary","Mt. Scott-Arleta","SEUL","Noelle","Winiecki",,"Portland","OR","97206",,,,"Noelle Winiecki","38464","346176","12/11/2020 15:10"
-,"Treasurer/Finance Committee Chair","Mt. Scott-Arleta","SEUL","Martha","Tucker",,"Portland","OR","97206",,,,"Martha Tucker","39462","1302246","12/11/2020 15:11"
-,"Land Use/Planning Committee Chair/Co-Chair","Mt. Scott-Arleta","SEUL","Matchu","Williams",,"Portland","OR","97214",,,"MSANAchair@gmail.com","Matchu Williams","40350","1694700","12/11/2020 15:24"
-,"City Required Notice Contact/Co-Contact","Mt. Scott-Arleta","SEUL","Sarah","Iannarone",,"Portland","OR","97214",,,"MSANAchair@gmail.com","Sarah Iannarone","41067","1601613","12/11/2020 15:22"
-,"General correspondance","Mt. Scott-Arleta","SEUL","MtScott-ArletaNA","GeneralCorrespondenceContact","3534 SE MAIN ST","Portland","OR","97214",,,"MSANA.chair@gmail.com","MtScott-ArletaNA GeneralCorrespondenceContact","41068","903496","12/11/2020 15:19"
-,"Chair/Co-Chair/President","Mt. Tabor","SEUL",,,,"Portland","OR",,,,"contact.mtna@gmail.com","Mt Tabor Neighborhood Association","41257","990168","5/26/2021 13:36"
-,"Treasurer/Finance Committee Chair","Mt. Tabor","SEUL","Bing","Wong",,"Portland","OR",,,,,"Bing Wong","4705","155265","5/26/2021 13:22"
-,"Land Use/Planning Committee Chair/Co-Chair","Mt. Tabor","SEUL","Stephanie","Stewart",,"Portland","OR",,,,"contact.MTNA@gmail.com","Stephanie Stewart","32846","1379532","5/26/2021 13:24"
-,"City Required Notice Contact/Co-Contact","Mt. Tabor","SEUL","Stephanie","Stewart",,"Portland","OR",,,,"contact.MTNA@gmail.com","Stephanie Stewart","39850","1554150","5/26/2021 13:23"
-,"General correspondance","Mt. Tabor","SEUL","MtTaborNA","GeneralCorrespondenceContact","5122 SE Hawthorne Blvd.","Portland","OR","97215",,,"contact.MTNA@gmail.com","MtTaborNA GeneralCorrespondenceContact","40863","898986","2/8/2017 12:24"
-,"Chair/Co-Chair/President","Multnomah","SWNI","Maria","Thi Mai",,"Portland","OR",,,,"thimai.maria@gmail.com","Maria Thi Mai","42014","1008336","4/15/2021 18:11"
-,"Treasurer/Finance Committee Chair","Multnomah","SWNI","Sim","Hyde",,"Portland","OR",,,,"simhyde@comcast.net","Sim Hyde","42019","1386627","4/15/2021 18:12"
-,"Land Use/Planning Committee Chair/Co-Chair","Multnomah","SWNI","Frank","Rudloff","2635 SW Hume St.","Portland","OR","97219","(503) 246-0883","(503) 226-0622","rudloff@mca-architects.com","Frank Rudloff","8857","371994","4/15/2021 18:14"
-,"City Required Notice Contact/Co-Contact","Multnomah","SWNI","MultnomahNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-multnomah@swni.org","MultnomahNA RequiredNoticeContact","41017","1599663","8/7/2017 16:28"
-,"General correspondance","Multnomah","SWNI","MultnomahNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-multnomah@swni.org","MultnomahNA GeneralCorrespondenceContact","41018","902396","8/7/2017 16:29"
-,"Chair/Co-Chair/President","North Tabor","SEUL","Robert","Jordan",,"Portland","OR",,,,"chair@northtabor.org","Robert Jordan","40444","970656","11/10/2020 14:12"
-,"Vice Chair/Vice President","North Tabor","SEUL","Charles","Tubens",,"Portland","OR","97213",,,,"Charles Tubens","40445","1011125","10/26/2016 12:09"
-,"Secretary","North Tabor","SEUL","Patty","Lackaff",,"Portland","OR",,,,,"Patty Lackaff","40448","364032","11/10/2020 14:14"
-,"Treasurer/Finance Committee Chair","North Tabor","SEUL","Patty","Lackaff",,"Portland","OR",,,,,"Patty Lackaff","41575","1371975","11/10/2020 14:14"
-,"Land Use/Planning Committee Chair/Co-Chair","North Tabor","SEUL","Lars","Kasch",,"Portland","OR","97213",,,"landuse@northtabor.org","Lars Kasch","41670","1750140","11/18/2019 13:50"
-,"Land Use/Planning Committee Chair/Co-Chair","North Tabor","SEUL","Lisa","Maddocks",,"Portland","OR",,,,"landuse@northtabor.org","Lisa Maddocks","241","10122","11/18/2019 13:52"
-,"City Required Notice Contact/Co-Contact","North Tabor","SEUL","Lisa","Maddocks",,"Portland","OR",,,,"landuse@northtabor.org","Lisa Maddocks","241","9399","11/18/2019 13:52"
-,"City Required Notice Contact/Co-Contact","North Tabor","SEUL","Lars","Kasch",,"Portland","OR",,,,"landuse@northtabor.org","Lars Kasch","41070","1601730","11/10/2020 14:19"
-,"General correspondance","North Tabor","SEUL","NorthTaborNA","GeneralCorrespondenceContact","c/o SE Uplift, 3534 SE Main St.","Portland","OR","97214",,,"board@northtabor.org","NorthTaborNA GeneralCorrespondenceContact","41071","903562","6/29/2017 13:18"
-,"Chair/Co-Chair/President","Northwest District","NWNW","Parker","McNulty",,"Portland","OR",,,,"president@northwestdistrictassociation.org","Parker McNulty","41724","1001376","3/23/2021 11:49"
-,"Vice Chair/Vice President","Northwest District","NWNW","Parker","McNulty",,"Portland","OR",,,,"president@northwestdistrictassociation.org","Parker McNulty","41724","1043100","3/23/2021 11:49"
-,"Treasurer/Finance Committee Chair","Northwest District","NWNW","Vicki","Skryha",,"Salem","OR","97309",,"(503) 945-9722","treasurer@northwestdistrictassociation.org","Vicki Skryha","1504","49632","12/30/2020 15:27"
-,"Land Use/Planning Committee Chair/Co-Chair","Northwest District","NWNW","Greg","Theisen",,"Portland","OR","97210","(503) 227-5430",,"planning@northwestdistrictassociation.org","Greg Theisen","2252","94584","12/23/2019 14:27"
-,"City Required Notice Contact/Co-Contact","Northwest District","NWNW","NWDA","Required/Certified/GeneralContact","2257 NW Raleigh St.","Portland","OR","97210",,"(503) 823-4288","president@northwestdistrictassociation.org","NWDA Required/Certified/GeneralContact","40607","1583673","11/30/2016 15:42"
-,"General correspondance","Northwest District","NWNW","NWDA","Required/Certified/GeneralContact","2257 NW Raleigh St.","Portland","OR","97210",,"(503) 823-4288","president@northwestdistrictassociation.org","NWDA Required/Certified/GeneralContact","40607","893354","11/30/2016 15:42"
-,"Chair/Co-Chair/President","Northwest Heights","NWNW","Barry","Newman","4055 NW Twilight","Portland",,"97229",,,"president@nwheights.org","Barry  Newman","38762","930288","6/15/2017 16:41"
-,"Vice Chair/Vice President","Northwest Heights","NWNW","Brian","Owendoff",,"Portland","OR",,,,"brian.owendoff@yahoo.com","Brian Owendoff","41261","1031525","6/15/2017 16:43"
-,"Secretary","Northwest Heights","NWNW","Pamela","Morris",,"Portland","OR",,,,"secretary@nwheights.org","Pamela Morris","41262","371358","6/15/2017 16:49"
-,"Treasurer/Finance Committee Chair","Northwest Heights","NWNW","Pamela","Morris",,"Portland","OR",,,,"secretary@nwheights.org","Pamela Morris","41262","1361646","6/15/2017 16:49"
-,"City Required Notice Contact/Co-Contact","Northwest Heights","NWNW","NWHNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","board@nwheights.org","NWHNA Required/General/CertifiedContact","40624","1584336","12/1/2016 13:56"
-,"General correspondance","Northwest Heights","NWNW","NWHNA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","board@nwheights.org","NWHNA Required/General/CertifiedContact","40624","893728","12/1/2016 13:56"
-,"Chair/Co-Chair/President","Old Town","NWNW","Jessie","Burke",,"Portland","OR",,,,"chair@pdxoldtown.org","Jessie Burke","39473","947352","4/15/2021 16:21"
-,"Vice Chair/Vice President","Old Town","NWNW","Scott","Kerman",,"Portland","OR",,,,"vice-chair@pdxoldtown.org","Scott Kerman","41936","1048400","4/15/2021 16:18"
-,"Secretary","Old Town","NWNW","Mary-Rain","O'Meara","2257 NW Raleigh St","Portland","OR","97210",,,"secretary@pdxoldtown.org","Mary-Rain O'Meara","32475","292275","4/15/2021 16:42"
-,"Treasurer/Finance Committee Chair","Old Town","NWNW","Jonathan","Cohen",,"Portland","OR",,,,"treasurer@pdxoldtown.org","Jonathan Cohen","42038","1387254","4/15/2021 16:27"
-,"Land Use/Planning Committee Chair/Co-Chair","Old Town","NWNW","Jonathan","Cohen",,"Portland","OR",,,,"treasurer@pdxoldtown.org","Jonathan Cohen","42038","1765596","4/15/2021 16:27"
-,"Land Use/Planning Committee Chair/Co-Chair","Old Town","NWNW","Mary-Rain","O'Meara","2257 NW Raleigh St","Portland","OR","97210",,,"secretary@pdxoldtown.org","Mary-Rain O'Meara","32475","1363950","4/15/2021 16:42"
-,"City Required Notice Contact/Co-Contact","Old Town","NWNW","OTCA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","board@PDXoldtown.org","OTCA Required/General/CertifiedContact","40628","1584492","10/4/2019 10:46"
-,"General correspondance","Old Town","NWNW","OTCA","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","board@PDXoldtown.org","OTCA Required/General/CertifiedContact","40628","893816","10/4/2019 10:46"
-,"Chair/Co-Chair/President","Overlook","NPNS","Alexandra","Degher","2209 N. Schofield St","Portland","OR","97217",,,"chair@overlookneighborhood.org","Alexandra Degher","40420","970080","12/11/2019 12:55"
-,"Treasurer/Finance Committee Chair","Overlook","NPNS","Brad","Halverson",,"Portland","OR",,,,"info@overlookneighborhood.org","Brad Halverson","40423","1333959","12/11/2019 12:58"
-,"Land Use/Planning Committee Chair/Co-Chair","Overlook","NPNS","Brian","Yarne",,"Portland","OR",,,,"landuse@overlookneighborhood.org","Brian Yarne","42024","1765008","3/23/2021 11:56"
-,"City Required Notice Contact/Co-Contact","Overlook","NPNS","OverlookNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"landuse@overlookneighborhood.org","OverlookNA RequiredNoticeContact","40940","1596660","5/30/2017 15:01"
-,"General correspondance","Overlook","NPNS","OverlookNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"chair@overlookneighborhood.org","OverlookNA GeneralCorrespondenceContact","40941","900702","5/30/2017 15:01"
-,"Chair/Co-Chair/President","Parkrose","EPCO","Tom","Badrick","1725 NE 118th Ave","Portland","OR","97220",,,"tbadrick@aol.com","Tom Badrick","2118","50832","2/20/2017 13:14"
-,"City Required Notice Contact/Co-Contact","Parkrose","EPCO","ParkroseHghtsAssoofNeighbors","RequiredNotice Contact","c/o EPCO, 1017 NE 117th Ave.","Portland","OR","97220",,"(971) 325-9727","badrickt@gmail.com","ParkroseHghtsAssoofNeighbors RequiredNotice Contact","40891","1594749","3/18/2019 15:30"
-,"General correspondance","Parkrose","EPCO","Parkrose Hghts AssoofNeighbors","General Correspondence Contact","c/o EPCO, 1017 NE 117th Ave.","Portland","OR","97220",,"(971) 325-9727","badrickt@gmail.com","Parkrose Hghts AssoofNeighbors General Correspondence Contact","40892","899624","3/18/2019 15:31"
-,"Chair/Co-Chair/President","Parkrose","EPCO","Annette","Stanhope",,"Portland","OR","97220",,,,"Annette Stanhope","37079","889896","4/4/2014 14:44"
-,"City Required Notice Contact/Co-Contact","Parkrose","EPCO","ParkoseNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"parkroseneighbors@gmail.com","ParkoseNA RequiredNoticeContact","41103","1603017","3/23/2017 9:33"
-,"General correspondance","Parkrose","EPCO","ParkroseNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"parkroseneighbors@gmail.com","ParkroseNA GeneralCorrespondenceContact","41104","904288","3/23/2017 9:34"
-,"Chair/Co-Chair/President","Pearl District","NWNW","Stanley","Penkin",,"Portland",,,"(845) 417-8755",,"stanleypenkin@gmail.com","Stanley Penkin","38814","931536","9/19/2018 14:01"
-,"Vice Chair/Vice President","Pearl District","NWNW","David","Dysert",,"Portland","OR","97209",,,"planning@pearldistrict.org","David Dysert","41260","1031500","11/18/2020 17:23"
-,"Secretary","Pearl District","NWNW","Bill","Bagnall",,"Portland","OR",,,,"secretary@pearldistrict.org","Bill Bagnall","41154","370386","3/22/2017 13:42"
-,"Treasurer/Finance Committee Chair","Pearl District","NWNW","Christian","Maynard-Phillip",,"Portland","OR",,,,"treasurer@pearldistrict.org","Christian Maynard-Phillip","41525","1370325","11/25/2017 13:25"
-,"Land Use/Planning Committee Chair/Co-Chair","Pearl District","NWNW","David","Dysert",,"Portland","OR","97209",,,"planning@pearldistrict.org","David Dysert","41260","1732920","11/18/2020 17:23"
-,"Land Use/Planning Committee Chair/Co-Chair","Pearl District","NWNW","Reza","Farhoodi",,"Portland","OR","97209",,,"planning@pearldistrict.org","Reza Farhoodi","40080","1683360","11/18/2020 14:04"
-,"City Required Notice Contact/Co-Contact","Pearl District","NWNW","Pearl","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@pearldistrict.org","Pearl Required/General/CertifiedContact","40629","1584531","12/2/2016 13:16"
-,"General correspondance","Pearl District","NWNW","Pearl","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@pearldistrict.org","Pearl Required/General/CertifiedContact","40629","893838","12/2/2016 13:16"
-,"Chair/Co-Chair/President","Piedmont","NPNS","Shaun","Sullens",,"Portland","OR",,,,"shaun.sullens@msn.com","Shaun Sullens","42049","1009176","5/16/2021 16:49"
-,"Treasurer/Finance Committee Chair","Piedmont","NPNS","Deanne","Gomez",,"Portland","OR","97217",,,"gomez.deanne@yahoo.com","Deanne Gomez","182","6006","3/19/2014 13:10"
-,"City Required Notice Contact/Co-Contact","Piedmont","NPNS","PiedmontNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"landuse@piedmontemerald.com","PiedmontNA RequiredNoticeContact","40943","1596777","5/30/2017 14:42"
-,"General correspondance","Piedmont","NPNS","PiedmontNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"landuse@piedmontemerald.com","PiedmontNA GeneralCorrespondenceContact","40944","900768","5/30/2017 14:42"
-,"Chair/Co-Chair/President","Pleasant Valley","EPCO","Dale","Shelter",,"Portland","OR","97266-0000",,,"dale.shetler@gmail.com","Dale Shelter","39983","959592","9/10/2018 11:26"
-,"Land Use/Planning Committee Chair/Co-Chair","Pleasant Valley","EPCO","Steve","Montgomery",,,,,,,"foxtrotlove@hotmail.com","Steve Montgomery","39984","1679328","11/30/2016 14:15"
-,"City Required Notice Contact/Co-Contact","Pleasant Valley","EPCO","PleasantValleyNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"pleasantvalleyna@gmail.com","PleasantValleyNA RequiredNoticeContact","40882","1594398","6/8/2017 16:36"
-,"General correspondance","Pleasant Valley","EPCO","PleasantValleyNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"pleasantvalleyna@gmail.com","PleasantValleyNA GeneralCorrespondenceContact","40883","899426","6/8/2017 16:36"
-,"Chair/Co-Chair/President","Portland Downtown","NWNW","Walter","Weyler","1221 SW 10th Ave #805","Portland","OR",,"(503) 490-3907",,"walter_weyler@sequenceusa.com","Walter Weyler","41836","1004064","3/29/2019 10:58"
-,"Vice Chair/Vice President","Portland Downtown","NWNW","Wendy","Rahm",,"Portland","OR","97205",,,"wwrahm@aol.com","Wendy Rahm","33228","830700","7/16/2012 9:31"
-,"Treasurer/Finance Committee Chair","Portland Downtown","NWNW","Natasha","Voloshina",,"Portland","OR",,,,"natashavo@icloud.com","Natasha  Voloshina","41917","1383261","11/19/2019 17:57"
-,"Land Use/Planning Committee Chair/Co-Chair","Portland Downtown","NWNW","Wendy","Rahm",,"Portland","OR","97205",,,"wwrahm@aol.com","Wendy Rahm","33228","1395576","7/16/2012 9:31"
-,"City Required Notice Contact/Co-Contact","Portland Downtown","NWNW","Downtown","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@portlanddowntownna.com","Downtown Required/General/CertifiedContact","40630","1584570","12/2/2016 13:17"
-,"General correspondance","Portland Downtown","NWNW","Downtown","Required/General/CertifiedContact","2257 NW Raleigh Street","Portland","OR","97210",,"(503) 823-4288","president@portlanddowntownna.com","Downtown Required/General/CertifiedContact","40630","893860","12/2/2016 13:17"
-,"Chair/Co-Chair/President","Portsmouth","NPNS","Kelly","Lynn",,"Portland","OR",,,,"kellylynnpna@gmail.com","Kelly Lynn","41966","1007184","10/5/2020 15:50"
-,"Chair/Co-Chair/President","Portsmouth","NPNS","Mary-Margaret","Wheeler-Weber",,"Portland","OR","97203",,,"mary.wheeler@gmail.com","Mary-Margaret Wheeler-Weber","21863","524712","11/12/2020 10:43"
-,"Secretary","Portsmouth","NPNS","Neveen","Hurd",,"Portland","OR",,,,"neveen.pna@gmail.com","Neveen Hurd","41975","377775","11/5/2020 14:19"
-,"Treasurer/Finance Committee Chair","Portsmouth","NPNS","Paul","Buchanan",,"Portland","OR",,,,"paul.c.buchanan@gmail.com","Paul  Buchanan","41974","1385142","11/5/2020 14:15"
-,"City Required Notice Contact/Co-Contact","Portsmouth","NPNS","PortsmouthNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"portsmouthchair@gmail.com","PortsmouthNA RequiredNoticeContact","40946","1596894","5/20/2021 14:47"
-,"General correspondance","Portsmouth","NPNS","PortsmouthNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"portsmouthchair@gmail.com","PortsmouthNA GeneralCorrespondenceContact","40947","900834","5/30/2017 14:34"
-,"Chair/Co-Chair/President","Powellhurst-Gilbert","EPCO","Richard","Dickinson",,"Portland","OR","98266",,,"pgnaboard@gmail.com","Richard Dickinson","40706","976944","2/9/2021 10:58"
-,"Chair/Co-Chair/President","Powellhurst-Gilbert","EPCO","Timothy","Crawley",,"Portland","OR","98236",,,"pgnaboard@gmail.com","Timothy  Crawley","39985","959640","3/18/2019 15:35"
-,"Secretary","Powellhurst-Gilbert","EPCO","Shaina","Boal",,"Portland","OR",,,,"pgnaboard@gmail.com","Shaina Boal","41676","375084","2/9/2021 10:52"
-,"Treasurer/Finance Committee Chair","Powellhurst-Gilbert","EPCO","Jody","Folkedahl Eppolito",,"Portland","OR","97266",,,,"Jody Folkedahl Eppolito","40707","1343331","3/28/2017 10:04"
-,"City Required Notice Contact/Co-Contact","Powellhurst-Gilbert","EPCO","PowellhurstGilbertNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"pgnaboard@gmail.com","PowellhurstGilbertNA RequiredNoticeContact","40860","1593540","2/8/2017 11:33"
-,"General correspondance","Powellhurst-Gilbert","EPCO","PowellhurstGilbertNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"pgnaboard@gmail.com","PowellhurstGilbertNA GeneralCorrespondenceContact","40861","898942","2/9/2021 10:51"
-,"Chair/Co-Chair/President","Reed","SEUL","Anne","Tillinga",,"Portland","OR",,,,"tillinga@gmail.com","Anne Tillinga","41250","990000","11/10/2020 14:28"
-,"Treasurer/Finance Committee Chair","Reed","SEUL","Xander","Blair",,"Portland","OR",,,,"xander.blair@gmail.com","Xander Blair","41723","1376859","11/10/2020 14:29"
-,"Land Use/Planning Committee Chair/Co-Chair","Reed","SEUL","Xander","Blair",,"Portland","OR",,,,"xander.blair@gmail.com","Xander Blair","41723","1752366","11/10/2020 14:29"
-,"City Required Notice Contact/Co-Contact","Reed","SEUL","Xander","Blair",,"Portland","OR",,,,"xander.blair@gmail.com","Xander Blair","41073","1601847","11/10/2020 14:32"
-,"General correspondance","Reed","SEUL","ReedNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"ReedNA GeneralCorrespondenceContact","41074","903628","3/10/2017 11:42"
-,"Chair/Co-Chair/President","Richmond","SEUL","Debby","Hochhalter",,"Portland","OR",,,,"richmond.pdx.chair@gmail.com","Debby Hochhalter","40427","970248","10/31/2019 13:40"
-,"Secretary","Richmond","SEUL","Allen","Field",,,,,,,"richmondnasecretary@gmail.com","Allen Field","3088","27792","10/31/2019 13:47"
-,"Treasurer/Finance Committee Chair","Richmond","SEUL","Jonathan","King",,"Portland","OR","97214",,,,"Jonathan King","39097","1290201","7/6/2016 17:17"
-,"City Required Notice Contact/Co-Contact","Richmond","SEUL","Heather","Flint Chatto","3534 SE Main St","Portland","OR","97214",,,"richmond.pdx.lutc@gmail.com","Heather Flint Chatto","41076","1601964","11/1/2019 8:47"
-,"General correspondance","Richmond","SEUL","Debby","Hochhalter","3534 SE Main St","Portland","OR","97214",,,"richmond.pdx.chair@gmail.com","Debby Hochhalter","41077","903694","11/1/2019 12:31"
-,"Chair/Co-Chair/President","Rose City Park","CNN","Tamara","DeRidder","1707 NE 52nd Ave.","Portland","OR","97213","(503) 249-6977",,"SustainableDesign@tdridder.users.panix.com","Tamara DeRidder","34423","826152","4/1/2015 16:16"
-,"Vice Chair/Vice President","Rose City Park","CNN","Ed","Gorman","3105 NE 60th Ave.","Portland","OR","97213","(503) 281-4594",,"anne.e.lindsay@gmail.com","Ed Gorman","37479","936975","1/6/2021 12:00"
-,"Secretary","Rose City Park","CNN","Jennifer","Santhouse",,"Portland","OR",,,,"estiefvater@hotmail.com","Jennifer Santhouse","41152","370368","1/6/2021 12:01"
-,"Treasurer/Finance Committee Chair","Rose City Park","CNN","Richard","Crockett",,"Portland","OR",,,,"crockett1947@comcast.net","Richard  Crockett","39470","1302510","4/1/2015 16:24"
-,"Land Use/Planning Committee Chair/Co-Chair","Rose City Park","CNN","Tamara","DeRidder","1707 NE 52nd Ave.","Portland","OR","97213","(503) 249-6977",,"SustainableDesign@tdridder.users.panix.com","Tamara DeRidder","34423","1445766","4/1/2015 16:16"
-,"City Required Notice Contact/Co-Contact","Rose City Park","CNN","RoseCityParkNA","RequiredNoticeContact","4415 NE 87th Ave","Portland","OR","97220",,,,"RoseCityParkNA RequiredNoticeContact","40962","1597518","4/21/2021 13:31"
-,"General correspondance","Rose City Park","CNN","RoseCityParkNA","GeneralCorrespondenceContact","4415 NE 87th Ave","Portland","OR","97220",,,,"RoseCityParkNA GeneralCorrespondenceContact","40963","901186","4/21/2021 13:32"
-,"Chair/Co-Chair/President","Roseway","CNN","Caitlin","Hill","4415 NE 87th Ave","Portland","OR","97220",,,"crhill84@gmail.com","Caitlin Hill","42004","1008096","3/16/2021 12:38"
-,"Vice Chair/Vice President","Roseway","CNN","Ted","Carlston","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"tedcarlston2@yahoo.com","Ted Carlston","37006","925150","2/11/2021 10:38"
-,"Treasurer/Finance Committee Chair","Roseway","CNN","Sarah","Gibney","c/o CNN 4415 NE 87th Ave",,,"97220","(503) 288-0911",,"smgibney@gmail.com","Sarah Gibney","30078","992574","3/16/2021 12:41"
-,"Land Use/Planning Committee Chair/Co-Chair","Roseway","CNN","Ted","Carlston","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"tedcarlston2@yahoo.com","Ted Carlston","37006","1554252","2/11/2021 10:38"
-,"City Required Notice Contact/Co-Contact","Roseway","CNN","RosewayNA","RequiredNoticeContact","4415 NE 87th Ave","Portland","OR","97220",,,,"RosewayNA RequiredNoticeContact","40965","1597635","4/21/2021 13:34"
-,"General correspondance","Roseway","CNN","RosewayNA","GeneralCorrespondenceContact","4415 NE 87th Ave","Portland","OR","97220",,,"rna-pdx-board@googlegroups.com","RosewayNA GeneralCorrespondenceContact","40966","901252","4/21/2021 13:34"
-,"Chair/Co-Chair/President","Russell","EPCO","Ron","Glanville",,"Portland",,,"(503) 341-1402",,"ronglanville@gmail.com","Ron Glanville","38640","927360","12/19/2013 16:41"
-,"Treasurer/Finance Committee Chair","Russell","EPCO","Ashton","Simpson",,"Portland","OR","97230",,,"quiltnelson@gmail.com","Ashton  Simpson","39987","1319571","3/18/2019 15:36"
-,"City Required Notice Contact/Co-Contact","Russell","EPCO","RussellNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"ronglanville@gmail.com","RussellNA RequiredNoticeContact","41106","1603134","3/23/2017 13:59"
-,"General correspondance","Russell","EPCO","RussellNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"ronglanville@gmail.com","RussellNA GeneralCorrespondenceContact","41107","904354","3/23/2017 13:59"
-,"Chair/Co-Chair/President","Sabin","NECN","Don","Rouzie","4520 NE 15th","Portland","OR","97211",,,"donrouzie@icloud.com","Don Rouzie","4976","119424","6/10/2019 12:55"
-,"Secretary","Sabin","NECN","Rachel","Lee",,"Portland","OR","97211",,,,"Rachel Lee","37610","338490","5/17/2018 10:10"
-,"Treasurer/Finance Committee Chair","Sabin","NECN","Maria","Hein",,"Portland","OR",,,,"maria.hein@gmail.com","Maria Hein","42010","1386330","3/9/2021 12:47"
-,"Land Use/Planning Committee Chair/Co-Chair","Sabin","NECN","Rachel","Lee",,"Portland","OR","97211",,,,"Rachel Lee","37610","1579620","5/17/2018 10:10"
-,"City Required Notice Contact/Co-Contact","Sabin","NECN","SabinCA","RequiredNoticeContact","c/o NECN, 4815 NE 7th Ave.","Portland","OR","97211",,,"rach.c.lee@gmail.com","SabinCA RequiredNoticeContact","40903","1595217","3/9/2021 12:43"
-,"General correspondance","Sabin","NECN","SabinCA","GeneralCorrespondenceContact","c/o NECN, 4815 NE 7th Ave.","Portland","OR","97211",,"(503) 961-3702","sabin@necoalition.org","SabinCA GeneralCorrespondenceContact","40904","899888","2/27/2017 9:30"
-,"Chair/Co-Chair/President","Sellwood-Moreland","SEUL","Simon","Fulford",,"Portland","OR",,,,"simonrfulford@gmail.com","Simon Fulford","41227","989448","1/19/2021 11:20"
-,"Vice Chair/Vice President","Sellwood-Moreland","SEUL","Bob","Burkholder",,"Portland","OR",,,,"spark101245@gmail.com","Bob Burkholder","41994","1049850","1/19/2021 11:21"
-,"Secretary","Sellwood-Moreland","SEUL","Eric","Norberg",,"Portland","OR",,,,"norberg@myexcel.com","Eric Norberg","1603","14427","1/19/2021 11:28"
-,"Treasurer/Finance Committee Chair","Sellwood-Moreland","SEUL","Patrick","Hainley",,"Portland","OR",,,,"pat@hainley-lavey.com","Patrick Hainley","23177","764841","1/19/2021 11:28"
-,"Land Use/Planning Committee Chair/Co-Chair","Sellwood-Moreland","SEUL","David","Schoellhamer",,"Portland","OR",,,,"chair.landuse.smile@gmail.com","David Schoellhamer","36318","1525356","1/19/2021 11:29"
-,"City Required Notice Contact/Co-Contact","Sellwood-Moreland","SEUL","SMILE","RequiredNoticeContact","8210 SE 13th Ave.","Portland","OR","97202",,,"SMILE@sellwood.org","SMILE RequiredNoticeContact","40885","1594515","5/6/2021 9:55"
-,"General correspondance","Sellwood-Moreland","SEUL","SMILE","GeneralCorrespondenceContact","8210 SE 13th Ave.","Portland","OR","97202",,"(503) 234-3570","smilestation@sellwood.org","SMILE GeneralCorrespondenceContact","40886","899492","1/19/2021 11:34"
-,"Chair/Co-Chair/President","South Burlingame","SWNI","Shannon","Hiller-Webb",,,"OR",,"(503) 928-9539",,"president@southburlingamena.org","Shannon Hiller-Webb","36095","866280","4/28/2021 15:02"
-,"Vice Chair/Vice President","South Burlingame","SWNI","Robert","Lennox",,,"OR",,,,"contact@southburlingamena.org","Robert Lennox","39686","992150","4/28/2021 15:03"
-,"City Required Notice Contact/Co-Contact","South Burlingame","SWNI","SouthBurlingameNA","RequiredNoticeContact","Use E-mail for all correspondence",,"OR",,,,"contact@southburlingamena.org","SouthBurlingameNA RequiredNoticeContact","41020","1599780","4/28/2021 15:00"
-,"General correspondance","South Burlingame","SWNI","SouthBurlingameNA","GeneralCorrespondenceContact","Use E-mail for all correspondence",,"OR",,,,"contact@southburlingamena.org","SouthBurlingameNA GeneralCorrespondenceContact","41021","902462","4/28/2021 15:02"
-,"City Required Notice Contact/Co-Contact","South","SWNI","SouthPortlandNA","RequiredNoticeContact","Jim Gardner, 2930 SW 2nd Ave","Portland","OR","97201",,,"contact@southportlandna.org","SouthPortlandNA RequiredNoticeContact","41023","1599897","11/27/2017 16:44"
-,"General correspondance","South","SWNI","SouthPortlandNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@southportlandna.org","SouthPortlandNA GeneralCorrespondenceContact","41024","902528","8/7/2017 16:45"
-,"Chair/Co-Chair/President","South Tabor","SEUL","Pete","Forsyth",,"Portland","OR","97286",,,"president@southtabor.org","Pete Forsyth","38000","912000","8/14/2019 10:56"
-,"Vice Chair/Vice President","South Tabor","SEUL","Ben","Chatterton",,"Portland","OR","97286",,,,"Ben Chatterton","40312","1007800","8/14/2019 10:59"
-,"Treasurer/Finance Committee Chair","South Tabor","SEUL","Ute","Munger",,"Portland","OR","97206",,,"treasurer@southtabor.org","Ute Munger","24092","795036","7/13/2009 0:00"
-,"Land Use/Planning Committee Chair/Co-Chair","South Tabor","SEUL","Nate","Canfield",,"Portland","OR",,,,"nathaniel.canfield@gmail.com","Nate Canfield","41155","1728510","11/10/2020 14:21"
-,"City Required Notice Contact/Co-Contact","South Tabor","SEUL","Nate","Canfield","PO Box 86836","Portland","OR","97286",,,"nathaniel.canfield@gmail.com","Nate Canfield","41079","1602081","11/10/2020 14:22"
-,"General correspondance","South Tabor","SEUL","STNA","GeneralCorrespondenceContact","PO Box 86836","Portland","OR","97286",,,"communications@southtabor.org","STNA GeneralCorrespondenceContact","41080","903760","3/23/2017 9:03"
-,"City Required Notice Contact/Co-Contact","Southwest Hills","SWNI","SWHillsResidLeague","RequiredNoticeContact","SWHRL, c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact@swhrl.org","SWHillsResidLeague RequiredNoticeContact","41026","1600014","11/20/2017 10:34"
-,"General correspondance","Southwest Hills","SWNI","SWHillsResidLeague","GeneralCorrespondenceContact","SWHRL, c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy.","Portland","OR","97219-2457",,,"contact@swhrl.org","SWHillsResidLeague GeneralCorrespondenceContact","41027","902594","11/20/2017 10:35"
-,"Chair/Co-Chair/President","St. Johns","NPNS","Jose","Alamilla",,"Portland","OR",,,,"info@stjohnspdx.org","Jose Alamilla","41977","1007448","2/23/2021 15:10"
-,"Treasurer/Finance Committee Chair","St. Johns","NPNS","Bernadine","Lee",,"Portland","OR",,,,"minimouse313@gmail.com","Bernadine Lee","41464","1368312","12/11/2019 11:16"
-,"Land Use/Planning Committee Chair/Co-Chair","St. Johns","NPNS","Michelle","Brinning",,"Portland","OR",,,,"landuse@stjohnspdx.org","Michelle Brinning","41996","1763832","1/25/2021 15:28"
-,"City Required Notice Contact/Co-Contact","St. Johns","NPNS","StJohnsNA","RequiredNoticeContact2","2209 N. Schofield","Portland","OR","97217",,,"landuse@stjohnspdx.org","StJohnsNA RequiredNoticeContact2","40921","1595919","1/30/2019 9:47"
-,"City Required Notice Contact/Co-Contact","St. Johns","NPNS","StJohnsNA","RequiredNoticeContact1","2209 N. Schofield","Portland","OR","97217",,,"landuse@stjohnspdx.org","StJohnsNA RequiredNoticeContact1","40916","1595724","2/24/2021 10:09"
-,"General correspondance","St. Johns","NPNS","StJohnsNA","GeneralCorrespondenceContact","2209 N Schofield","Portland","OR","97217",,,,"StJohnsNA GeneralCorrespondenceContact","40917","900174","11/20/2018 12:26"
-,"Chair/Co-Chair/President","Sullivan's Gulch","NECN","Dave","Brook",,"Portland","OR","97232",,"(503) 313-1320","dbrookportland@gmail.com","Dave Brook","18742","449808","1/24/2020 11:02"
-,"Chair/Co-Chair/President","Sullivan's Gulch","NECN","Mary Beth","Christopher",,"Portland","OR",,,,,"Mary Beth Christopher","41846","1004304","4/10/2019 12:29"
-,"Secretary","Sullivan's Gulch","NECN","Kathy","Hansen","1605 NE Clackamas, #508B","Portland","OR","97232","(503) 221-4845",,"hansenk1324@q.com","Kathy Hansen","40328","362952","8/2/2016 10:35"
-,"Treasurer/Finance Committee Chair","Sullivan's Gulch","NECN","Dan","Lerch-Walters",,"Portland","OR","97232","(503) 284-7605",,,"Dan Lerch-Walters","33648","1110384","1/24/2020 11:04"
-,"Land Use/Planning Committee Chair/Co-Chair","Sullivan's Gulch","NECN","DJ","Heffernan","2525 NE Halsey Street","Portland","OR","97232","(503) 310-2306",,"djheff1@gmail.com","DJ Heffernan","7834","329028","10/31/2016 9:40"
-,"City Required Notice Contact/Co-Contact","Sullivan's Gulch","NECN","SullivansGulchNA","RequiredNoticeContact","c/o Holladay Park Plaza 1300 NE 16th Ave","Portland","OR","97232",,,"sgnagulchnet@gmail.com","SullivansGulchNA RequiredNoticeContact","41133","1604187","1/24/2020 11:07"
-,"General correspondance","Sullivan's Gulch","NECN","SullivansGulchNA","GeneralCorrespondenceContact","SGNA c/o Holladay Park Plaza 1300 NE 16th Ave","Portland","OR","97232",,,,"SullivansGulchNA GeneralCorrespondenceContact","41134","904948","3/13/2017 12:52"
-,"Chair/Co-Chair/President","Sumner","CNN","Yvonne","Rice","c/o CNN, 4415 NE 87th Ave.","Portland","OR","97220",,,"sumner.neighborhood.chair@gmail.com","Yvonne Rice","40382","969168","4/21/2021 13:38"
-,"Vice Chair/Vice President","Sumner","CNN","Karen","McAninch","c/o CNN 4415 NE 87th Ave","Portland","OR","97220","(503) 453-5289",,,"Karen McAninch","41570","1039250","9/30/2020 12:02"
-,"Secretary","Sumner","CNN","Virginia","Petersen","c/o CNN 4415 NE 87th Ave","Portland","OR","97220","(503) 775-0953",,"virgepete@msn.com","Virginia Petersen","33562","302058","9/30/2020 12:03"
-,"Treasurer/Finance Committee Chair","Sumner","CNN","Janet","Shannon","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,,"Janet Shannon","41752","1377816","9/30/2020 12:04"
-,"Land Use/Planning Committee Chair/Co-Chair","Sumner","CNN","Dave","Ganslein","c/o CNN 4415 NE 87th Ave","Portland","OR","97220",,,"daveganslein@hotmail.com","Dave Ganslein","41954","1762068","9/30/2020 12:03"
-,"City Required Notice Contact/Co-Contact","Sumner","CNN","SumnerAN","RequiredNoticeContact","4415 NE 87th Ave.","Portland","OR","97220",,,"sumner.neighborhood.chair@gmail.com","SumnerAN RequiredNoticeContact","40663","1585857","12/12/2016 13:21"
-,"General correspondance","Sumner","CNN","SumnerAN","GeneralCorrespContact","4415 NE 87th Ave.","Portland","OR","97220",,"(503) 823-3157","sumner.neighborhood.chair@gmail.com","SumnerAN GeneralCorrespContact","40664","894608","12/12/2016 13:21"
-,"Vice Chair/Vice President","Sunderland","CNN","Lisa","Larson","c/o CNN 4415 NE 87th Ave - neighborhood association is currently inactive","Portland","OR",,,,,"Lisa Larson","41952","1048800","10/1/2020 13:28"
-,"City Required Notice Contact/Co-Contact","Sunderland","CNN","SunderlandNA","RequiredNoticeContact","c/o CNN, 4415 NE 87th Ave.","Portland","OR","97220",,,"sandral@cnncoalition.org","SunderlandNA RequiredNoticeContact","40968","1597752","4/4/2018 12:42"
-,"General correspondance","Sunderland","CNN","SunderlandNA","GeneralCorrespondenceContact","c/o CNN, 4415 NE 87th Ave.","Portland","OR","97220",,"(503) 823-3156","sandral@cnncoalition.org","SunderlandNA GeneralCorrespondenceContact","40969","901318","3/13/2017 16:43"
-,"Chair/Co-Chair/President","Sunnyside","SEUL","Matt","Lembo",,"Portland","OR",,"(503) 705-7609",,"matt.lembo@gmail.com","Matt Lembo","41920","1006080","12/9/2019 8:08"
-,"Vice Chair/Vice President","Sunnyside","SEUL","Reuben","Deumling",,"Portland","OR","97214",,,,"Reuben Deumling","32955","823875","7/5/2013 16:54"
-,"Secretary","Sunnyside","SEUL","Lorraine","Henriques",,"Portland","OR","97214",,,,"Lorraine Henriques","37462","337158","7/5/2013 16:59"
-,"Treasurer/Finance Committee Chair","Sunnyside","SEUL","K.C.","Hoffert",,"Portland","OR",,,,,"K.C. Hoffert","41921","1383393","12/9/2019 8:11"
-,"City Required Notice Contact/Co-Contact","Sunnyside","SEUL","SunnysideNA","RequiredNoticeContact",,"Portland","OR",,,,,"SunnysideNA RequiredNoticeContact","41082","1602198","3/10/2017 11:52"
-,"General correspondance","Sunnyside","SEUL","SunnysideNA","GeneralCorrespondenceContact",,"Portland","OR",,,,,"SunnysideNA GeneralCorrespondenceContact","41083","903826","3/10/2017 11:53"
-,"Chair/Co-Chair/President","Sylvan-Highlands","NWNW","Michele","Shea-Han",,"Portland","OR",,,,"president@sylvanhighlands.org","Michele Shea-Han","41951","1006824","8/26/2020 16:07"
-,"Vice Chair/Vice President","Sylvan-Highlands","NWNW","Sally","Knueven",,,,,"(503) 226-4850",,,"Sally Knueven","2232","55800","4/1/2001 0:00"
-,"Secretary","Sylvan-Highlands","NWNW","Sally","Knueven",,,,,"(503) 226-4850",,,"Sally Knueven","2232","20088","4/1/2001 0:00"
-,"Treasurer/Finance Committee Chair","Sylvan-Highlands","NWNW","Dave","Malcolm",,"Portland","OR","97221","(503) 805-9587",,"djm.shna@gmail.com","Dave Malcolm","30753","1014849","8/31/2020 11:54"
-,"Land Use/Planning Committee Chair/Co-Chair","Sylvan-Highlands","NWNW","Rick","Kneuven","5200 SW Barnes Road","Portland","OR","97221","(503) 226-4850","(503) 294-2018","rkneuven@netscape.net","Rick Kneuven","3581","150402","8/26/2020 16:05"
-,"Land Use/Planning Committee Chair/Co-Chair","Sylvan-Highlands","NWNW","Dave","Malcolm",,"Portland","OR","97221","(503) 805-9587",,"djm.shna@gmail.com","Dave Malcolm","30753","1291626","8/31/2020 11:54"
-,"City Required Notice Contact/Co-Contact","Sylvan-Highlands","NWNW","SHNA","Required/General/CertifiedContact","2257 NW Raleigh St","Portland","OR","97203","(503) 823-4288",,"president@sylvanhighlands.org","SHNA Required/General/CertifiedContact","40618","1584102","12/11/2020 17:57"
-,"General correspondance","Sylvan-Highlands","NWNW","SHNA","Required/General/CertifiedContact","2257 NW Raleigh St","Portland","OR","97203","(503) 823-4288",,"president@sylvanhighlands.org","SHNA Required/General/CertifiedContact","40618","893596","12/11/2020 17:57"
-,"Chair/Co-Chair/President","University Park","NPNS","Mike","Lambert",,"Portland","OR",,,,"mike.lambert@upnapdx.org","Mike Lambert","42023","1008552","3/22/2021 21:13"
-,"Secretary","University Park","NPNS","Tom","Karwaki",,"Portland","OR",,,,"karwaki@yahoo.com","Tom Karwaki","41972","377748","11/3/2020 17:51"
-,"Treasurer/Finance Committee Chair","University Park","NPNS","Jacob","Williams",,,"OR",,,,"UPNAjacob@gmail.com","Jacob Williams","39922","1317426","11/5/2020 9:57"
-,"Land Use/Planning Committee Chair/Co-Chair","University Park","NPNS","Tom","Karwaki","2209 N Schofield","Portland","OR","97217","(253) 318-2075",,"karwaki@yahoo.com","Tom Karwaki","39395","1654590","11/5/2020 10:09"
-,"City Required Notice Contact/Co-Contact","University Park","NPNS","UniversityParkNA","RequiredNoticeContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"karwaki@yahoo.com","UniversityParkNA RequiredNoticeContact","40949","1597011","11/5/2020 9:57"
-,"General correspondance","University Park","NPNS","UniversityParkNA","GeneralCorrespondenceContact","North Portland Neighborhood Services 2209 N. Schofield St.","Portland","OR","97217",,,"matthew.glazewski@gmail.com","UniversityParkNA GeneralCorrespondenceContact","40950","900900","11/5/2020 9:58"
-,"Chair/Co-Chair/President","Vernon","NECN","Christine","Laliberte",,"Portland","OR",,,,"calaliberte@gmail.com","Christine Laliberte","41912","1005888","10/24/2019 14:36"
-,"City Required Notice Contact/Co-Contact","Vernon","NECN","VernonNA Land Use","RequiredNoticeContact","c/o Northeast Coalition of Neighborhoods 4815 NE 7th Ave","Portland","OR","97211",,,"vnaboard@gmail.com","VernonNA Land Use RequiredNoticeContact","41136","1604304","11/17/2020 19:02"
-,"General correspondance","Vernon","NECN","VernonNA","GeneralCorrespondenceContact","c/o Northeast Coalition of Neighborhoods 4815 NE 7th Ave","Portland","OR","97211",,,,"VernonNA GeneralCorrespondenceContact","41137","905014","3/13/2017 13:31"
-,"City Required Notice Contact/Co-Contact","West Portland Park","SWNI","WestPortlandParkNA","RequiredNoticeContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-wpp@swni.org","WestPortlandParkNA RequiredNoticeContact","41029","1600131","8/7/2017 17:06"
-,"General correspondance","West Portland Park","SWNI","WestPortlandParkNA","GeneralCorrespondenceContact","c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy","Portland","OR","97219-2457",,,"contact-wpp@swni.org","WestPortlandParkNA GeneralCorrespondenceContact","41030","902660","8/7/2017 17:14"
-,"Chair/Co-Chair/President","Wilkes","EPCO","Richard","Mohle",,"Portland","OR",,,,"richardmohley@gmail.com","Richard Mohle","39989","959736","12/17/2015 13:12"
-,"Land Use/Planning Committee Chair/Co-Chair","Wilkes","EPCO","Richard","Anderson",,"Portland",,"97230","(503) 254-1625",,"randers1000@gmail.com","Richard  Anderson","38033","1597386","3/18/2019 15:38"
-,"City Required Notice Contact/Co-Contact","Wilkes","EPCO","WilkesCmtyGroup","RequiredNoticeContact","1017 NE 117th","Portland","OR","97220",,,"wilkes.communitygroup.chair@gmail.com","WilkesCmtyGroup RequiredNoticeContact","40857","1593423","2/8/2017 11:23"
-,"General correspondance","Wilkes","EPCO","WilkesCmtyGroup","GeneralCorrespondenceContact","1017 NE 117th","Portland","OR","97220",,,"wilkes.communitygroup.chair@gmail.com","WilkesCmtyGroup GeneralCorrespondenceContact","40858","898876","2/8/2017 11:25"
-,"City Required Notice Contact/Co-Contact","Woodland Park","EPCO","WoodlandParkNA","RequiredNoticeContact","1017 NE 117th Ave.","Portland","OR","97220",,,"woodlandparkneighbors@gmail.com","WoodlandParkNA RequiredNoticeContact","41109","1603251","2/25/2020 12:44"
-,"General correspondance","Woodland Park","EPCO","WoodlandParkNA","GeneralCorrespondenceContact","1017 NE 117th Ave.","Portland","OR","97220",,,"woodlandparkneighbors@gmail.com","WoodlandParkNA GeneralCorrespondenceContact","41110","904420","2/25/2020 12:44"
-,"Chair/Co-Chair/President","Woodlawn","NECN","Melody","Randolph",,"Portland","OR",,,,"medicalmelody@gmail.com","Melody Randolph","41905","1005720","10/3/2019 16:04"
-,"Chair/Co-Chair/President","Woodlawn","NECN","Maija","Spencer",,"Portland","OR",,,,"maijaspencer@hotmail.com","Maija Spencer","1052","25248","11/14/2016 13:23"
-,"Land Use/Planning Committee Chair/Co-Chair","Woodlawn","NECN","Anjala","Ehelebe",,"Portland","OR",,,,"aehelebe@gmail.com","Anjala Ehelebe","41908","1760136","10/8/2019 14:21"
-,"Land Use/Planning Committee Chair/Co-Chair","Woodlawn","NECN","Patricia","Rimmer",,"Portland","OR",,,,"rimmer9492@comcast.net","Patricia Rimmer","41909","1760178","10/9/2019 13:08"
-,"City Required Notice Contact/Co-Contact","Woodlawn","NECN","WoodlawnNA","RequiredNoticeContact","4815 NE 7th Ave","Portland","OR","97211",,,"info@gowoodlawn.com; maijaspencer@hotmail.com","WoodlawnNA RequiredNoticeContact","41139","1604421","4/9/2019 12:26"
-,"General correspondance","Woodlawn","NECN","WoodlawnNA","GeneralCorrespondenceContact","Northeast Coalition of Neighborhoods 4815 NE 7th Ave","Portland","OR","97211",,,"info@gowoodlawn.com; maijaspencer@hotmail.com","WoodlawnNA GeneralCorrespondenceContact","41140","905080","2/7/2018 14:10"
-,"Chair/Co-Chair/President","Woodstock","SEUL","Becky","Luening",,"Portland","OR","97206",,,,"Becky Luening","37463","899112","7/21/2016 12:13"
-,"Chair/Co-Chair/President","Woodstock","SEUL","Elisa","Edgington",,"Portland","OR","97206",,,,"Elisa Edgington","38475","923400","7/21/2016 12:13"
-,"Secretary","Woodstock","SEUL","Florence","Dezeix",,"Portland","OR","97206",,,,"Florence Dezeix","39562","356058","7/21/2016 11:57"
-,"Treasurer/Finance Committee Chair","Woodstock","SEUL","Merrilee","Spence",,"Portland","OR","97206",,,,"Merrilee Spence","39105","1290465","7/21/2016 12:13"
-,"Land Use/Planning Committee Chair/Co-Chair","Woodstock","SEUL","Thatch","Moyle",,"Portland","OR",,,,"thatchmoyle@gmail.com","Thatch Moyle","41248","1732416","11/10/2020 14:34"
-,"City Required Notice Contact/Co-Contact","Woodstock","SEUL","Thatch","Moyle",,"Portland","OR",,,,"thatchmoyle@gmail.com","Thatch Moyle","41085","1602315","11/10/2020 14:35"
-,"General correspondance","Woodstock","SEUL","WoodstockNA","GeneralCorrespondenceContact","5905 SE 43rd Ave.","Portland","OR","97206","(503) 278-6265",,"ekedgin@gmail.com","WoodstockNA GeneralCorrespondenceContact","41086","903892","6/22/2018 11:38"
+DUMMY_COL,GROUP_NAME,NEIGHBORHOOD_NAME,COALITION_ACRONYM,FIRST_NAME,LAST_NAME,ADDRESS,CITY,STATE_ABBR,ZIP,HOME_PHONE,WORK_PHONE,EMAIL,CONTACT_NAME,CONTACT_ID,CONTACT_ID_UNIQUE,DATE_MODIFIED
+,Chair/Co-Chair/President,Alameda,NECN,Steve,Backer,,Portland,,,,,stevebacker@gmail.com,Steve Backer,37752,906048,10/30/2012 10:19
+,Chair/Co-Chair/President,Alameda,NECN,Robert,McConville,,Portland,OR,,,,rfmcconville@gmail.com,Robert McConville,42008,1008192,3/5/2021 17:41
+,Chair/Co-Chair/President,Alameda,NECN,Travis,Weedman,,Portland,OR,,,,travis@weedmandesignpartners.com,Travis Weedman,42009,1008216,3/5/2021 17:53
+,Secretary,Alameda,NECN,Mariah,Dulah,,Portland,OR,97212,,,,Mariah Dulah,32227,290043,6/12/2018 13:58
+,Treasurer/Finance Committee Chair,Alameda,NECN,Charles,Rice,,Portland,OR,,,,,Charles Rice,37480,1236840,6/12/2018 13:59
+,Treasurer/Finance Committee Chair,Alameda,NECN,Charles,Rice,,Portland,OR,97212,,,,Charles Rice,4073,134409,6/12/2018 13:55
+,City Required Notice Contact/Co-Contact,Alameda,NECN,AlamedaNA,RequiredNoticeContact,2806 NE Bryce,Portland,OR,97212,,,stevebacker@gmail.com,AlamedaNA RequiredNoticeContact,41112,1603368,3/9/2021 13:15
+,General correspondance,Alameda,NECN,AlamedaNA,GeneralCorrespondenceContact,2806 NE Bryce,Portland,OR,97212,,,scottarider@gmail.com; alamedapdx@gmail.com,AlamedaNA GeneralCorrespondenceContact,41113,904486,6/12/2018 14:02
+,Chair/Co-Chair/President,Arbor Lodge,NPNS,Andrea,Matthews,2209 N. Schofield,Portland,OR,97217,,,arborlodgeandrea@gmail.com,Andrea Matthews,41968,1007232,11/3/2020 15:07
+,Vice Chair/Vice President,Arbor Lodge,NPNS,Susan,Harris,,Portland,OR,,,,susan@arborlodgeneighborhood.com,Susan Harris,42022,1050550,5/27/2021 15:01
+,Secretary,Arbor Lodge,NPNS,Tommy,Styles,,Portland,OR,,,,tommy@tommystyles.com,Tommy Styles,41984,377856,12/16/2020 12:09
+,Land Use/Planning Committee Chair/Co-Chair,Arbor Lodge,NPNS,Dan,Craver,,Portland,OR,,,,landuse@arborlodgeneighborhood.com,Dan Craver,41686,1750812,11/2/2020 15:36
+,City Required Notice Contact/Co-Contact,Arbor Lodge,NPNS,ArborLodgeNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N Schofield,Portland,OR,97217,,,landuse@arborlodgeneighborhood.com,ArborLodgeNA RequiredNoticeContact,40922,1595958,5/30/2017 14:37
+,General correspondance,Arbor Lodge,NPNS,ArborLodgeNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St,Portland,OR,97217,,,board@arborlodgeneighborhood.com,ArborLodgeNA GeneralCorrespondenceContact,40923,900306,11/28/2017 15:11
+,Chair/Co-Chair/President,Ardenwald-Johnson Creek,SEUL,Matt,Rinker,,Milwaukie,OR,97222,,,,Matt Rinker,26947,646728,1/23/2019 13:20
+,Vice Chair/Vice President,Ardenwald-Johnson Creek,SEUL,Jeff,Davis,,Milwaukie,OR,97222,,,,Jeff Davis,33463,836575,1/23/2019 13:23
+,Treasurer/Finance Committee Chair,Ardenwald-Johnson Creek,SEUL,Mark,Taylor,,Milwaukie,OR,97222,,,,Mark Taylor,41441,1367553,9/26/2017 17:21
+,Land Use/Planning Committee Chair/Co-Chair,Ardenwald-Johnson Creek,SEUL,Lisa,Gunion-Rinker,,Portland,OR,97222,,,astrantialgr@gmail.com,Lisa Gunion-Rinker,30013,1260546,3/7/2018 13:45
+,City Required Notice Contact/Co-Contact,Ardenwald-Johnson Creek,SEUL,ArdenwaldJohnsonCrkNA,RequiredNoticeContact,,Portland,OR,,,,,ArdenwaldJohnsonCrkNA RequiredNoticeContact,41038,1600482,3/10/2017 10:33
+,General correspondance,Ardenwald-Johnson Creek,SEUL,ArdenwaldJohnsonCrkNA,GeneralCorrespondenceContact,,Portland,OR,,,,,ArdenwaldJohnsonCrkNA GeneralCorrespondenceContact,41039,902858,3/10/2017 10:33
+,Chair/Co-Chair/President,Argay Terrace,EPCO,Doug,Cook,PO Box 20635,Portland,OR,97294-0635,,,doug.cook12@gmail.com,Doug Cook,39980,959520,12/17/2015 12:17
+,Vice Chair/Vice President,Argay Terrace,EPCO,Craig,Tolonen,,Portland,OR,,,,argayvpcraig@centurylink.net,Craig Tolonen,39981,999525,12/17/2015 12:21
+,Treasurer/Finance Committee Chair,Argay Terrace,EPCO,Bill,Lindekugel,14535 NE Rose Parkway,Portland,OR,97230,,,,Bill Lindekugel,39313,1297329,7/14/2015 14:04
+,City Required Notice Contact/Co-Contact,Argay Terrace,EPCO,ArgayTerraceNA,RequiredNoticeContact,,Portland,OR,,,,,ArgayTerraceNA RequiredNoticeContact,41088,1602432,3/10/2017 12:17
+,General correspondance,Argay Terrace,EPCO,ArgayTerraceNA,GeneralCorrespondenceContact,,Portland,OR,,,,,ArgayTerraceNA GeneralCorrespondenceContact,41089,903958,3/10/2017 12:18
+,Chair/Co-Chair/President,Arlington Heights,NWNW,Kathy,Goeddel,"c/o NWNW, 2257 NW Raleigh",Portland,OR,97210,,,president@arlingtonheightspdx.org,Kathy Goeddel,39410,945840,12/6/2018 15:32
+,Chair/Co-Chair/President,Arlington Heights,NWNW,Kristi,Wuttig,,Portland,OR,,,,president@arlingtonheightspdx.org,Kristi Wuttig,41814,1003536,12/6/2018 15:38
+,Secretary,Arlington Heights,NWNW,Jim,Cameron,,Portland,OR,,,,planning@arlingtonheightspdx.org,Jim Cameron,41992,377928,1/14/2021 12:11
+,Treasurer/Finance Committee Chair,Arlington Heights,NWNW,Richard,Turner,,Portland,OR,,,,treasurer@arlingtonheightspdx.org,Richard Turner,41526,1370358,12/6/2018 15:33
+,Land Use/Planning Committee Chair/Co-Chair,Arlington Heights,NWNW,Kathy,Goeddel,"c/o NWNW, 2257 NW Raleigh",Portland,OR,97210,,,president@arlingtonheightspdx.org,Kathy Goeddel,39410,1655220,12/6/2018 15:32
+,Land Use/Planning Committee Chair/Co-Chair,Arlington Heights,NWNW,Jim,Cameron,,Portland,OR,,,,planning@arlingtonheightspdx.org,Jim Cameron,41992,1763664,1/14/2021 12:11
+,City Required Notice Contact/Co-Contact,Arlington Heights,NWNW,AHNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@arlingtonheightspdx.org,AHNA Required/General/CertifiedContact,40619,1584141,11/30/2016 18:39
+,General correspondance,Arlington Heights,NWNW,AHNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@arlingtonheightspdx.org,AHNA Required/General/CertifiedContact,40619,893618,11/30/2016 18:39
+,Land Use/Planning Committee Chair/Co-Chair,Arnold Creek,Includes City supported SW Neighborhoods,Nancy,Mattson,,Portland,OR,,,,board@arnoldcreek.org,Nancy Mattson,42040,1765680,8/13/2021 10:46
+,City Required Notice Contact/Co-Contact,Ashcreek,Includes City supported SW Neighborhoods,AshcreekNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@ashcreekna.org,AshcreekNA RequiredNoticeContact,40983,1598337,8/13/2021 10:43
+,General correspondance,Ashcreek,Includes City supported SW Neighborhoods,AshcreekNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@ashcreekna.org,AshcreekNA GeneralCorrespondenceContact,40984,901648,8/13/2021 10:44
+,Chair/Co-Chair/President,Beaumont-Wilshire,CNN,Tim,Gillespie,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,(503) 287-6272,,president@bwnapdx.org,Tim Gillespie,41962,1007088,1/5/2021 14:59
+,Vice Chair/Vice President,Beaumont-Wilshire,CNN,Andrew,Rinke,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,info@bwnapdx.org,Andrew Rinke,41963,1049075,5/24/2021 11:41
+,Secretary,Beaumont-Wilshire,CNN,Barbara,Strunk,"c/o CNN, 4415 NE 87th Ave.",Portland,OR,97220,(503) 284-7502,,secretary@bwnapdx.org,Barbara Strunk,41194,370746,12/15/2020 13:50
+,Treasurer/Finance Committee Chair,Beaumont-Wilshire,CNN,Karla,Lenox,"c/o CNN, 4415 NE 87th Ave",Portland,OR,97220,,,treasurer@bwnapdx.org,Karla Lenox,39171,1292643,3/22/2021 13:15
+,City Required Notice Contact/Co-Contact,Beaumont-Wilshire,CNN,Beaumont-Wilshire,NeighborhoodAssociation,"c/o The Postal Station, 2000 NE 42nd Ave., Ste. #394",Portland,OR,97213-1397,,,info@bwnapdx.org,Beaumont-Wilshire NeighborhoodAssociation,40952,1597128,3/22/2021 13:23
+,General correspondance,Beaumont-Wilshire,CNN,Beaumont-Wilshire,NeighborhoodAssociation,"c/o The Postal Station, 2000 NE 42nd Ave., Ste. #394",Portland,OR,97213-1397,,,info@bwnapdx.org,Beaumont-Wilshire NeighborhoodAssociation,40953,900966,3/22/2021 13:24
+,Chair/Co-Chair/President,Boise,NECN,Howard,Patterson,,Portland,OR,,,,boisena@gmail.com,Howard Patterson,41982,1007568,11/17/2020 18:51
+,Treasurer/Finance Committee Chair,Boise,NECN,Karis,Stoudamire,,Portland,OR,97227,,,karis@stoudamire.com,Karis Stoudamire,29076,959508,1/27/2011 9:58
+,Land Use/Planning Committee Chair/Co-Chair,Boise,NECN,Boise,Landuse,,Portland,OR,,,,boiselanduse@gmail.com,Boise Landuse,40183,1687686,5/3/2016 9:27
+,City Required Notice Contact/Co-Contact,Boise,NECN,BoiseNA,RequiredNoticeContact,c/o Kay Newell of Sunlan Lighting 3901 N. Mississippi Ave,Portland,OR,97227,,,,BoiseNA RequiredNoticeContact,41115,1603485,3/13/2017 13:18
+,General correspondance,Boise,NECN,BoiseNA,GeneralCorrespondenceContact,"c/o Kay Newell of Sunlan Lighting 3901 N. Mississippi Ave,",Portland,OR,97227,,,,BoiseNA GeneralCorrespondenceContact,41116,904552,3/13/2017 13:20
+,Chair/Co-Chair/President,Brentwood-Darlington,SEUL,Chelsea,Powers,,Portland,OR,97206,,,,Chelsea Powers,40632,975168,12/5/2016 14:14
+,Secretary,Brentwood-Darlington,SEUL,Loralie,Cole,,Portland,OR,,,,,Loralie Cole,42056,378504,6/8/2021 15:34
+,Treasurer/Finance Committee Chair,Brentwood-Darlington,SEUL,Lynn,Reck,,Portland,OR,,,,,Lynn Reck,34496,1138368,12/9/2019 14:11
+,Land Use/Planning Committee Chair/Co-Chair,Brentwood-Darlington,SEUL,Stephenie,Frederick,,,OR,,,,bdlanduse@gmail.com,Stephenie Frederick,39413,1655346,6/8/2021 15:34
+,City Required Notice Contact/Co-Contact,Brentwood-Darlington,SEUL,BrentwoodDarlingtonNA,RequiredNoticeContact,7211 SE 62ND AVE,Portland,OR,97206,,,bdlanduse@gmail.com,BrentwoodDarlingtonNA RequiredNoticeContact,40974,1597986,12/9/2019 14:12
+,General correspondance,Brentwood-Darlington,SEUL,BrentwoodDarlingtonNA,GeneralCorrespondenceContact,7211 SE 62nd Ave,Portland,OR,97206,,,,BrentwoodDarlingtonNA GeneralCorrespondenceContact,40975,901450,11/10/2020 13:49
+,Chair/Co-Chair/President,Bridgeton,NPNS,Tom,Hickey,2209 N. Schofield,Portland,OR,97217,,,hickeyt+bna.pdx@gmail.com,Tom  Hickey,41452,994848,10/16/2018 14:01
+,Secretary,Bridgeton,NPNS,Bridget,Bayer,,Portland,OR,,,(503) 290-4377,bridget@historicparkrose.com,Bridget Bayer,3660,32940,12/4/2017 14:53
+,Treasurer/Finance Committee Chair,Bridgeton,NPNS,Matthew,Whitney,2209 N. Schofield,Portland,OR,97217,,(503) 823-4524,mattwhitney@comcast.net,Matthew Whitney,2798,92334,7/16/2015 14:17
+,City Required Notice Contact/Co-Contact,Bridgeton,NPNS,BridgetonNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield,Portland,OR,97217,,,epmolander@gmail.com,BridgetonNA RequiredNoticeContact,40925,1596075,5/30/2017 14:22
+,General correspondance,Bridgeton,NPNS,BridgetonNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,hickeyt+bna.pdx@gmail.com,BridgetonNA GeneralCorrespondenceContact,40926,900372,10/17/2018 15:18
+,Land Use/Planning Committee Chair/Co-Chair,Bridlemile,Includes City supported SW Neighborhoods,BNA,Contact,"PO Box 123, 6663 SW Beaveron HIllsdale Hwy",Portland,OR,97225,,,board@bridlemilepdx.org,BNA Contact,36920,1550640,8/25/2021 15:46
+,City Required Notice Contact/Co-Contact,Bridlemile,Includes City supported SW Neighborhoods,BNA,Contact,"PO Box 123, 6663 SW Beaveron HIllsdale Hwy",Portland,OR,97225,,,board@bridlemilepdx.org,BNA Contact,36920,1439880,8/25/2021 15:46
+,General correspondance,Bridlemile,Includes City supported SW Neighborhoods,BridlemileNA,GeneralCorrespondenceContact,"PO Box 123, 6663 SW Beaverton Hillsdale Hwy",Portland,OR,97225,,,board@bridlemilepdx.org,BridlemileNA GeneralCorrespondenceContact,40987,901714,8/25/2021 15:45
+,Chair/Co-Chair/President,Brooklyn,SEUL,Josh,Hetrick,,Portland,OR,,,,chair@brooklyn-neighborhood.org,Josh Hetrick,40449,970776,4/2/2021 18:28
+,Vice Chair/Vice President,Brooklyn,SEUL,Melaney,Dittler,,Portland,OR,,,,board@brooklyn-neighborhood.org,Melaney Dittler,37782,944550,8/20/2021 18:42
+,Secretary,Brooklyn,SEUL,John,Karabaic,,Portland,OR,,,,board@brooklyn-neighborhood.org,John Karabaic,41467,373203,4/2/2021 18:38
+,Treasurer/Finance Committee Chair,Brooklyn,SEUL,Tim,Walsh,,Portland,OR,,,,board@brooklyn-neighborhood.org,Tim Walsh,17573,579909,4/2/2021 18:39
+,Land Use/Planning Committee Chair/Co-Chair,Brooklyn,SEUL,Josh,Hetrick,,Portland,OR,,,,chair@brooklyn-neighborhood.org,Josh Hetrick,40449,1698858,4/2/2021 18:28
+,City Required Notice Contact/Co-Contact,Brooklyn,SEUL,BrooklynActionCorps,RequiredNoticeContact,,Portland,OR,,,,,BrooklynActionCorps RequiredNoticeContact,41042,1600638,3/10/2017 10:37
+,General correspondance,Brooklyn,SEUL,BrooklynActionCorps,GeneralCorrespondenceContact,,Portland,OR,,,,,BrooklynActionCorps GeneralCorrespondenceContact,41043,902946,3/10/2017 10:39
+,Chair/Co-Chair/President,Buckman,SEUL,Stephen,Fischer,,Portland,OR,,,,s3fisher@mac.com,Stephen Fischer,40450,970800,8/20/2021 19:03
+,Chair/Co-Chair/President,Buckman,SEUL,Susan,Lindsay,,Portland,OR,97214,,,,Susan Lindsay,1686,40464,1/26/2017 21:00
+,Secretary,Buckman,SEUL,Jeffrey,Yaskin,,Portland,OR,,,,,Jeffrey  Yaskin,42069,378621,8/20/2021 19:10
+,Treasurer/Finance Committee Chair,Buckman,SEUL,Nick,Olson,,Portland,OR,,,,buckmanlandusepdx@gmail.com,Nick Olson,41998,1385934,1/28/2021 11:52
+,Land Use/Planning Committee Chair/Co-Chair,Buckman,SEUL,John,Rose,,Portland,OR,,,,,John Rose,42068,1766856,8/20/2021 19:09
+,Land Use/Planning Committee Chair/Co-Chair,Buckman,SEUL,Josh,Baker,,Portland,OR,,,,buckmanlandusepdx@gmail.com,Josh Baker,40454,1699068,1/28/2021 11:50
+,City Required Notice Contact/Co-Contact,Buckman,SEUL,Buckman Community Association,RequiredNoticeContact,3534 SE Main St.,Portland,OR,97214,,,,Buckman Community Association RequiredNoticeContact,41045,1600755,12/28/2018 11:36
+,General correspondance,Buckman,SEUL,BuckmanCmtyAsso,GeneralCorrespondenceContact,,Portland,OR,,,,,BuckmanCmtyAsso GeneralCorrespondenceContact,41046,903012,3/10/2017 10:45
+,Chair/Co-Chair/President,Cathedral Park,NPNS,Jon,Smart,,Portland,OR,,,(503) 303-0990,chair@cathedralparkpdx.org,Jon Smart,41635,999240,6/23/2020 13:59
+,Secretary,Cathedral Park,NPNS,Nico,Smith,,Portland,OR,,,,smithofnico@gmail.com,Nico Smith,41579,374211,12/19/2017 13:21
+,Land Use/Planning Committee Chair/Co-Chair,Cathedral Park,NPNS,Steve,Capoccia,,Portland,OR,,,,cpna.landuse@gmail.com,Steve Capoccia,41795,1755390,3/25/2020 16:41
+,City Required Notice Contact/Co-Contact,Cathedral Park,NPNS,CathedralParkNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St,Portland,OR,97217,,,scapoccia21@gmail.com,CathedralParkNA RequiredNoticeContact,40928,1596192,10/17/2018 15:20
+,General correspondance,Cathedral Park,NPNS,CathedralParkNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St,Portland,OR,97217,,,chair@cathedralparkpdx.org,CathedralParkNA GeneralCorrespondenceContact,40929,900438,5/20/2021 14:43
+,Chair/Co-Chair/President,Centennial,EPCO,Daniel,Bramske,,Portland,OR,,,,dbramske@gmail.com,Daniel Bramske,41896,1005504,9/8/2021 14:05
+,Secretary,Centennial,EPCO,Gayle,Palmer,,Portland,OR,,,,,Gayle Palmer,41897,377073,9/6/2019 11:10
+,Treasurer/Finance Committee Chair,Centennial,EPCO,Jessica,Edholm,,Portland,OR,,,,,Jessica Edholm,41898,1382634,9/6/2019 11:10
+,City Required Notice Contact/Co-Contact,Centennial,EPCO,CentennialCmtyAsso,RequiredNoticeContact,,Portland,OR,,,,,CentennialCmtyAsso RequiredNoticeContact,41091,1602549,3/10/2017 12:21
+,General correspondance,Centennial,EPCO,CentennialCmtyAsso,GeneralCorrespondenceContact,,Portland,OR,,,,,CentennialCmtyAsso GeneralCorrespondenceContact,41092,904024,3/10/2017 12:21
+,City Required Notice Contact/Co-Contact,Collins View,Includes City supported SW Neighborhoods,CollinsViewNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@collinsview.org,CollinsViewNA RequiredNoticeContact,40989,1598571,8/13/2021 10:07
+,General correspondance,Collins View,Includes City supported SW Neighborhoods,CollinsViewNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@collinsview.org,CollinsViewNA GeneralCorrespondenceContact,40990,901780,8/13/2021 10:07
+,Chair/Co-Chair/President,Concordia,NECN,Astrid,Furstner,,Portland,OR,,,,astrid.b.furstner@gmail.com,Astrid Furstner,41934,1006416,1/6/2020 11:32
+,Vice Chair/Vice President,Concordia,NECN,Garlynn,Woodsong,5267 NE 29th Ave.,Portland,OR,97211,(503) 936-9873,,landuse@concordiapdx.org,Garlynn Woodsong,38663,966575,8/16/2017 9:24
+,Secretary,Concordia,NECN,Steve,Elder,4910 NE 34th Ave,Portland,OR,97211,,,east2@concordiapdx.org,Steve Elder,22885,205965,1/10/2020 15:04
+,Treasurer/Finance Committee Chair,Concordia,NECN,Heather,Pashley,,Portland,OR,,,,Treasurer@concordiapdx.org,Heather Pashley,41344,1364352,8/15/2017 15:45
+,Land Use/Planning Committee Chair/Co-Chair,Concordia,NECN,Garlynn,Woodsong,5267 NE 29th Ave.,Portland,OR,97211,(503) 936-9873,,landuse@concordiapdx.org,Garlynn Woodsong,38663,1623846,8/16/2017 9:24
+,City Required Notice Contact/Co-Contact,Concordia,NECN,Garlynn,Woodsong,5267 NE 29th Ave.,Portland,OR,97211,(503) 936-9873,,landuse@concordiapdx.org,Garlynn Woodsong,38663,1507857,8/16/2017 9:24
+,General correspondance,Concordia,NECN,Astrid,Furstner,PO Box 11194,Portland,OR,97211,(503) 290-6871,,Chair@concordiapdx.org,Astrid Furstner,41119,904618,1/6/2020 11:48
+,Chair/Co-Chair/President,Creston-Kenilworth,SEUL,Elizabeth,Durham McPherson,,Portland,OR,,,,ckna.chair@gmail.com,Elizabeth  Durham McPherson,42071,1009704,8/20/2021 19:49
+,Secretary,Creston-Kenilworth,SEUL,Ann,Duran,,Portland,OR,,,,,Ann Duran,41196,370764,8/20/2021 19:52
+,Treasurer/Finance Committee Chair,Creston-Kenilworth,SEUL,Seth,Otto,,Portland,OR,,,,ckna.landchair@gmail.com,Seth Otto,40260,1328580,12/16/2020 13:21
+,Land Use/Planning Committee Chair/Co-Chair,Creston-Kenilworth,SEUL,Seth,Otto,,Portland,OR,,,,ckna.landchair@gmail.com,Seth Otto,40260,1690920,12/16/2020 13:21
+,City Required Notice Contact/Co-Contact,Creston-Kenilworth,SEUL,Creston-KenilworthNA,RequiredNoticeContact,,Portland,OR,,,,,Creston-KenilworthNA RequiredNoticeContact,41048,1600872,3/10/2017 10:49
+,General correspondance,Creston-Kenilworth,SEUL,Creston-KenilworthNA,GeneralCorrespondenceContact,3586 SE 26th Ave,Portland,OR,97202,,,,Creston-KenilworthNA GeneralCorrespondenceContact,41049,903078,12/12/2018 14:23
+,Chair/Co-Chair/President,Crestwood,Includes City supported SW Neighborhoods,Mary,Fitzgerald,"c/o 10537 SW 64th dr,",Portland,OR,97219,(503) 246-1847,,crestwood-board@swni.org,Mary Fitzgerald,31465,755160,8/19/2021 19:56
+,Secretary,Crestwood,Includes City supported SW Neighborhoods,Charles,Mosley,,Portland,OR,,,,crestwood-board@swni.org,Charles Mosley,42039,378351,8/13/2021 10:03
+,Treasurer/Finance Committee Chair,Crestwood,Includes City supported SW Neighborhoods,Charles,Mosley,,Portland,OR,,,,crestwood-board@swni.org,Charles Mosley,42039,1387287,8/13/2021 10:03
+,General correspondance,Crestwood,Includes City supported SW Neighborhoods,Mary,Fitzgerald,"c/o 10537 SW 64th dr,",Portland,OR,97219,(503) 246-1847,,crestwood-board@swni.org,Mary Fitzgerald,31465,692230,8/19/2021 19:56
+,Chair/Co-Chair/President,Cully,CNN,Josh,Heumann,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,(503) 853-0771,,heumann@gmail.com,Josh Heumann,41862,1004688,7/28/2021 11:35
+,Vice Chair/Vice President,Cully,CNN,Isha,Leinow,4415 NE 87th Ave,Portland,OR,97220,,,ishalelnow@gmail.com,Isha Leinow,42051,1051275,5/27/2021 14:25
+,Secretary,Cully,CNN,Maria,Grzanka,4415 NE 87th Ave,Portland,OR,97220,,,,Maria Grzanka,42044,378396,4/21/2021 13:17
+,Treasurer/Finance Committee Chair,Cully,CNN,Vena,Rainwater,4415 NE 87th Ave,Portland,OR,97220,,,vena.rain@gmail.com,Vena Rainwater,42045,1387485,7/28/2021 11:34
+,Land Use/Planning Committee Chair/Co-Chair,Cully,CNN,David,Sweet,4759 NE Going St.,Portland,OR,97218,(503) 493-9434,,cullyguy@gmail.com,David Sweet,2983,125286,12/13/2016 16:42
+,City Required Notice Contact/Co-Contact,Cully,CNN,CullyAN,RequiredNoticeContact,4415 NE 87th Ave.,Portland,OR,97220,,,cully@cullyneighbors.org,CullyAN RequiredNoticeContact,40692,1586988,1/4/2017 14:08
+,General correspondance,Cully,CNN,CullyAN,GeneralCorrespondenceContact,4415 NE 87th Ave.,Portland,OR,97220,,,cully@cullyneighbors.org,CullyAN GeneralCorrespondenceContact,40693,895246,1/4/2017 14:10
+,Chair/Co-Chair/President,East Columbia,NPNS,Gary,Kunz,,Portland,OR,,,,garymkunz@comcast.net,Gary Kunz,39297,943128,11/3/2020 15:20
+,Treasurer/Finance Committee Chair,East Columbia,NPNS,Karen,Myers,2018 NE Blue Heron Dr.,Portland,OR,97211,(503) 240-4418,(503) 853-6239,rrmyers2018@msn.com,Karen Myers,31749,1047717,1/14/2009 0:00
+,Land Use/Planning Committee Chair/Co-Chair,East Columbia,NPNS,Maryhelen,Kincaid,2030 NE Blue Heron DR,Portland,OR,97211-1680,,,jamasu88@msn.com,Maryhelen Kincaid,39305,1650810,5/3/2016 13:41
+,City Required Notice Contact/Co-Contact,East Columbia,NPNS,EastColumbiaNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,garykunz@comcast.net,EastColumbiaNA RequiredNoticeContact,40931,1596309,9/18/2017 12:43
+,General correspondance,East Columbia,NPNS,EastColumbiaNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,garykunz@comcast.net,EastColumbiaNA GeneralCorrespondenceContact,40932,900504,9/18/2017 12:43
+,Chair/Co-Chair/President,Eastmoreland,SEUL,Matthew,Timberlake,,Portland,OR,,,,vicepresident@eastmorelandpdx.org,Matthew Timberlake,39449,946776,2/10/2020 12:44
+,Vice Chair/Vice President,Eastmoreland,SEUL,Christian,Solsby,,Portland,OR,,,,,Christian Solsby,42063,1051575,8/20/2021 18:35
+,Secretary,Eastmoreland,SEUL,Dinah,Adkins,,Portland,OR,,,,secretary@eastmorelandpdx.org,Dinah Adkins,41746,375714,8/20/2021 18:34
+,Treasurer/Finance Committee Chair,Eastmoreland,SEUL,David,Dowell,,Portland,OR,,,,treasurer@eastmorelandpdx.org,David Dowell,41324,1363692,5/10/2021 16:16
+,Land Use/Planning Committee Chair/Co-Chair,Eastmoreland,SEUL,Rod,Merrick,,Portland,OR,97202,,,president@eastmorelandpdx.org,Rod Merrick,16881,709002,3/19/2018 13:14
+,Land Use/Planning Committee Chair/Co-Chair,Eastmoreland,SEUL,Karissa,Dean,,Portland,OR,,,,,Karissa Dean,42064,1766688,8/20/2021 18:36
+,City Required Notice Contact/Co-Contact,Eastmoreland,SEUL,EastmorelandNA,RequiredNoticeContact,3627 SE Cooper St.,Portland,OR,97202,,,president@eastmorelandpdx.org,EastmorelandNA RequiredNoticeContact,40977,1598103,5/6/2021 16:34
+,General correspondance,Eastmoreland,SEUL,EastmorelandNA,GeneralCorrespondenceContact,PO Box 82520,Portland,OR,97282,,,,EastmorelandNA GeneralCorrespondenceContact,40978,901516,11/15/2017 15:19
+,Chair/Co-Chair/President,Eliot,NECN,Jimmy,Wilson,,Portland,OR,,,,chair@eliotneighborhood.org,Jimmy  Wilson,41926,1006224,12/16/2019 14:03
+,Chair/Co-Chair/President,Eliot,NECN,Allan,Rudwick,228 NE Morris St,Portland,OR,97212,(503) 703-3910,,chair@eliotneighborhood.org,Allan Rudwick,2049,49176,12/16/2019 14:04
+,Secretary,Eliot,NECN,Jennifer,Wilcox,,Portland,OR,,,,jennifer.wilcox@cascadiabhc.org,Jennifer Wilcox,41927,377343,12/16/2019 14:06
+,Treasurer/Finance Committee Chair,Eliot,NECN,Jim,Hlava,,Portland,OR,,,,jim.hlava@cascadiabhc.org  treasurer@eliotneighborhood.org,Jim Hlava,7827,258291,12/16/2019 14:11
+,Land Use/Planning Committee Chair/Co-Chair,Eliot,NECN,Brad,Baker,,Portland,OR,,,,lutcchair@eliotneighborhood.org info@eliotneighborhood.org,Brad  Baker,41907,1760094,12/17/2019 17:39
+,Land Use/Planning Committee Chair/Co-Chair,Eliot,NECN,Jonathan,Konkol,,Portland,OR,97212,,,info@eliotneighborhood.org,Jonathan Konkol,37121,1559082,12/17/2019 17:39
+,City Required Notice Contact/Co-Contact,Eliot,NECN,EliotNA,RequiredNoticeContact,C/o Jimmy Wilson 634 ne church st. Portland Or 97211,Portland,OR,97212,,,,EliotNA RequiredNoticeContact,41121,1603719,12/19/2019 10:25
+,City Required Notice Contact/Co-Contact,Far Southwest,Includes City supported SW Neighborhoods,FarSWNA,RequiredNoticeContact,c/o 6045 SW Haines Street,Portland,OR,97219,,,Campmbellmj74@comcast.net,FarSWNA RequiredNoticeContact,40995,1598805,8/19/2021 19:49
+,General correspondance,Far Southwest,Includes City supported SW Neighborhoods,FarSWNA,GeneralCorrespondenceContact,c/o 6045 SW Haines,Portland,OR,97219,,,Campbellmj74@comcast.net,FarSWNA GeneralCorrespondenceContact,40996,901912,8/19/2021 19:48
+,Chair/Co-Chair/President,Forest Park,NWNW,Carol,Chesarek,,Portland,OR,97231,,,president@forestparkneighbors.org,Carol Chesarek,22626,543024,12/18/2017 19:14
+,Vice Chair/Vice President,Forest Park,NWNW,Susan,Andrews,,Portland,OR,,,,sgoldfield@aol.com,Susan Andrews,41153,1028825,3/22/2017 13:31
+,Treasurer/Finance Committee Chair,Forest Park,NWNW,Les,Blaize,9630 NW Skyline Blvd.,Portland,OR,97231,(503) 286-2206,,lblaize@q.com,Les Blaize,2218,73194,3/25/2016 9:36
+,Land Use/Planning Committee Chair/Co-Chair,Forest Park,NWNW,Jerry,Grossnickle,13510 NW Old Germantown Rd,Portland,OR,97231,(503) 289-3046,,landuse@forestparkneighbors.org,Jerry Grossnickle,33849,1421658,10/4/2019 11:18
+,City Required Notice Contact/Co-Contact,Forest Park,NWNW,FPNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@forestparkneighbors.org,FPNA Required/General/CertifiedContact,40620,1584180,11/30/2016 18:45
+,General correspondance,Forest Park,NWNW,FPNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@forestparkneighbors.org,FPNA Required/General/CertifiedContact,40620,893640,11/30/2016 18:45
+,Chair/Co-Chair/President,Foster-Powell,SEUL,Lotus,Romey-Yu,,,OR,,,,chair@fosterpowell.com,Lotus Romey-Yu,40138,963312,9/30/2021 15:48
+,Secretary,Foster-Powell,SEUL,Jenn,Bass,,Portland,OR,,,,secretary@fosterpowell.com,Jenn Bass,40313,362817,9/30/2021 16:13
+,Treasurer/Finance Committee Chair,Foster-Powell,SEUL,Sean,McClintock,,Portland,OR,,,,treasurer@fosterpowell.com,Sean McClintock,41299,1362867,9/30/2021 15:45
+,Land Use/Planning Committee Chair/Co-Chair,Foster-Powell,SEUL,Joseph,Liu,,Portland,OR,,,,land.use@fosterpowell.com,Joseph Liu,39555,1661310,12/1/2020 13:48
+,City Required Notice Contact/Co-Contact,Foster-Powell,SEUL,Foster-Powell Neighborhood Association,c/o SE Uplift,3534 SE Main St,Portland,OR,97214,,,contact@fosterpowell.com,Foster-Powell Neighborhood Association c/o SE Uplift,41052,1601028,11/10/2020 13:20
+,General correspondance,Foster-Powell,SEUL,Foster-Powell Neighborhood Association,c/o SE Uplift,3534 SE Main St,Portland,OR,97214,,,contact@fosterpowell.com,Foster-Powell Neighborhood Association c/o SE Uplift,41053,903166,11/10/2020 13:21
+,Chair/Co-Chair/President,Glenfair,EPCO,Yoana,Molina,,Portland,OR,,,,chair@glenfairneighborhood.org,Yoana  Molina,41835,1004040,3/18/2019 16:48
+,City Required Notice Contact/Co-Contact,Glenfair,EPCO,GlenfairNA,RequiredNoticeContact,"c/o EPCO, 1017 NE 117th Ave",Portland,OR,97220,,,,GlenfairNA RequiredNoticeContact,41094,1602666,3/18/2019 15:23
+,General correspondance,Glenfair,EPCO,GlenfairNA,GeneralCorrespondenceContact,"c/o EPCO , 1017 NE 117th Ave",Portland,OR,97220,,,,GlenfairNA GeneralCorrespondenceContact,41095,904090,3/18/2019 15:23
+,Chair/Co-Chair/President,Goose Hollow,NWNW,Tracy,Prince,,,,,,,vice-chair@goosehollow.org,Tracy Prince,26442,634608,11/28/2017 13:17
+,Vice Chair/Vice President,Goose Hollow,NWNW,Jerry,Powell,1926 SW Madison St.,Portland,OR,97205-1718,,(503) 222-7173,planning@goosehollow.org,Jerry Powell,1212,30300,5/15/2015 13:34
+,Secretary,Goose Hollow,NWNW,Eva,Kutas,,Portland,OR,,,,secretary@goosehollow.org,Eva Kutas,41935,377415,1/17/2020 16:29
+,Treasurer/Finance Committee Chair,Goose Hollow,NWNW,Bridget,Bimrose,1535 SW Clay St. #216,Portland,OR,97201,(503) 853-2362,,bridgetbimrose@gmail.com,Bridget Bimrose,41790,1379070,10/9/2018 20:09
+,Land Use/Planning Committee Chair/Co-Chair,Goose Hollow,NWNW,Jerry,Powell,1926 SW Madison St.,Portland,OR,97205-1718,,(503) 222-7173,planning@goosehollow.org,Jerry Powell,1212,50904,5/15/2015 13:34
+,Land Use/Planning Committee Chair/Co-Chair,Goose Hollow,NWNW,Scott,Schaffer,,Portland,OR,97201,,,planning@goosehollow.org,Scott Schaffer,33483,1406286,1/17/2020 16:32
+,City Required Notice Contact/Co-Contact,Goose Hollow,NWNW,GHFL,Required/General/CertifiedContact,2257 NW Raleigh St,Portland,OR,97210,,(503) 823-4288,board@goosehollow.org,GHFL Required/General/CertifiedContact,40621,1584219,12/2/2016 13:42
+,General correspondance,Goose Hollow,NWNW,GHFL,Required/General/CertifiedContact,2257 NW Raleigh St,Portland,OR,97210,,(503) 823-4288,board@goosehollow.org,GHFL Required/General/CertifiedContact,40621,893662,12/2/2016 13:42
+,Chair/Co-Chair/President,Grant Park,CNN,Ron,Laster,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,printresults@aol.com,Ron Laster,2936,70464,9/30/2020 12:28
+,Vice Chair/Vice President,Grant Park,CNN,Ron,Laster,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,printresults@aol.com,Ron Laster,2936,73400,9/30/2020 12:28
+,Secretary,Grant Park,CNN,MaryCal,Hanson,4415 NE 87th Ave,Portland,OR,97220,,,marycal@comcast.net,MaryCal Hanson,42048,378432,4/22/2021 11:30
+,Treasurer/Finance Committee Chair,Grant Park,CNN,Ron,Laster,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,printresults@aol.com,Ron Laster,2936,96888,9/30/2020 12:28
+,Land Use/Planning Committee Chair/Co-Chair,Grant Park,CNN,Neon,Brooks,4415 NE 87th Ave,Portland,OR,97220,,,neonbluebrooks@gmail.com,Neon Brooks,42046,1765932,4/22/2021 11:26
+,City Required Notice Contact/Co-Contact,Grant Park,CNN,GrantParkNA,RequiredNoticeContact,4415 NE 87th Ave,Portland,OR,97220,,,,GrantParkNA RequiredNoticeContact,40956,1597284,4/21/2021 13:25
+,General correspondance,Grant Park,CNN,GrantParkNA,GeneralCorrespondenceContact,4415 NE 87th Ave,Portland,OR,97220,,,,GrantParkNA GeneralCorrespondenceContact,40957,901054,4/21/2021 13:26
+,Chair/Co-Chair/President,Hayden Island,NPNS,Marty,Slapikas,,Portland,OR,,,,slapikasm@gmail.com,Marty Slapikas,41970,1007280,8/24/2021 14:45
+,Treasurer/Finance Committee Chair,Hayden Island,NPNS,Patricia,Buescher,,Portland,OR,,,,PB@furzwo.com,Patricia Buescher,42050,1387650,5/17/2021 12:33
+,Land Use/Planning Committee Chair/Co-Chair,Hayden Island,NPNS,Marty,Slapikas,,Portland,OR,,,,slapikasm@gmail.com,Marty Slapikas,41970,1762740,8/24/2021 14:45
+,City Required Notice Contact/Co-Contact,Hayden Island,NPNS,HINooN,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St,Portland,OR,97217,,,slapikasm@gmail.com,HINooN RequiredNoticeContact,40934,1596426,8/25/2021 9:22
+,General correspondance,Hayden Island,NPNS,HINooN,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,slapikasm@gmail.com,HINooN GeneralCorrespondenceContact,40935,900570,8/25/2021 9:28
+,City Required Notice Contact/Co-Contact,Hayhurst,Includes City supported SW Neighborhoods,HayhurstNA,RequiredNoticeContact,6214 SW 41st,Portland,OR,97221,,,hayhurst-board@swni.org,HayhurstNA RequiredNoticeContact,40998,1598922,8/13/2021 9:57
+,General correspondance,Hayhurst,Includes City supported SW Neighborhoods,HayhurstNA,GeneralCorrespondenceContact,6214 SW 41st,Portland,OR,97221,,,hayhurst-board@swni.org,HayhurstNA GeneralCorrespondenceContact,40999,901978,8/13/2021 9:58
+,Chair/Co-Chair/President,Hazelwood,EPCO,Arlene,Kimura,,Portland,OR,97230,,,arlene.kimura@gmail.com,Arlene Kimura,1492,35808,3/10/2015 12:05
+,Treasurer/Finance Committee Chair,Hazelwood,EPCO,Iris,Newhouse,,Portland,OR,97220,,,newhouseiris@gmail.com,Iris Newhouse,31847,1050951,9/25/2015 12:40
+,Land Use/Planning Committee Chair/Co-Chair,Hazelwood,EPCO,Arlene,Kimura,,Portland,OR,97230,,,arlene.kimura@gmail.com,Arlene Kimura,1492,62664,3/10/2015 12:05
+,City Required Notice Contact/Co-Contact,Hazelwood,EPCO,HazelwoodNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,arlene.kimura@gmail.com,HazelwoodNA RequiredNoticeContact,41097,1602783,3/23/2017 9:19
+,General correspondance,Hazelwood,EPCO,HazelwoodNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,arlene.kimura@gmail.com,HazelwoodNA GeneralCorrespondenceContact,41098,904156,3/23/2017 9:20
+,Vice Chair/Vice President,Healy Heights,Includes City supported SW Neighborhoods,Mason,Van Buren,4273 SW Council Crest Dr.,Portland,OR,97239,(503) 223-1864,,masonvanburen@comcast.net,Mason Van Buren,31725,793125,12/16/2008 0:00
+,Treasurer/Finance Committee Chair,Healy Heights,Includes City supported SW Neighborhoods,Sarah,Ferguson,,,,,(503) 233-4087,,,Sarah Ferguson,37235,1228755,3/19/2012 13:53
+,City Required Notice Contact/Co-Contact,Healy Heights,Includes City supported SW Neighborhoods,HealyHeightsNA,RequiredNoticeContact,,Portland,OR,,,,,HealyHeightsNA RequiredNoticeContact,41032,1600248,3/10/2017 9:22
+,General correspondance,Healy Heights,Includes City supported SW Neighborhoods,HealyHeightsNA,GeneralCorrespondenceContact,,Portland,OR,,,,,HealyHeightsNA GeneralCorrespondenceContact,41033,902726,3/10/2017 9:23
+,City Required Notice Contact/Co-Contact,Hillsdale,Includes City supported SW Neighborhoods,HillsdaleNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@hna-pdx.com,HillsdaleNA RequiredNoticeContact,41001,1599039,8/13/2021 9:51
+,General correspondance,Hillsdale,Includes City supported SW Neighborhoods,HillsdaleNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@hna-pdx.com,HillsdaleNA GeneralCorrespondenceContact,41002,902044,8/13/2021 9:51
+,Chair/Co-Chair/President,Hillside,NWNW,Jim,Olsson,,Portland,OR,,,,president@hillsidena.org,Jim Olsson,41983,1007592,11/30/2020 15:39
+,Vice Chair/Vice President,Hillside,NWNW,Kevin,Kohnstamm,,Portland,OR,97210,,,kevin.kohnstamm@comcast.net,Kevin Kohnstamm,41200,1030000,11/10/2021 12:11
+,Treasurer/Finance Committee Chair,Hillside,NWNW,Scott,Miller,,Portland,OR,,,,scott@holthomes.com,Scott Miller,41352,1364616,8/11/2017 17:09
+,Land Use/Planning Committee Chair/Co-Chair,Hillside,NWNW,Jim,Olsson,,Portland,OR,,,,president@hillsidena.org,Jim Olsson,41983,1763286,11/30/2020 15:39
+,City Required Notice Contact/Co-Contact,Hillside,NWNW,Jim,Olsson,,Portland,OR,,,,president@hillsidena.org,Jim Olsson,41983,1637337,11/30/2020 15:39
+,City Required Notice Contact/Co-Contact,Hillside,NWNW,,Hillside NA Required/GeneralContact,2257 NW Raleigh St.,Portland,OR,97210,,,president@hillsidena.org,Hillside NA Required/GeneralContact,40631,1584609,12/3/2020 13:31
+,General correspondance,Hillside,NWNW,,Hillside NA Required/GeneralContact,2257 NW Raleigh St.,Portland,OR,97210,,,president@hillsidena.org,Hillside NA Required/GeneralContact,40631,893882,12/3/2020 13:31
+,Vice Chair/Vice President,Hollywood,CNN,Steve,Colburn,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,stevecolburn3@gmail.com,Steve Colburn,41822,1045550,3/16/2021 12:18
+,Secretary,Hollywood,CNN,Peter,Sysyn,4415 NE 87th Ave,Portland,OR,97220,(971) 266-8667,,psysyn1@gmail.com,Peter Sysyn,42017,378153,3/16/2021 12:34
+,Treasurer/Finance Committee Chair,Hollywood,CNN,Ian,Timm,P.O. BOX 13308,Portland,OR,97213,(503) 288-9822,,istimm@pacifier.com,Ian Timm,5413,178629,10/1/2020 13:24
+,Land Use/Planning Committee Chair/Co-Chair,Hollywood,CNN,Jo,Schaefer,,Portland,OR,97220,(503) 351-7271,,jaschaef@comcast.net,Jo Schaefer,30920,1298640,1/6/2021 11:41
+,City Required Notice Contact/Co-Contact,Hollywood,CNN,HollywoodNA,RequiredNoticeContact,4415 NE 87th Ave,Portland,OR,97220,,,,HollywoodNA RequiredNoticeContact,40959,1597401,4/21/2021 13:29
+,General correspondance,Hollywood,CNN,HollywoodNA,GeneralCorrespondenceContact,4415 NE 87th Ave,Portland,OR,97220,,,,HollywoodNA GeneralCorrespondenceContact,40960,901120,4/21/2021 13:29
+,Chair/Co-Chair/President,Homestead,Includes City supported SW Neighborhoods,Ed,Fischer,3404 SW 13th Ave.,Portland,OR,97239,,,board@homesteadna.org,Ed Fischer,37778,906672,8/13/2021 9:44
+,Secretary,Homestead,Includes City supported SW Neighborhoods,Lee,Buhler,127 SW Hamilton St.,Portland,OR,97239,(503) 227-0160,,board@homesteadna.org,Lee Buhler,5947,53523,8/13/2021 9:49
+,Treasurer/Finance Committee Chair,Homestead,Includes City supported SW Neighborhoods,Aaron,Clemons,3435 SW 12th Ave.,Portland,OR,97219-2457,(503) 234-9357,,board@homesteadna.org,Aaron Clemons,38644,1275252,8/13/2021 9:47
+,Land Use/Planning Committee Chair/Co-Chair,Homestead,Includes City supported SW Neighborhoods,Milt,Jones,,Portland,OR,,,,board@homesteadna.org,Milt Jones,37779,1586718,8/13/2021 9:46
+,City Required Notice Contact/Co-Contact,Homestead,Includes City supported SW Neighborhoods,HomesteadNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,land-use@homesteadna.org,HomesteadNA RequiredNoticeContact,41004,1599156,11/6/2017 18:47
+,General correspondance,Homestead,Includes City supported SW Neighborhoods,Elizabeth,Hinds,"2545 SW Terwilliger Blvd, Apt 1221",Portland,OR,97201,(503) 808-7458,,board@homesteadna.org,Elizabeth Hinds,42035,924770,8/13/2021 9:48
+,General correspondance,Homestead,Includes City supported SW Neighborhoods,Michael,Harrison,3181 SW Sam Jackson Park Road,Portland,OR,97239,(503) 381-8539,,board@homesteadna.org,Michael Harrison,2177,47894,8/13/2021 9:48
+,Chair/Co-Chair/President,Hosford-Abernethy,SEUL,Christopher,Eycamp,,Portland,OR,,,,chair@handpdx.org,Christopher Eycamp,41855,1004520,4/30/2019 8:22
+,Vice Chair/Vice President,Hosford-Abernethy,SEUL,Mark,Linehan,,Portland,OR,,,,mhl@mlinehan.us,Mark Linehan,41735,1043375,6/22/2018 8:08
+,Secretary,Hosford-Abernethy,SEUL,Karen,Girard,,Portland,OR,,,,,Karen Girard,41473,373257,7/12/2021 16:38
+,Treasurer/Finance Committee Chair,Hosford-Abernethy,SEUL,Mark,Linehan,,Portland,OR,,,,mhl@mlinehan.us,Mark Linehan,41735,1377255,6/22/2018 8:08
+,Land Use/Planning Committee Chair/Co-Chair,Hosford-Abernethy,SEUL,Michael,Wade,,Portland,OR,,,,wade.michael@comcast.net,Michael Wade,17566,737772,1/23/2019 14:03
+,City Required Notice Contact/Co-Contact,Hosford-Abernethy,SEUL,HAND,RequiredNoticeContact,"c/o SE Uplift, 3534 SE Main St.",Portland,OR,97214,,,chair@handpdx.org,HAND RequiredNoticeContact,41055,1601145,10/17/2017 12:29
+,General correspondance,Hosford-Abernethy,SEUL,HAND,GeneralCorrespondenceContact,2101 SE Tibbetts,Portland,OR,97202,,,,HAND GeneralCorrespondenceContact,41056,903232,6/22/2018 10:53
+,Chair/Co-Chair/President,Humboldt,NECN,Kymberly,Jeka,,Portland,OR,,,,HNAnews@gmail.com,Kymberly Jeka,37470,899280,7/7/2020 12:46
+,Vice Chair/Vice President,Humboldt,NECN,John,Ollis,,Portland,OR,,,,solchild@gmail.com,John Ollis,41806,1045150,7/7/2020 12:47
+,Secretary,Humboldt,NECN,Alicia,Richards,,Portland,OR,,,,aliciarichards60@gmail.com,Alicia Richards,41807,376263,11/14/2018 13:47
+,Land Use/Planning Committee Chair/Co-Chair,Humboldt,NECN,John,Ollis,,Portland,OR,,,,solchild@gmail.com,John Ollis,41806,1755852,7/7/2020 12:47
+,City Required Notice Contact/Co-Contact,Humboldt,NECN,HumboldtNA,RequiredNoticeContact,"c/o Northeast Coalition of Neighborhoods, 4815 NE 7th Ave",Portland,OR,97211,,,,HumboldtNA RequiredNoticeContact,41124,1603836,3/13/2017 13:14
+,General correspondance,Humboldt,NECN,HumboldtNA,GeneralCorrespondenceContact,"c/o Northeast Coalition of Neighborhoods, 4815 NE 7th Ave",Portland,OR,97211,,,,HumboldtNA GeneralCorrespondenceContact,41125,904750,3/13/2017 13:14
+,Chair/Co-Chair/President,Irvington,NECN,Steven,Cole,,Portland,OR,97212,,,stevencole86@gmail.com,Steven Cole,37518,900432,3/18/2014 10:09
+,Chair/Co-Chair/President,Irvington,NECN,Peter,O'Neil,,Portland,OR,,,,poneil@realtytrust.com,Peter O'Neil,37604,902496,1/23/2017 15:21
+,Secretary,Irvington,NECN,Doug,Cooke,,Portland,OR,,,,secretary@irvingtonpdx.com,Doug Cooke,41690,375210,7/29/2019 15:45
+,Treasurer/Finance Committee Chair,Irvington,NECN,Jim,Barta,,,,,(503) 544-2429,,jbarta@securasite.net,Jim Barta,33665,1110945,10/27/2011 11:59
+,Land Use/Planning Committee Chair/Co-Chair,Irvington,NECN,Dean,Gisvold,2225 NE 15th Ave,Portland,OR,97212,,,deang@mcewengisvold.com,Dean Gisvold,23085,969570,6/25/2007 0:00
+,City Required Notice Contact/Co-Contact,Irvington,NECN,IrvingtonCmtyAsso,RequiredNoticeContact,"PO Box 12102,",Portland,OR,97212,,,,IrvingtonCmtyAsso RequiredNoticeContact,41127,1603953,3/13/2017 13:26
+,General correspondance,Irvington,NECN,IrvingtonCmtyAsso,GeneralCorrespondenceContact,PO Box 12102,Portland,OR,97212,,,,IrvingtonCmtyAsso GeneralCorrespondenceContact,41128,904816,3/13/2017 13:27
+,Chair/Co-Chair/President,Kenton,NPNS,Tyler,Roppe,2209 N. Schofield,Portland,OR,97217,,,knachair@gmail.com,Tyler Roppe,40251,966024,7/6/2016 11:57
+,Chair/Co-Chair/President,Kenton,NPNS,Terrance,Moses,7735 N Brandon Ave.,Portland,OR,97217,(503) 490-2598,,knachair@gmail.com,Terrance Moses,40647,975528,11/3/2020 17:59
+,Treasurer/Finance Committee Chair,Kenton,NPNS,Angela,Moos,,Portland,OR,97217,,,amoos49@comcast.net,Angela Moos,32381,1068573,5/12/2011 9:57
+,City Required Notice Contact/Co-Contact,Kenton,NPNS,KentonNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St,Portland,OR,97217,,,knalanduse@gmail.com,KentonNA RequiredNoticeContact,40937,1596543,5/30/2017 14:19
+,General correspondance,Kenton,NPNS,KentonNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,knachair@gmail.com,KentonNA GeneralCorrespondenceContact,40938,900636,5/30/2017 14:20
+,Chair/Co-Chair/President,Kerns,SEUL,Jay,Harris,,Portland,OR,,,,rhythmmon@mindspring.com,Jay Harris,20908,501792,5/26/2021 13:05
+,Vice Chair/Vice President,Kerns,SEUL,Dave,Weaver,,Portland,OR,,,,dave@webais.com,Dave  Weaver,41181,1029525,5/26/2021 13:05
+,Secretary,Kerns,SEUL,Gretchen,Hollands,,Portland,OR,,,,wghollands@comcast.net,Gretchen Hollands,41730,375570,5/26/2021 13:06
+,Treasurer/Finance Committee Chair,Kerns,SEUL,Jay,Harris,,Portland,OR,,,,,Jay Harris,41474,1368642,8/14/2019 16:45
+,Land Use/Planning Committee Chair/Co-Chair,Kerns,SEUL,Jesse,Lopez,,,OR,,,,yosoyjay@gmail.com,Jesse Lopez,41229,1731618,5/26/2021 13:10
+,City Required Notice Contact/Co-Contact,Kerns,SEUL,Kerns NA,RequiredNoticeContact,,Portland,OR,,,,yosoyjay@gmail.com,Kerns NA RequiredNoticeContact,41058,1601262,11/18/2019 13:15
+,General correspondance,Kerns,SEUL,KernsNA,GeneralCorrespondenceContact,,Portland,OR,,,,,KernsNA GeneralCorrespondenceContact,41059,903298,3/10/2017 11:24
+,Chair/Co-Chair/President,King,NECN,John,Rooney,,Portland,OR,,,,johnr.kingnapdx@gmail.com,John Rooney,41958,1006992,9/4/2020 13:31
+,Chair/Co-Chair/President,King,NECN,Laverne,Martin,,Portland,OR,,,,laverne.kingnapdx@gmail.com,Laverne Martin,41959,1007016,9/4/2020 13:34
+,Secretary,King,NECN,John,Kim,,Portland,OR,,,,johnk.kingnapdx@gmail.com,John Kim,41913,377217,10/30/2019 10:58
+,Treasurer/Finance Committee Chair,King,NECN,Libby,Deal,,Portland,OR,,,,libby.kingnapdx@gmail.com,Libby Deal,41719,1376727,10/30/2019 10:57
+,City Required Notice Contact/Co-Contact,King,NECN,Libby,Deal,,Portland,OR,,,,libby.kingnapdx@gmail.com,Libby Deal,41719,1627041,10/30/2019 10:57
+,City Required Notice Contact/Co-Contact,King,NECN,KingNA,RequiredNoticeContact,4815 NE 7th Ave,Portland,OR,97211,,,kingnapdx@gmail.com,KingNA RequiredNoticeContact,41130,1604070,1/9/2020 12:18
+,General correspondance,King,NECN,KingNA,GeneralCorrespondenceContact,4815 NE 7th Ave,Portland,OR,97211,,,,KingNA GeneralCorrespondenceContact,41131,904882,3/13/2017 13:28
+,Chair/Co-Chair/President,Laurelhurst,SEUL,Jeff,Martin,,Portland,OR,97232,,,,Jeff Martin,17502,420048,11/18/2019 13:26
+,Vice Chair/Vice President,Laurelhurst,SEUL,Vince,Sliwoski,,Portland,OR,97232,,,,Vince Sliwoski,41283,1032075,11/18/2019 13:22
+,Secretary,Laurelhurst,SEUL,Jim,Edelson,,Portland,OR,97232,,,,Jim Edelson,27717,249453,12/5/2016 15:04
+,Treasurer/Finance Committee Chair,Laurelhurst,SEUL,Mike,Dublinsky,,Portland,OR,,,,,Mike Dublinsky,40340,1331220,8/8/2016 13:08
+,Land Use/Planning Committee Chair/Co-Chair,Laurelhurst,SEUL,Peter,Meijer,,Portland,OR,,,,info@pmapdx.com,Peter Meijer,1272,53424,11/10/2020 13:55
+,Land Use/Planning Committee Chair/Co-Chair,Laurelhurst,SEUL,Amy,Smith,,Portland,OR,,,,asmith@lrsarchitects.com,Amy Smith,40337,1694154,11/10/2020 13:54
+,City Required Notice Contact/Co-Contact,Laurelhurst,SEUL,Amy,Smith,,Portland,OR,,,,asmith@lrsarchitects.com,Amy Smith,41061,1601379,11/10/2020 13:56
+,City Required Notice Contact/Co-Contact,Laurelhurst,SEUL,Peter,Meijer,,Portland,OR,,,,info@pmapdx.com,Peter Meijer,41976,1637064,11/10/2020 13:58
+,General correspondance,Laurelhurst,SEUL,LaurelhurstNA,GeneralCorrespondenceContact,,Portland,OR,,,,,LaurelhurstNA GeneralCorrespondenceContact,41062,903364,3/10/2017 11:27
+,City Required Notice Contact/Co-Contact,Lents,EPCO,LentsNA,RequiredNoticeContact2,"c/o EPCO, 1017 NE 117th Ave",Portland,OR,,,,,LentsNA RequiredNoticeContact2,40912,1595568,9/29/2021 14:53
+,General correspondance,Lents,EPCO,LentsNA,GeneralCorrespondenceContact,"c/o EPCO, 1017 NE 117th Ave.",Portland,OR,97220,,,,LentsNA GeneralCorrespondenceContact,40913,900086,9/29/2021 14:53
+,Chair/Co-Chair/President,Linnton,NWNW,Richard,Barker,,Portland,OR,,,,chair@linntonna.org,Richard Barker,41566,997584,12/30/2020 12:23
+,Vice Chair/Vice President,Linnton,NWNW,Sarah,Taylor,,Portland,OR,,,,sarahsojourner@mac.com,Sarah Taylor,42073,1051825,9/1/2021 20:52
+,Treasurer/Finance Committee Chair,Linnton,NWNW,Amy,Jauron,,Portland,OR,,,,jauronamy@gmail.com,Amy Jauron,42074,1388442,9/2/2021 17:41
+,Land Use/Planning Committee Chair/Co-Chair,Linnton,NWNW,Sarah,Taylor,,Portland,OR,,,,sarahsojourner@mac.com,Sarah Taylor,42073,1767066,9/1/2021 20:52
+,City Required Notice Contact/Co-Contact,Linnton,NWNW,LinntonNA,RequiredNoticeContact,2257 NW Raleigh St.,Portland,OR,97210,,,Chair@linntonna.org,LinntonNA RequiredNoticeContact,40602,1583478,11/23/2016 13:39
+,General correspondance,Linnton,NWNW,LinntonNA,GeneralCorrespondenceContact,2257 NW Raleigh St.,Portland,OR,97210,,(503) 823-4288,Chair@linntonna.org,LinntonNA GeneralCorrespondenceContact,40603,893266,11/23/2016 13:48
+,Chair/Co-Chair/President,Lloyd District,NECN,Jeremy,Taylor,,Portland,OR,,,,jeremy@temple-baptist.com,Jeremy Taylor,41878,1005072,6/27/2019 13:00
+,Secretary,Lloyd District,NECN,Emily,Mandic,,Portland,OR,,,,emandic@americanassests.com,Emily Mandic,41879,376911,6/27/2019 13:03
+,Treasurer/Finance Committee Chair,Lloyd District,NECN,Ryan,Walters,,Portland,OR,,,,rwalters@columbiabank.com,Ryan Walters,41880,1382040,6/27/2019 13:05
+,Land Use/Planning Committee Chair/Co-Chair,Lloyd District,NECN,Ziggy,Lopuszynski,P.O. Box 6762,Portland,OR,97228,,,zlopuszynski@cpportland.com,Ziggy Lopuszynski,40311,1693062,1/28/2019 10:57
+,City Required Notice Contact/Co-Contact,Lloyd District,NECN,LLoydDistrictCmtyAsso,RequireNoticeContact,PO Box 6762,Portland,OR,97228-6762,,,,LLoydDistrictCmtyAsso RequireNoticeContact,41035,1600365,6/27/2018 13:31
+,General correspondance,Lloyd District,NECN,LloydDistrictCmtyAsso,GeneralCorrespondenceContact,PO Box 6762,Portland,OR,97228-6762,,,,LloydDistrictCmtyAsso GeneralCorrespondenceContact,41036,902792,6/27/2018 15:06
+,Chair/Co-Chair/President,Madison South,CNN,Dave,Smith,8310 NE Brazee,Portland,OR,,(503) 254-7790,,Dave.Smith@portlandoregon.gov,Dave Smith,34415,825960,12/5/2016 15:53
+,Vice Chair/Vice President,Madison South,CNN,Stacy,Bancroft,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,will@lumberyardmtb.com,Stacy Bancroft,40637,1015925,1/6/2021 12:29
+,Secretary,Madison South,CNN,Lisa,Walsh,,Portland,OR,97220,(503) 805-1496,,secretary@madisonsouth.org,Lisa Walsh,32063,288567,3/30/2009 0:00
+,Treasurer/Finance Committee Chair,Madison South,CNN,Ronda,Johnson,4415 NE 87th Ave,Portland,OR,97220,,(503) 823-2780,rondaj@cnncoalition.org,Ronda Johnson,41988,1385604,1/6/2021 11:57
+,Land Use/Planning Committee Chair/Co-Chair,Madison South,CNN,Tristan,Isaac,4415 NE 87th Ave,Portland,OR,97220,,,t.rominemann@gmail.com,Tristan Isaac,42075,1767150,10/11/2021 12:44
+,City Required Notice Contact/Co-Contact,Madison South,CNN,MadisonSouthNA,RequiredNoticeContact,4415 NE 87th Ave.,Portland,OR,97220,,,,MadisonSouthNA RequiredNoticeContact,40625,1584375,12/1/2016 15:32
+,General correspondance,Madison South,CNN,MadisonSouthNA,GeneralCorrespondenceContact,4415 NE 87th Ave.,Portland,OR,97220,,,,MadisonSouthNA GeneralCorrespondenceContact,40626,893772,12/1/2016 15:33
+,Chair/Co-Chair/President,Maplewood,Includes City supported SW Neighborhoods,Claire,Carder,6156 SW Nevada Ct.,Portland,OR,97219,(503) 977-3683,(503) 880-6503,scherzcarder@comcast.net,Claire Carder,22582,541968,4/15/2021 17:50
+,Secretary,Maplewood,Includes City supported SW Neighborhoods,Joan,Frazer,,,,,,,joan@spiretech.com,Joan Frazer,32585,293265,5/3/2021 10:00
+,Treasurer/Finance Committee Chair,Maplewood,Includes City supported SW Neighborhoods,Jim,Scherzinger,,Portland,OR,,,,scherzcom@comcast.net,Jim Scherzinger,24526,809358,4/15/2021 17:45
+,Land Use/Planning Committee Chair/Co-Chair,Maplewood,Includes City supported SW Neighborhoods,Claire,Carder,6156 SW Nevada Ct.,Portland,OR,97219,(503) 977-3683,(503) 880-6503,scherzcarder@comcast.net,Claire Carder,22582,948444,4/15/2021 17:50
+,City Required Notice Contact/Co-Contact,Maplewood,Includes City supported SW Neighborhoods,MaplewoodNA,RequiredNoticeContact,,Portland,OR,,,,scherzcarder@comcast.net,MaplewoodNA RequiredNoticeContact,41007,1599273,8/13/2021 8:52
+,General correspondance,Maplewood,Includes City supported SW Neighborhoods,MaplewoodNA,GeneralCorrespondenceContact,,Portland,OR,,,,scherzcarder@comcast.net,MaplewoodNA GeneralCorrespondenceContact,41008,902176,8/13/2021 8:52
+,City Required Notice Contact/Co-Contact,Markham,Includes City supported SW Neighborhoods,MarkhamNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@markhamneighborhood.com,MarkhamNA RequiredNoticeContact,41010,1599390,8/13/2021 9:21
+,General correspondance,Markham,Includes City supported SW Neighborhoods,MarkhamNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@markhamneighborhood.com,MarkhamNA GeneralCorrespondenceContact,41011,902242,8/13/2021 9:21
+,Land Use/Planning Committee Chair/Co-Chair,Marshall Park,Includes City supported SW Neighborhoods,MarshallParkNA,GeneralCorrespondenceContact,"Mike Charles, 9415 SW 18th Place",Portland,OR,97219-2457,,,marshallparkna@yahoo.com,MarshallParkNA GeneralCorrespondenceContact,41015,1722630,8/13/2021 9:17
+,City Required Notice Contact/Co-Contact,Marshall Park,Includes City supported SW Neighborhoods,MarshallParkNA,RequiredNoticeContact,"Mike Charles, 9415 SW 18th Place",Portland,OR,97219,,,marshallparkna@yahoo.com,MarshallParkNA RequiredNoticeContact,41014,1599546,8/13/2021 9:18
+,General correspondance,Marshall Park,Includes City supported SW Neighborhoods,MarshallParkNA,GeneralCorrespondenceContact,"Mike Charles, 9415 SW 18th Place",Portland,OR,97219-2457,,,marshallparkna@yahoo.com,MarshallParkNA GeneralCorrespondenceContact,41015,902330,8/13/2021 9:17
+,Vice Chair/Vice President,Mill Park,EPCO,Trevor,Hopper,1840 SE 117th,Portland,OR,97216,(503) 703-7744,,mill.park.pdx.chair@gmail.com,Trevor Hopper,35605,890125,5/24/2016 10:25
+,Treasurer/Finance Committee Chair,Mill Park,EPCO,Violet,Pascoe,2019 SE 117th Ave.,Portland,OR,97216,(503) 408-2367,,pascoeviolet@yahoo.com,Violet Pascoe,38638,1275054,6/19/2014 14:58
+,Land Use/Planning Committee Chair/Co-Chair,Mill Park,EPCO,Trevor,Hopper,1840 SE 117th,Portland,OR,97216,(503) 703-7744,,mill.park.pdx.chair@gmail.com,Trevor Hopper,35605,1495410,5/24/2016 10:25
+,City Required Notice Contact/Co-Contact,Mill Park,EPCO,MillParkNA,RequiredNoticeContact,1840 SE 117th,Portland,OR,97216,(503) 703-7744,,mill.park.pdx.chair@gmail.com,MillParkNA RequiredNoticeContact,41100,1602900,1/26/2018 13:24
+,General correspondance,Mill Park,EPCO,MillParkNA,GeneralCorrespondenceContact,1840 SE 117th,Portland,OR,97216,(503) 703-7744,,mill.park.pdx.chair@gmail.com,MillParkNA GeneralCorrespondenceContact,41101,904222,1/26/2018 13:25
+,Chair/Co-Chair/President,Montavilla,SEUL,Louise,Hoff,,Portland,OR,,,,louise@montavillapdx.org,Louise Hoff,41999,1007976,1/28/2021 12:08
+,Vice Chair/Vice President,Montavilla,SEUL,Alice,King,,Portland,OR,,,,alice@montavillapdx.org,Alice King,42000,1050000,1/28/2021 12:10
+,Secretary,Montavilla,SEUL,Jacob,Loeb,,Portland,OR,,,,jacob@montavillapdx.org,Jacob Loeb,41511,373599,1/28/2021 12:13
+,Treasurer/Finance Committee Chair,Montavilla,SEUL,Peter,Emerson,,Portland,OR,,,,peter@montavillapdx.org,Peter Emerson,42001,1386033,1/28/2021 12:14
+,Land Use/Planning Committee Chair/Co-Chair,Montavilla,SEUL,Adam,Wilson,,Portland,OR,97216,,,adam@montavillapdx.org,Adam Wilson,41510,1743420,2/9/2021 11:09
+,City Required Notice Contact/Co-Contact,Montavilla,SEUL,Montavilla,NeighborhoodAssociation,,Portland,OR,97216,,,notifications@montavillapdx.org,Montavilla NeighborhoodAssociation,41064,1601496,2/10/2021 15:10
+,General correspondance,Montavilla,SEUL,Montavilla,NeighborhoodAssociation,"c/o SE Uplift, 3534 SE Main St.",Portland,OR,97214,,,hello@montavillapdx.org,Montavilla NeighborhoodAssociation,41065,903430,3/17/2017 13:30
+,Chair/Co-Chair/President,Mt. Scott-Arleta,SEUL,Matchu,Williams,,Portland,OR,97214,,,MSANAchair@gmail.com,Matchu Williams,40350,968400,12/11/2020 15:24
+,Secretary,Mt. Scott-Arleta,SEUL,Noelle,Winiecki,,Portland,OR,,,,,Noelle Winiecki,38464,346176,6/2/2021 12:42
+,Treasurer/Finance Committee Chair,Mt. Scott-Arleta,SEUL,Martha,Tucker,,Portland,OR,97206,,,,Martha Tucker,39462,1302246,12/11/2020 15:11
+,Land Use/Planning Committee Chair/Co-Chair,Mt. Scott-Arleta,SEUL,Sarah,Iannarone,,Portland,OR,97214,,,MSANAlandusechair@gmail.com,Sarah Iannarone,41067,1724814,6/2/2021 12:42
+,City Required Notice Contact/Co-Contact,Mt. Scott-Arleta,SEUL,Sarah,Iannarone,,Portland,OR,97214,,,MSANAlandusechair@gmail.com,Sarah Iannarone,41067,1601613,6/2/2021 12:42
+,General correspondance,Mt. Scott-Arleta,SEUL,MtScott-ArletaNA,GeneralCorrespondenceContact,3534 SE MAIN ST,Portland,OR,97214,,,MSANA.chair@gmail.com,MtScott-ArletaNA GeneralCorrespondenceContact,41068,903496,12/11/2020 15:19
+,Chair/Co-Chair/President,Mt. Tabor,SEUL,Jim,Pierce,,Portland,OR,,,,,Jim Pierce,41243,989832,8/24/2021 12:32
+,Treasurer/Finance Committee Chair,Mt. Tabor,SEUL,Bing,Wong,,Portland,OR,,,,,Bing Wong,4705,155265,5/26/2021 13:22
+,Land Use/Planning Committee Chair/Co-Chair,Mt. Tabor,SEUL,Stephanie,Stewart,,Portland,OR,,,,contact.MTNA@gmail.com,Stephanie Stewart,32846,1379532,5/26/2021 13:24
+,City Required Notice Contact/Co-Contact,Mt. Tabor,SEUL,Stephanie,Stewart,,Portland,OR,,,,contact.MTNA@gmail.com,Stephanie Stewart,39850,1554150,5/26/2021 13:23
+,General correspondance,Mt. Tabor,SEUL,MtTaborNA,GeneralCorrespondenceContact,5122 SE Hawthorne Blvd.,Portland,OR,97215,,,contact.MTNA@gmail.com,MtTaborNA GeneralCorrespondenceContact,40863,898986,2/8/2017 12:24
+,Chair/Co-Chair/President,Multnomah,,Frank,Rudloff,,Portland,OR,,,,multnomah-board@swni.org,Frank Rudloff,42014,1008336,8/13/2021 9:08
+,Land Use/Planning Committee Chair/Co-Chair,Multnomah,,Frank,Rudloff,2635 SW Hume St.,Portland,OR,97219,(503) 246-0883,(503) 226-0622,multnomah-board@swni.org,Frank Rudloff,8857,371994,8/13/2021 9:14
+,City Required Notice Contact/Co-Contact,Multnomah,,MultnomahNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,multnomah-board@swni.org,MultnomahNA RequiredNoticeContact,41017,1599663,8/13/2021 9:11
+,General correspondance,Multnomah,,MultnomahNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,multnomah-board@swni.org,MultnomahNA GeneralCorrespondenceContact,41018,902396,8/13/2021 9:12
+,Chair/Co-Chair/President,North Tabor,SEUL,Greg,Scott,,Portland,OR,,,,chair@northtabor.org,Greg Scott,40444,970656,8/20/2021 18:38
+,Chair/Co-Chair/President,North Tabor,SEUL,CJ,Alicandro,,Portland,OR,,,,chair@northtabor.org,CJ Alicandro,42065,1009560,8/20/2021 18:39
+,Secretary,North Tabor,SEUL,Sarah,Mongue,,Portland,OR,,,,,Sarah Mongue,40448,364032,8/20/2021 18:40
+,Treasurer/Finance Committee Chair,North Tabor,SEUL,Patty,Lackaff,,Portland,OR,,,,,Patty Lackaff,41575,1371975,11/10/2020 14:14
+,Land Use/Planning Committee Chair/Co-Chair,North Tabor,SEUL,Lars,Kasch,,Portland,OR,97213,,,landuse@northtabor.org,Lars Kasch,41670,1750140,11/18/2019 13:50
+,Land Use/Planning Committee Chair/Co-Chair,North Tabor,SEUL,Lisa,Maddocks,,Portland,OR,,,,landuse@northtabor.org,Lisa Maddocks,241,10122,11/18/2019 13:52
+,City Required Notice Contact/Co-Contact,North Tabor,SEUL,Lisa,Maddocks,,Portland,OR,,,,landuse@northtabor.org,Lisa Maddocks,241,9399,11/18/2019 13:52
+,City Required Notice Contact/Co-Contact,North Tabor,SEUL,Lars,Kasch,,Portland,OR,,,,landuse@northtabor.org,Lars Kasch,41070,1601730,11/10/2020 14:19
+,General correspondance,North Tabor,SEUL,NorthTaborNA,GeneralCorrespondenceContact,"c/o SE Uplift, 3534 SE Main St.",Portland,OR,97214,,,board@northtabor.org,NorthTaborNA GeneralCorrespondenceContact,41071,903562,6/29/2017 13:18
+,Chair/Co-Chair/President,Northwest District,NWNW,Parker,McNulty,,Portland,OR,,,,president@northwestdistrictassociation.org,Parker McNulty,41724,1001376,3/23/2021 11:49
+,Vice Chair/Vice President,Northwest District,NWNW,Parker,McNulty,,Portland,OR,,,,president@northwestdistrictassociation.org,Parker McNulty,41724,1043100,3/23/2021 11:49
+,Treasurer/Finance Committee Chair,Northwest District,NWNW,Vicki,Skryha,,Salem,OR,97309,,(503) 945-9722,treasurer@northwestdistrictassociation.org,Vicki Skryha,1504,49632,12/30/2020 15:27
+,Land Use/Planning Committee Chair/Co-Chair,Northwest District,NWNW,Greg,Theisen,,Portland,OR,97210,(503) 227-5430,,planning@northwestdistrictassociation.org,Greg Theisen,2252,94584,12/23/2019 14:27
+,City Required Notice Contact/Co-Contact,Northwest District,NWNW,NWDA,Required/Certified/GeneralContact,2257 NW Raleigh St.,Portland,OR,97210,,(503) 823-4288,president@northwestdistrictassociation.org,NWDA Required/Certified/GeneralContact,40607,1583673,11/30/2016 15:42
+,General correspondance,Northwest District,NWNW,NWDA,Required/Certified/GeneralContact,2257 NW Raleigh St.,Portland,OR,97210,,(503) 823-4288,president@northwestdistrictassociation.org,NWDA Required/Certified/GeneralContact,40607,893354,11/30/2016 15:42
+,Chair/Co-Chair/President,Northwest Heights,NWNW,Barry,Newman,4055 NW Twilight,Portland,,97229,,,president@nwheights.org,Barry  Newman,38762,930288,6/15/2017 16:41
+,Vice Chair/Vice President,Northwest Heights,NWNW,Brian,Owendoff,,Portland,OR,,,,brian.owendoff@yahoo.com,Brian Owendoff,41261,1031525,6/15/2017 16:43
+,Secretary,Northwest Heights,NWNW,Pamela,Morris,,Portland,OR,,,,secretary@nwheights.org,Pamela Morris,41262,371358,6/15/2017 16:49
+,Treasurer/Finance Committee Chair,Northwest Heights,NWNW,Pamela,Morris,,Portland,OR,,,,secretary@nwheights.org,Pamela Morris,41262,1361646,6/15/2017 16:49
+,City Required Notice Contact/Co-Contact,Northwest Heights,NWNW,NWHNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,board@nwheights.org,NWHNA Required/General/CertifiedContact,40624,1584336,12/1/2016 13:56
+,General correspondance,Northwest Heights,NWNW,NWHNA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,board@nwheights.org,NWHNA Required/General/CertifiedContact,40624,893728,12/1/2016 13:56
+,Chair/Co-Chair/President,Old Town,NWNW,Jessie,Burke,,Portland,OR,,,,chair@pdxoldtown.org,Jessie Burke,39473,947352,4/15/2021 16:21
+,Vice Chair/Vice President,Old Town,NWNW,Scott,Kerman,,Portland,OR,,,,vice-chair@pdxoldtown.org,Scott Kerman,41936,1048400,4/15/2021 16:18
+,Secretary,Old Town,NWNW,Mary-Rain,O'Meara,2257 NW Raleigh St,Portland,OR,97210,,,secretary@pdxoldtown.org,Mary-Rain O'Meara,32475,292275,4/15/2021 16:42
+,Treasurer/Finance Committee Chair,Old Town,NWNW,Jonathan,Cohen,,Portland,OR,,,,treasurer@pdxoldtown.org,Jonathan Cohen,42038,1387254,4/15/2021 16:27
+,Land Use/Planning Committee Chair/Co-Chair,Old Town,NWNW,Jonathan,Cohen,,Portland,OR,,,,treasurer@pdxoldtown.org,Jonathan Cohen,42038,1765596,4/15/2021 16:27
+,Land Use/Planning Committee Chair/Co-Chair,Old Town,NWNW,Mary-Rain,O'Meara,2257 NW Raleigh St,Portland,OR,97210,,,secretary@pdxoldtown.org,Mary-Rain O'Meara,32475,1363950,4/15/2021 16:42
+,City Required Notice Contact/Co-Contact,Old Town,NWNW,OTCA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,board@PDXoldtown.org,OTCA Required/General/CertifiedContact,40628,1584492,10/4/2019 10:46
+,General correspondance,Old Town,NWNW,OTCA,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,board@PDXoldtown.org,OTCA Required/General/CertifiedContact,40628,893816,10/4/2019 10:46
+,Chair/Co-Chair/President,Overlook,NPNS,Alexandra,Degher,2209 N. Schofield St,Portland,OR,97217,,,chair@overlookneighborhood.org,Alexandra Degher,40420,970080,12/11/2019 12:55
+,Treasurer/Finance Committee Chair,Overlook,NPNS,Brad,Halverson,,Portland,OR,,,,info@overlookneighborhood.org,Brad Halverson,40423,1333959,12/11/2019 12:58
+,Land Use/Planning Committee Chair/Co-Chair,Overlook,NPNS,Brian,Yarne,,Portland,OR,,,,landuse@overlookneighborhood.org,Brian Yarne,42024,1765008,3/23/2021 11:56
+,City Required Notice Contact/Co-Contact,Overlook,NPNS,OverlookNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,landuse@overlookneighborhood.org,OverlookNA RequiredNoticeContact,40940,1596660,5/30/2017 15:01
+,General correspondance,Overlook,NPNS,OverlookNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,chair@overlookneighborhood.org,OverlookNA GeneralCorrespondenceContact,40941,900702,5/30/2017 15:01
+,Chair/Co-Chair/President,Parkrose,EPCO,Tom,Badrick,1725 NE 118th Ave,Portland,OR,97220,,,tbadrick@aol.com,Tom Badrick,2118,50832,2/20/2017 13:14
+,City Required Notice Contact/Co-Contact,Parkrose,EPCO,ParkroseHghtsAssoofNeighbors,RequiredNotice Contact,"c/o EPCO, 1017 NE 117th Ave.",Portland,OR,97220,,(971) 325-9727,badrickt@gmail.com,ParkroseHghtsAssoofNeighbors RequiredNotice Contact,40891,1594749,3/18/2019 15:30
+,General correspondance,Parkrose,EPCO,Parkrose Hghts AssoofNeighbors,General Correspondence Contact,"c/o EPCO, 1017 NE 117th Ave.",Portland,OR,97220,,(971) 325-9727,badrickt@gmail.com,Parkrose Hghts AssoofNeighbors General Correspondence Contact,40892,899624,3/18/2019 15:31
+,Chair/Co-Chair/President,Parkrose,EPCO,Annette,Stanhope,,Portland,OR,97220,,,,Annette Stanhope,37079,889896,4/4/2014 14:44
+,City Required Notice Contact/Co-Contact,Parkrose,EPCO,ParkoseNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,parkroseneighbors@gmail.com,ParkoseNA RequiredNoticeContact,41103,1603017,3/23/2017 9:33
+,General correspondance,Parkrose,EPCO,ParkroseNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,parkroseneighbors@gmail.com,ParkroseNA GeneralCorrespondenceContact,41104,904288,3/23/2017 9:34
+,Chair/Co-Chair/President,Pearl District,NWNW,Stanley,Penkin,,Portland,,,(845) 417-8755,,stanleypenkin@gmail.com,Stanley Penkin,38814,931536,9/19/2018 14:01
+,Vice Chair/Vice President,Pearl District,NWNW,David,Dysert,,Portland,OR,97209,,,planning@pearldistrict.org,David Dysert,41260,1031500,11/18/2020 17:23
+,Secretary,Pearl District,NWNW,Bill,Bagnall,,Portland,OR,,,,secretary@pearldistrict.org,Bill Bagnall,41154,370386,3/22/2017 13:42
+,Treasurer/Finance Committee Chair,Pearl District,NWNW,Christian,Maynard-Phillip,,Portland,OR,,,,treasurer@pearldistrict.org,Christian Maynard-Phillip,41525,1370325,11/25/2017 13:25
+,Land Use/Planning Committee Chair/Co-Chair,Pearl District,NWNW,David,Dysert,,Portland,OR,97209,,,planning@pearldistrict.org,David Dysert,41260,1732920,11/18/2020 17:23
+,Land Use/Planning Committee Chair/Co-Chair,Pearl District,NWNW,Reza,Farhoodi,,Portland,OR,97209,,,planning@pearldistrict.org,Reza Farhoodi,40080,1683360,11/18/2020 14:04
+,City Required Notice Contact/Co-Contact,Pearl District,NWNW,Pearl,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@pearldistrict.org,Pearl Required/General/CertifiedContact,40629,1584531,12/2/2016 13:16
+,General correspondance,Pearl District,NWNW,Pearl,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@pearldistrict.org,Pearl Required/General/CertifiedContact,40629,893838,12/2/2016 13:16
+,Chair/Co-Chair/President,Piedmont,NPNS,Shaun,Sullens,,Portland,OR,,,,shaun.sullens@msn.com,Shaun Sullens,42049,1009176,5/16/2021 16:49
+,Treasurer/Finance Committee Chair,Piedmont,NPNS,Deanne,Gomez,,Portland,OR,97217,,,gomez.deanne@yahoo.com,Deanne Gomez,182,6006,3/19/2014 13:10
+,Land Use/Planning Committee Chair/Co-Chair,Piedmont,NPNS,Deanne,Gomez,,Portland,OR,97217,,,gomez.deanne@yahoo.com,Deanne Gomez,182,7644,3/19/2014 13:10
+,City Required Notice Contact/Co-Contact,Piedmont,NPNS,PiedmontNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,gomez.deanne@yahoo.com,PiedmontNA RequiredNoticeContact,40943,1596777,8/25/2021 15:10
+,General correspondance,Piedmont,NPNS,PiedmontNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,gomez.deanne@yahoo.com,PiedmontNA GeneralCorrespondenceContact,40944,900768,8/25/2021 15:11
+,Chair/Co-Chair/President,Pleasant Valley,EPCO,Dale,Shelter,,Portland,OR,97266-0000,,,dale.shetler@gmail.com,Dale Shelter,39983,959592,9/10/2018 11:26
+,Land Use/Planning Committee Chair/Co-Chair,Pleasant Valley,EPCO,Steve,Montgomery,,,,,,,foxtrotlove@hotmail.com,Steve Montgomery,39984,1679328,11/30/2016 14:15
+,City Required Notice Contact/Co-Contact,Pleasant Valley,EPCO,PleasantValleyNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,pleasantvalleyna@gmail.com,PleasantValleyNA RequiredNoticeContact,40882,1594398,6/8/2017 16:36
+,General correspondance,Pleasant Valley,EPCO,PleasantValleyNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,pleasantvalleyna@gmail.com,PleasantValleyNA GeneralCorrespondenceContact,40883,899426,6/8/2017 16:36
+,Chair/Co-Chair/President,Portland Downtown,NWNW,Walter,Weyler,1221 SW 10th Ave #805,Portland,OR,,(503) 490-3907,,walter_weyler@sequenceusa.com,Walter Weyler,41836,1004064,3/29/2019 10:58
+,Vice Chair/Vice President,Portland Downtown,NWNW,Wendy,Rahm,,Portland,OR,97205,,,wwrahm@aol.com,Wendy Rahm,33228,830700,7/16/2012 9:31
+,Treasurer/Finance Committee Chair,Portland Downtown,NWNW,Natasha,Voloshina,,Portland,OR,,,,natashavo@icloud.com,Natasha  Voloshina,41917,1383261,11/19/2019 17:57
+,Land Use/Planning Committee Chair/Co-Chair,Portland Downtown,NWNW,Wendy,Rahm,,Portland,OR,97205,,,wwrahm@aol.com,Wendy Rahm,33228,1395576,7/16/2012 9:31
+,City Required Notice Contact/Co-Contact,Portland Downtown,NWNW,Downtown,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@portlanddowntownna.com,Downtown Required/General/CertifiedContact,40630,1584570,12/2/2016 13:17
+,General correspondance,Portland Downtown,NWNW,Downtown,Required/General/CertifiedContact,2257 NW Raleigh Street,Portland,OR,97210,,(503) 823-4288,president@portlanddowntownna.com,Downtown Required/General/CertifiedContact,40630,893860,12/2/2016 13:17
+,Chair/Co-Chair/President,Portsmouth,NPNS,Mary-Margaret,Wheeler-Weber,,Portland,OR,97203,,,mary.wheeler@gmail.com,Mary-Margaret Wheeler-Weber,21863,524712,11/12/2020 10:43
+,Secretary,Portsmouth,NPNS,Neveen,Hurd,,Portland,OR,,,,neveen.pna@gmail.com,Neveen Hurd,41975,377775,11/5/2020 14:19
+,Treasurer/Finance Committee Chair,Portsmouth,NPNS,Paul,Buchanan,,Portland,OR,,,,portsmouthpdxlandandtrans@gmail.com,Paul  Buchanan,41974,1385142,7/14/2021 18:18
+,City Required Notice Contact/Co-Contact,Portsmouth,NPNS,PortsmouthNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,portsmouthchair@gmail.com,PortsmouthNA RequiredNoticeContact,40946,1596894,5/20/2021 14:47
+,General correspondance,Portsmouth,NPNS,PortsmouthNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,portsmouthchair@gmail.com,PortsmouthNA GeneralCorrespondenceContact,40947,900834,5/30/2017 14:34
+,Chair/Co-Chair/President,Powellhurst-Gilbert,EPCO,Richard,Dickinson,,Portland,OR,98266,,,pgnaboard@gmail.com,Richard Dickinson,40706,976944,2/9/2021 10:58
+,Chair/Co-Chair/President,Powellhurst-Gilbert,EPCO,Timothy,Crawley,,Portland,OR,98236,,,pgnaboard@gmail.com,Timothy  Crawley,39985,959640,3/18/2019 15:35
+,Secretary,Powellhurst-Gilbert,EPCO,Shaina,Boal,,Portland,OR,,,,pgnaboard@gmail.com,Shaina Boal,41676,375084,2/9/2021 10:52
+,Treasurer/Finance Committee Chair,Powellhurst-Gilbert,EPCO,Jody,Folkedahl Eppolito,,Portland,OR,97266,,,,Jody Folkedahl Eppolito,40707,1343331,3/28/2017 10:04
+,City Required Notice Contact/Co-Contact,Powellhurst-Gilbert,EPCO,PowellhurstGilbertNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,pgnaboard@gmail.com,PowellhurstGilbertNA RequiredNoticeContact,40860,1593540,2/8/2017 11:33
+,General correspondance,Powellhurst-Gilbert,EPCO,PowellhurstGilbertNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,pgnaboard@gmail.com,PowellhurstGilbertNA GeneralCorrespondenceContact,40861,898942,2/9/2021 10:51
+,Chair/Co-Chair/President,Reed,SEUL,Anne,Tillinga,,Portland,OR,,,,tillinga@gmail.com,Anne Tillinga,41250,990000,11/10/2020 14:28
+,Vice Chair/Vice President,Reed,SEUL,Ronald,Rosin,,Portland,OR,,,,,Ronald Rosin,42053,1051325,6/2/2021 12:54
+,Secretary,Reed,SEUL,Gina,Ensuna,,Portland,OR,,,,,Gina Ensuna,41251,371259,6/2/2021 12:54
+,Treasurer/Finance Committee Chair,Reed,SEUL,Xander,Blair,,Portland,OR,,,,xander.blair@gmail.com,Xander Blair,41723,1376859,11/10/2020 14:29
+,Land Use/Planning Committee Chair/Co-Chair,Reed,SEUL,Xander,Blair,,Portland,OR,,,,xander.blair@gmail.com,Xander Blair,41723,1752366,11/10/2020 14:29
+,City Required Notice Contact/Co-Contact,Reed,SEUL,Xander,Blair,,Portland,OR,,,,xander.blair@gmail.com,Xander Blair,41073,1601847,11/10/2020 14:32
+,General correspondance,Reed,SEUL,ReedNA,GeneralCorrespondenceContact,,Portland,OR,,,,,ReedNA GeneralCorrespondenceContact,41074,903628,3/10/2017 11:42
+,Chair/Co-Chair/President,Richmond,SEUL,Debby,Hochhalter,,Portland,OR,,,,richmond.pdx.chair@gmail.com,Debby Hochhalter,40427,970248,10/31/2019 13:40
+,Secretary,Richmond,SEUL,Allen,Field,,,,,,,richmondnasecretary@gmail.com,Allen Field,3088,27792,7/12/2021 16:42
+,Treasurer/Finance Committee Chair,Richmond,SEUL,Simon,Fulford,,Portland,OR,,,,,Simon Fulford,39097,1290201,8/20/2021 18:50
+,City Required Notice Contact/Co-Contact,Richmond,SEUL,Heather,Flint Chatto,3534 SE Main St,Portland,OR,97214,,,richmond.pdx.lutc@gmail.com,Heather Flint Chatto,41076,1601964,11/1/2019 8:47
+,General correspondance,Richmond,SEUL,Debby,Hochhalter,3534 SE Main St,Portland,OR,97214,,,richmond.pdx.chair@gmail.com,Debby Hochhalter,41077,903694,11/1/2019 12:31
+,Chair/Co-Chair/President,Rose City Park,CNN,Tamara,DeRidder,1707 NE 52nd Ave.,Portland,OR,97213,(503) 249-6977,,SustainableDesign@tdridder.users.panix.com,Tamara DeRidder,34423,826152,4/1/2015 16:16
+,Vice Chair/Vice President,Rose City Park,CNN,Zoe,Ezechiels,4415 NE 87th Ave,Portland,OR,97220,,,,Zoe Ezechiels,42062,1051550,8/10/2021 13:15
+,Secretary,Rose City Park,CNN,Jennifer,Santhouse,,Portland,OR,,,,estiefvater@hotmail.com,Jennifer Santhouse,41152,370368,1/6/2021 12:01
+,Treasurer/Finance Committee Chair,Rose City Park,CNN,Richard,Crockett,,Portland,OR,,,,crockett1947@comcast.net,Richard  Crockett,39470,1302510,4/1/2015 16:24
+,Land Use/Planning Committee Chair/Co-Chair,Rose City Park,CNN,Tamara,DeRidder,1707 NE 52nd Ave.,Portland,OR,97213,(503) 249-6977,,SustainableDesign@tdridder.users.panix.com,Tamara DeRidder,34423,1445766,4/1/2015 16:16
+,City Required Notice Contact/Co-Contact,Rose City Park,CNN,RoseCityParkNA,RequiredNoticeContact,4415 NE 87th Ave,Portland,OR,97220,,,,RoseCityParkNA RequiredNoticeContact,40962,1597518,4/21/2021 13:31
+,General correspondance,Rose City Park,CNN,RoseCityParkNA,GeneralCorrespondenceContact,4415 NE 87th Ave,Portland,OR,97220,,,,RoseCityParkNA GeneralCorrespondenceContact,40963,901186,4/21/2021 13:32
+,Chair/Co-Chair/President,Roseway,CNN,Caitlin,Hill,4415 NE 87th Ave,Portland,OR,97220,,,crhill84@gmail.com,Caitlin Hill,42004,1008096,3/16/2021 12:38
+,Vice Chair/Vice President,Roseway,CNN,Ted,Carlston,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,tedcarlston2@yahoo.com,Ted Carlston,37006,925150,2/11/2021 10:38
+,Secretary,Roseway,CNN,Kellie,McGiverin-Bohan,4415 NE 87th Ave,Portland,OR,97220,(812) 219-3531,,kelliemcgb@gmail.com,Kellie McGiverin-Bohan,42018,378162,4/21/2021 13:44
+,Treasurer/Finance Committee Chair,Roseway,CNN,Sarah,Gibney,c/o CNN 4415 NE 87th Ave,,,97220,(503) 288-0911,,smgibney@gmail.com,Sarah Gibney,30078,992574,3/16/2021 12:41
+,Land Use/Planning Committee Chair/Co-Chair,Roseway,CNN,Ted,Carlston,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,tedcarlston2@yahoo.com,Ted Carlston,37006,1554252,2/11/2021 10:38
+,City Required Notice Contact/Co-Contact,Roseway,CNN,RosewayNA,RequiredNoticeContact,4415 NE 87th Ave,Portland,OR,97220,,,,RosewayNA RequiredNoticeContact,40965,1597635,4/21/2021 13:34
+,General correspondance,Roseway,CNN,RosewayNA,GeneralCorrespondenceContact,4415 NE 87th Ave,Portland,OR,97220,,,rna-pdx-board@googlegroups.com,RosewayNA GeneralCorrespondenceContact,40966,901252,4/21/2021 13:34
+,Chair/Co-Chair/President,Russell,EPCO,Kenja,Battis,,Portland,OR,,,,russellneighborhood@gmail.com,Kenja Battis,42072,1009728,8/25/2021 11:42
+,City Required Notice Contact/Co-Contact,Russell,EPCO,RussellNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,russellneighborhood@gmail.com,RussellNA RequiredNoticeContact,41106,1603134,8/25/2021 11:45
+,General correspondance,Russell,EPCO,RussellNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,russellneighborhood@gmail.com,RussellNA GeneralCorrespondenceContact,41107,904354,8/25/2021 11:46
+,Chair/Co-Chair/President,Sabin,NECN,Don,Rouzie,4520 NE 15th,Portland,OR,97211,,,donrouzie@icloud.com,Don Rouzie,4976,119424,6/10/2019 12:55
+,Secretary,Sabin,NECN,Rachel,Lee,,Portland,OR,97211,,,,Rachel Lee,37610,338490,5/17/2018 10:10
+,Treasurer/Finance Committee Chair,Sabin,NECN,Maria,Hein,,Portland,OR,,,,maria.hein@gmail.com,Maria Hein,42010,1386330,3/9/2021 12:47
+,Land Use/Planning Committee Chair/Co-Chair,Sabin,NECN,Rachel,Lee,,Portland,OR,97211,,,,Rachel Lee,37610,1579620,5/17/2018 10:10
+,City Required Notice Contact/Co-Contact,Sabin,NECN,SabinCA,RequiredNoticeContact,"c/o NECN, 4815 NE 7th Ave.",Portland,OR,97211,,,rach.c.lee@gmail.com,SabinCA RequiredNoticeContact,40903,1595217,3/9/2021 12:43
+,General correspondance,Sabin,NECN,SabinCA,GeneralCorrespondenceContact,"c/o NECN, 4815 NE 7th Ave.",Portland,OR,97211,,(503) 961-3702,sabin@necoalition.org,SabinCA GeneralCorrespondenceContact,40904,899888,2/27/2017 9:30
+,Chair/Co-Chair/President,Sellwood-Moreland,SEUL,Simon,Fulford,,Portland,OR,,,,simonrfulford@gmail.com,Simon Fulford,41227,989448,1/19/2021 11:20
+,Vice Chair/Vice President,Sellwood-Moreland,SEUL,Ayomide,Nikzi,,Portland,OR,,,,ayogreenevents@gmail.com,Ayomide Nikzi,41994,1049850,6/8/2021 13:53
+,Secretary,Sellwood-Moreland,SEUL,Eric,Norberg,,Portland,OR,,,,norberg@myexcel.com,Eric Norberg,1603,14427,1/19/2021 11:28
+,Treasurer/Finance Committee Chair,Sellwood-Moreland,SEUL,Patrick,Hainley,,Portland,OR,,,,pat@hainley-lavey.com,Patrick Hainley,23177,764841,1/19/2021 11:28
+,Land Use/Planning Committee Chair/Co-Chair,Sellwood-Moreland,SEUL,David,Schoellhamer,,Portland,OR,,,,chair.landuse.smile@gmail.com,David Schoellhamer,36318,1525356,1/19/2021 11:29
+,City Required Notice Contact/Co-Contact,Sellwood-Moreland,SEUL,SMILE,RequiredNoticeContact,8210 SE 13th Ave.,Portland,OR,97202,,,SMILE@sellwood.org,SMILE RequiredNoticeContact,40885,1594515,5/6/2021 9:55
+,General correspondance,Sellwood-Moreland,SEUL,SMILE,GeneralCorrespondenceContact,8210 SE 13th Ave.,Portland,OR,97202,,(503) 234-3570,smilestation@sellwood.org,SMILE GeneralCorrespondenceContact,40886,899492,1/19/2021 11:34
+,Chair/Co-Chair/President,South Burlingame,Includes City supported SW Neighborhoods,Shannon,Hiller-Webb,,,OR,,(503) 928-9539,,president@southburlingamena.org,Shannon Hiller-Webb,36095,866280,6/28/2021 16:45
+,City Required Notice Contact/Co-Contact,South Burlingame,Includes City supported SW Neighborhoods,SouthBurlingameNA,RequiredNoticeContact,Use E-mail for all correspondence,,OR,,,,president@southburlingamena.org,SouthBurlingameNA RequiredNoticeContact,41020,1599780,8/13/2021 9:05
+,General correspondance,South Burlingame,Includes City supported SW Neighborhoods,SouthBurlingameNA,GeneralCorrespondenceContact,Use E-mail for all correspondence,,OR,,,,president@southburlingamena.org,SouthBurlingameNA GeneralCorrespondenceContact,41021,902462,8/13/2021 9:04
+,City Required Notice Contact/Co-Contact,South,Includes City supported SW Neighborhoods,SouthPortlandNA,RequiredNoticeContact,"c/o SWNI, 7688 SW Capitol Hwy.",Portland,OR,97219,,,board@southportlandna.org,SouthPortlandNA RequiredNoticeContact,41023,1599897,8/13/2021 10:04
+,General correspondance,South,Includes City supported SW Neighborhoods,SouthPortlandNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,board@southportlandna.org,SouthPortlandNA GeneralCorrespondenceContact,41024,902528,8/13/2021 10:05
+,Chair/Co-Chair/President,South Tabor,SEUL,Tina,Kimmey,,Portland,OR,,,,chair@southtabor.org,Tina Kimmey,41210,989040,7/12/2021 16:48
+,Vice Chair/Vice President,South Tabor,SEUL,Juan,Cummings,,Portland,OR,,,,,Juan Cummings,40312,1007800,6/2/2021 12:59
+,Secretary,South Tabor,SEUL,Juan,Cummings,,Portland,OR,,,,,Juan Cummings,40312,362808,6/2/2021 12:59
+,Treasurer/Finance Committee Chair,South Tabor,SEUL,Brian,Haas,,Portland,OR,,,,,Brian Haas,42054,1387782,6/2/2021 13:01
+,Land Use/Planning Committee Chair/Co-Chair,South Tabor,SEUL,John,Carr,,Portland,OR,,,,landuse@southtabor.org,John Carr,41155,1728510,6/2/2021 13:02
+,City Required Notice Contact/Co-Contact,South Tabor,SEUL,Nate,Canfield,,Portland,OR,97286,,,nathaniel.canfield@gmail.com,Nate Canfield,41079,1602081,6/2/2021 13:04
+,General correspondance,South Tabor,SEUL,STNA,GeneralCorrespondenceContact,3534 SE Main St,Portland,OR,97214,,,communications@southtabor.org,STNA GeneralCorrespondenceContact,41080,903760,7/12/2021 16:45
+,Chair/Co-Chair/President,Southwest Hills,NWNW,Melanie,Billings-Yun,,Portland,OR,,,,president@swhrl.org,Melanie Billings-Yun,42015,1008360,8/3/2021 12:57
+,Vice Chair/Vice President,Southwest Hills,NWNW,John,Neumann,,Portland,OR,,,,president@swhrl.org,John Neumann,42058,1051450,8/3/2021 13:04
+,Secretary,Southwest Hills,NWNW,Fiona,Cundy,,Portland,OR,,,,secretary@swhrl.org,Fiona Cundy,42059,378531,8/3/2021 13:06
+,Treasurer/Finance Committee Chair,Southwest Hills,NWNW,Kim,Silverman,,Portland,OR,97201,,,treasurer@swhrl.org,Kim Silverman,39934,1317822,8/3/2021 13:01
+,Land Use/Planning Committee Chair/Co-Chair,Southwest Hills,NWNW,Land Use,Chair,,Portland,OR,,,,landuse@swhrl.org,Land Use Chair,42061,1766562,9/10/2021 15:51
+,City Required Notice Contact/Co-Contact,Southwest Hills,NWNW,SWHillsResidLeague,RequiredNoticeContact,"SWHRL, c/o Neighbors West-Northwest, 2257 NW Raleigh Street",Portland,OR,97210,,,contact@swhrl.org,SWHillsResidLeague RequiredNoticeContact,41026,1600014,8/3/2021 12:46
+,General correspondance,Southwest Hills,NWNW,SWHillsResidLeague,GeneralCorrespondenceContact,"SWHRL, c/o Neighbors West-Northwest, 2257 NW Raleigh Street",Portland,OR,97210,,,contact@swhrl.org,SWHillsResidLeague GeneralCorrespondenceContact,41027,902594,8/3/2021 12:56
+,Chair/Co-Chair/President,St. Johns,NPNS,Jose,Alamilla,,Portland,OR,,,,info@stjohnspdx.org,Jose Alamilla,41977,1007448,2/23/2021 15:10
+,Treasurer/Finance Committee Chair,St. Johns,NPNS,Bernadine,Lee,,Portland,OR,,,,minimouse313@gmail.com,Bernadine Lee,41464,1368312,12/11/2019 11:16
+,Land Use/Planning Committee Chair/Co-Chair,St. Johns,NPNS,Michelle,Brinning,,Portland,OR,,,,landuse@stjohnspdx.org,Michelle Brinning,41996,1763832,1/25/2021 15:28
+,City Required Notice Contact/Co-Contact,St. Johns,NPNS,StJohnsNA,RequiredNoticeContact2,2209 N. Schofield,Portland,OR,97217,,,landuse@stjohnspdx.org,StJohnsNA RequiredNoticeContact2,40921,1595919,1/30/2019 9:47
+,City Required Notice Contact/Co-Contact,St. Johns,NPNS,StJohnsNA,RequiredNoticeContact1,2209 N. Schofield,Portland,OR,97217,,,landuse@stjohnspdx.org,StJohnsNA RequiredNoticeContact1,40916,1595724,2/24/2021 10:09
+,General correspondance,St. Johns,NPNS,StJohnsNA,GeneralCorrespondenceContact,2209 N Schofield,Portland,OR,97217,,,,StJohnsNA GeneralCorrespondenceContact,40917,900174,11/20/2018 12:26
+,Chair/Co-Chair/President,Sullivan's Gulch,NECN,Dave,Brook,,Portland,OR,97232,,(503) 313-1320,dbrookportland@gmail.com,Dave Brook,18742,449808,1/24/2020 11:02
+,Chair/Co-Chair/President,Sullivan's Gulch,NECN,Mary Beth,Christopher,,Portland,OR,,,,,Mary Beth Christopher,41846,1004304,4/10/2019 12:29
+,Secretary,Sullivan's Gulch,NECN,Kathy,Hansen,"1605 NE Clackamas, #508B",Portland,OR,97232,(503) 221-4845,,hansenk1324@q.com,Kathy Hansen,40328,362952,8/2/2016 10:35
+,Treasurer/Finance Committee Chair,Sullivan's Gulch,NECN,Dan,Lerch-Walters,,Portland,OR,97232,(503) 284-7605,,,Dan Lerch-Walters,33648,1110384,1/24/2020 11:04
+,Land Use/Planning Committee Chair/Co-Chair,Sullivan's Gulch,NECN,DJ,Heffernan,2525 NE Halsey Street,Portland,OR,97232,(503) 310-2306,,djheff1@gmail.com,DJ Heffernan,7834,329028,10/31/2016 9:40
+,City Required Notice Contact/Co-Contact,Sullivan's Gulch,NECN,SullivansGulchNA,RequiredNoticeContact,c/o Holladay Park Plaza 1300 NE 16th Ave,Portland,OR,97232,,,sgnagulchnet@gmail.com,SullivansGulchNA RequiredNoticeContact,41133,1604187,1/24/2020 11:07
+,General correspondance,Sullivan's Gulch,NECN,SullivansGulchNA,GeneralCorrespondenceContact,SGNA c/o Holladay Park Plaza 1300 NE 16th Ave,Portland,OR,97232,,,,SullivansGulchNA GeneralCorrespondenceContact,41134,904948,3/13/2017 12:52
+,Chair/Co-Chair/President,Sumner,CNN,Yvonne,Rice,"c/o CNN, 4415 NE 87th Ave.",Portland,OR,97220,,,sumner.neighborhood.chair@gmail.com,Yvonne Rice,40382,969168,4/21/2021 13:38
+,Vice Chair/Vice President,Sumner,CNN,Karen,McAninch,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,(503) 453-5289,,,Karen McAninch,41570,1039250,9/30/2020 12:02
+,Secretary,Sumner,CNN,Virginia,Petersen,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,(503) 775-0953,,virgepete@msn.com,Virginia Petersen,33562,302058,9/30/2020 12:03
+,Treasurer/Finance Committee Chair,Sumner,CNN,Janet,Shannon,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,,Janet Shannon,41752,1377816,9/30/2020 12:04
+,Land Use/Planning Committee Chair/Co-Chair,Sumner,CNN,Dave,Ganslein,c/o CNN 4415 NE 87th Ave,Portland,OR,97220,,,daveganslein@hotmail.com,Dave Ganslein,41954,1762068,9/30/2020 12:03
+,City Required Notice Contact/Co-Contact,Sumner,CNN,SumnerAN,RequiredNoticeContact,4415 NE 87th Ave.,Portland,OR,97220,,,sumner.neighborhood.chair@gmail.com,SumnerAN RequiredNoticeContact,40663,1585857,12/12/2016 13:21
+,General correspondance,Sumner,CNN,SumnerAN,GeneralCorrespContact,4415 NE 87th Ave.,Portland,OR,97220,,(503) 823-3157,sumner.neighborhood.chair@gmail.com,SumnerAN GeneralCorrespContact,40664,894608,12/12/2016 13:21
+,Vice Chair/Vice President,Sunderland,CNN,Lisa,Larson,c/o CNN 4415 NE 87th Ave - neighborhood association is currently inactive,Portland,OR,,,,,Lisa Larson,41952,1048800,10/1/2020 13:28
+,City Required Notice Contact/Co-Contact,Sunderland,CNN,SunderlandNA,RequiredNoticeContact,"c/o CNN, 4415 NE 87th Ave.",Portland,OR,97220,,,sandral@cnncoalition.org,SunderlandNA RequiredNoticeContact,40968,1597752,4/4/2018 12:42
+,General correspondance,Sunderland,CNN,SunderlandNA,GeneralCorrespondenceContact,"c/o CNN, 4415 NE 87th Ave.",Portland,OR,97220,,(503) 823-3156,sandral@cnncoalition.org,SunderlandNA GeneralCorrespondenceContact,40969,901318,3/13/2017 16:43
+,Vice Chair/Vice President,Sunnyside,SEUL,Ash,Hester,,Portland,OR,,,,,Ash Hester,32955,823875,8/20/2021 19:30
+,Secretary,Sunnyside,SEUL,Ben,Wyatt,,Portland,OR,,,,,Ben Wyatt,37462,337158,8/20/2021 19:32
+,Treasurer/Finance Committee Chair,Sunnyside,SEUL,Vincent,Dawans,,Portland,OR,,,,,Vincent Dawans,41921,1383393,8/20/2021 19:33
+,Land Use/Planning Committee Chair/Co-Chair,Sunnyside,SEUL,Jes,Maran,,Portland,OR,,,,,Jes Maran,42070,1766940,8/20/2021 19:33
+,City Required Notice Contact/Co-Contact,Sunnyside,SEUL,SunnysideNA,RequiredNoticeContact,,Portland,OR,,,,,SunnysideNA RequiredNoticeContact,41082,1602198,3/10/2017 11:52
+,General correspondance,Sunnyside,SEUL,SunnysideNA,GeneralCorrespondenceContact,,Portland,OR,,,,,SunnysideNA GeneralCorrespondenceContact,41083,903826,3/10/2017 11:53
+,Chair/Co-Chair/President,Sylvan-Highlands,NWNW,Michele,Shea-Han,,Portland,OR,,,,president@sylvanhighlands.org,Michele Shea-Han,41951,1006824,8/26/2020 16:07
+,Vice Chair/Vice President,Sylvan-Highlands,NWNW,Sally,Knueven,,,,,(503) 226-4850,,,Sally Knueven,2232,55800,4/1/2001 0:00
+,Secretary,Sylvan-Highlands,NWNW,Sally,Knueven,,,,,(503) 226-4850,,,Sally Knueven,2232,20088,4/1/2001 0:00
+,Treasurer/Finance Committee Chair,Sylvan-Highlands,NWNW,Dave,Malcolm,,Portland,OR,97221,(503) 805-9587,,djm.shna@gmail.com,Dave Malcolm,30753,1014849,8/31/2020 11:54
+,Land Use/Planning Committee Chair/Co-Chair,Sylvan-Highlands,NWNW,Dave,Malcolm,,Portland,OR,97221,(503) 805-9587,,djm.shna@gmail.com,Dave Malcolm,30753,1291626,8/31/2020 11:54
+,Land Use/Planning Committee Chair/Co-Chair,Sylvan-Highlands,NWNW,Rick,Kneuven,5200 SW Barnes Road,Portland,OR,97221,(503) 226-4850,(503) 294-2018,rkneuven@netscape.net,Rick Kneuven,3581,150402,8/26/2020 16:05
+,City Required Notice Contact/Co-Contact,Sylvan-Highlands,NWNW,SHNA,Required/General/CertifiedContact,2257 NW Raleigh St,Portland,OR,97203,(503) 823-4288,,president@sylvanhighlands.org,SHNA Required/General/CertifiedContact,40618,1584102,12/11/2020 17:57
+,General correspondance,Sylvan-Highlands,NWNW,SHNA,Required/General/CertifiedContact,2257 NW Raleigh St,Portland,OR,97203,(503) 823-4288,,president@sylvanhighlands.org,SHNA Required/General/CertifiedContact,40618,893596,12/11/2020 17:57
+,Chair/Co-Chair/President,University Park,NPNS,Mike,Lambert,,Portland,OR,,,,mike.lambert@upnapdx.org,Mike Lambert,42023,1008552,3/22/2021 21:13
+,Secretary,University Park,NPNS,Tom,Karwaki,,Portland,OR,,,,karwaki@yahoo.com,Tom Karwaki,41972,377748,11/3/2020 17:51
+,Treasurer/Finance Committee Chair,University Park,NPNS,Jacob,Williams,,,OR,,,,UPNAjacob@gmail.com,Jacob Williams,39922,1317426,11/5/2020 9:57
+,Land Use/Planning Committee Chair/Co-Chair,University Park,NPNS,Tom,Karwaki,2209 N Schofield,Portland,OR,97217,(253) 318-2075,,karwaki@yahoo.com,Tom Karwaki,39395,1654590,11/5/2020 10:09
+,City Required Notice Contact/Co-Contact,University Park,NPNS,UniversityParkNA,RequiredNoticeContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,karwaki@yahoo.com,UniversityParkNA RequiredNoticeContact,40949,1597011,11/5/2020 9:57
+,General correspondance,University Park,NPNS,UniversityParkNA,GeneralCorrespondenceContact,North Portland Neighborhood Services 2209 N. Schofield St.,Portland,OR,97217,,,matthew.glazewski@gmail.com,UniversityParkNA GeneralCorrespondenceContact,40950,900900,11/5/2020 9:58
+,Chair/Co-Chair/President,Vernon,NECN,Christine,Laliberte,,Portland,OR,,,,vnaboard@gmail.com,Christine Laliberte,41912,1005888,6/9/2021 13:30
+,City Required Notice Contact/Co-Contact,Vernon,NECN,VernonNA Land Use,RequiredNoticeContact,c/o Northeast Coalition of Neighborhoods 4815 NE 7th Ave,Portland,OR,97211,,,vnaboard@gmail.com,VernonNA Land Use RequiredNoticeContact,41136,1604304,11/17/2020 19:02
+,General correspondance,Vernon,NECN,VernonNA,GeneralCorrespondenceContact,c/o Northeast Coalition of Neighborhoods 4815 NE 7th Ave,Portland,OR,97211,,,,VernonNA GeneralCorrespondenceContact,41137,905014,3/13/2017 13:31
+,City Required Notice Contact/Co-Contact,West Portland Park,Includes City supported SW Neighborhoods,WestPortlandParkNA,RequiredNoticeContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,wpp-board@swni.org,WestPortlandParkNA RequiredNoticeContact,41029,1600131,8/13/2021 9:00
+,General correspondance,West Portland Park,Includes City supported SW Neighborhoods,WestPortlandParkNA,GeneralCorrespondenceContact,"c/o Southwest Neighborhoods, Inc., 7688 SW Capitol Hwy",Portland,OR,97219-2457,,,wpp-board@swni.org,WestPortlandParkNA GeneralCorrespondenceContact,41030,902660,8/13/2021 8:59
+,Chair/Co-Chair/President,Wilkes,EPCO,Richard,Mohle,,Portland,OR,,,,richardmohley@gmail.com,Richard Mohle,39989,959736,12/17/2015 13:12
+,Land Use/Planning Committee Chair/Co-Chair,Wilkes,EPCO,Richard,Anderson,,Portland,,97230,(503) 254-1625,,randers1000@gmail.com,Richard  Anderson,38033,1597386,3/18/2019 15:38
+,City Required Notice Contact/Co-Contact,Wilkes,EPCO,WilkesCmtyGroup,RequiredNoticeContact,1017 NE 117th,Portland,OR,97220,,,wilkes.communitygroup.chair@gmail.com,WilkesCmtyGroup RequiredNoticeContact,40857,1593423,2/8/2017 11:23
+,General correspondance,Wilkes,EPCO,WilkesCmtyGroup,GeneralCorrespondenceContact,1017 NE 117th,Portland,OR,97220,,,wilkes.communitygroup.chair@gmail.com,WilkesCmtyGroup GeneralCorrespondenceContact,40858,898876,2/8/2017 11:25
+,City Required Notice Contact/Co-Contact,Woodland Park,EPCO,WoodlandParkNA,RequiredNoticeContact,1017 NE 117th Ave.,Portland,OR,97220,,,woodlandparkneighbors@gmail.com,WoodlandParkNA RequiredNoticeContact,41109,1603251,2/25/2020 12:44
+,General correspondance,Woodland Park,EPCO,WoodlandParkNA,GeneralCorrespondenceContact,1017 NE 117th Ave.,Portland,OR,97220,,,woodlandparkneighbors@gmail.com,WoodlandParkNA GeneralCorrespondenceContact,41110,904420,2/25/2020 12:44
+,Chair/Co-Chair/President,Woodlawn,NECN,Melody,Randolph,,Portland,OR,,,,medicalmelody@gmail.com,Melody Randolph,41905,1005720,10/3/2019 16:04
+,Chair/Co-Chair/President,Woodlawn,NECN,Maija,Spencer,,Portland,OR,,,,maijaspencer@hotmail.com,Maija Spencer,1052,25248,11/14/2016 13:23
+,Land Use/Planning Committee Chair/Co-Chair,Woodlawn,NECN,Anjala,Ehelebe,,Portland,OR,,,,aehelebe@gmail.com,Anjala Ehelebe,41908,1760136,10/8/2019 14:21
+,Land Use/Planning Committee Chair/Co-Chair,Woodlawn,NECN,Patricia,Rimmer,,Portland,OR,,,,rimmer9492@comcast.net,Patricia Rimmer,41909,1760178,10/9/2019 13:08
+,City Required Notice Contact/Co-Contact,Woodlawn,NECN,WoodlawnNA,RequiredNoticeContact,4815 NE 7th Ave,Portland,OR,97211,,,info@gowoodlawn.com; maijaspencer@hotmail.com,WoodlawnNA RequiredNoticeContact,41139,1604421,4/9/2019 12:26
+,General correspondance,Woodlawn,NECN,WoodlawnNA,GeneralCorrespondenceContact,Northeast Coalition of Neighborhoods 4815 NE 7th Ave,Portland,OR,97211,,,info@gowoodlawn.com; maijaspencer@hotmail.com,WoodlawnNA GeneralCorrespondenceContact,41140,905080,2/7/2018 14:10
+,Chair/Co-Chair/President,Woodstock,SEUL,Anna,Weichsel,,Portland,OR,,,,,Anna Weichsel,38475,923400,8/20/2021 18:44
+,Vice Chair/Vice President,Woodstock,SEUL,Pete,Jacobsen,,Portland,OR,,,,,Pete Jacobsen,42066,1051650,8/20/2021 18:46
+,Secretary,Woodstock,SEUL,Sonja,Miller,,Portland,OR,,,,,Sonja Miller,39562,356058,8/20/2021 18:47
+,Treasurer/Finance Committee Chair,Woodstock,SEUL,Elisa,Edgington,,Portland,OR,,,,,Elisa Edgington,39105,1290465,8/20/2021 18:47
+,Land Use/Planning Committee Chair/Co-Chair,Woodstock,SEUL,Thatch,Moyle,,Portland,OR,,,,thatchmoyle@gmail.com,Thatch Moyle,41248,1732416,11/10/2020 14:34
+,Land Use/Planning Committee Chair/Co-Chair,Woodstock,SEUL,Les,Szigethy,,Portland,OR,,,,,Les Szigethy,42067,1766814,8/20/2021 18:48
+,City Required Notice Contact/Co-Contact,Woodstock,SEUL,Thatch,Moyle,,Portland,OR,,,,thatchmoyle@gmail.com,Thatch Moyle,41085,1602315,11/10/2020 14:35
+,General correspondance,Woodstock,SEUL,WoodstockNA,GeneralCorrespondenceContact,5905 SE 43rd Ave.,Portland,OR,97206,(503) 278-6265,,ekedgin@gmail.com,WoodstockNA GeneralCorrespondenceContact,41086,903892,6/22/2018 11:38


### PR DESCRIPTION
FYI Due to changes in the CSV migration module, all existing migrations needed updating to rename `keys:` to `ids:`