### PR TITLE
POWR-3968 implement webform as entity reference field in Service content type

### DIFF
--- a/web/sites/default/config/core.entity_form_display.node.city_service.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.city_service.default.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
     - workflows.workflow.editorial
   module:
@@ -40,6 +41,7 @@ dependencies:
     - path
     - select2
     - text
+    - webform
 third_party_settings:
   field_group:
     group_administrative_fields:
@@ -52,7 +54,7 @@ third_party_settings:
         - url_redirects
         - field_search_keywords
       parent_name: ''
-      weight: 22
+      weight: 24
       format_type: details_sidebar
       region: content
       format_settings:
@@ -67,7 +69,7 @@ third_party_settings:
       children:
         - field_redirects
       parent_name: ''
-      weight: 18
+      weight: 20
       format_type: details
       region: content
       format_settings:
@@ -82,7 +84,7 @@ third_party_settings:
       children:
         - field_contact
       parent_name: ''
-      weight: 14
+      weight: 16
       format_type: details
       region: content
       format_settings:
@@ -97,7 +99,7 @@ third_party_settings:
       children:
         - field_address
       parent_name: ''
-      weight: 15
+      weight: 17
       format_type: details
       region: content
       format_settings:
@@ -112,7 +114,7 @@ third_party_settings:
       children:
         - field_online_application
       parent_name: ''
-      weight: 12
+      weight: 14
       format_type: details
       region: content
       format_settings:
@@ -127,7 +129,7 @@ third_party_settings:
       children:
         - field_topics
       parent_name: ''
-      weight: 13
+      weight: 15
       format_type: details
       region: content
       format_settings:
@@ -142,7 +144,7 @@ third_party_settings:
       children:
         - field_related_content
       parent_name: ''
-      weight: 17
+      weight: 19
       format_type: details
       region: content
       format_settings:
@@ -218,7 +220,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_display_groups:
-    weight: 19
+    weight: 21
     settings:
       match_operator: CONTAINS
       size: 60
@@ -273,7 +275,7 @@ content:
     type: boolean_checkbox
     region: content
   field_location:
-    weight: 16
+    weight: 18
     settings:
       entity_browser: service_locations
       field_widget_display: rendered_entity
@@ -360,7 +362,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_reviewer:
-    weight: 20
+    weight: 22
     settings:
       match_operator: CONTAINS
       size: 60
@@ -382,7 +384,7 @@ content:
     region: content
   field_service_mode:
     type: paragraphs
-    weight: 11
+    weight: 13
     settings:
       title: 'service mode'
       title_plural: 'service modes'
@@ -452,9 +454,17 @@ content:
     third_party_settings: {  }
     type: options_buttons
     region: content
+  field_webform:
+    weight: 11
+    settings:
+      default_data: true
+      webforms: {  }
+    third_party_settings: {  }
+    type: webform_entity_reference_select
+    region: content
   moderation_state:
     type: moderation_state_default
-    weight: 21
+    weight: 23
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -481,6 +491,11 @@ content:
       maxlength:
         maxlength_js: 78
         maxlength_js_label: '<strong>Full title</strong> for search. Use title case. Google displays ~78 characters for titles. Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+  translation:
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 12

--- a/web/sites/default/config/core.entity_view_display.node.city_service.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.default.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
   module:
     - address
@@ -34,13 +35,14 @@ dependencies:
     - options
     - text
     - user
+    - webform
 id: node.city_service.default
 targetEntityType: node
 bundle: city_service
 mode: default
 content:
   field_address:
-    weight: 9
+    weight: 10
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -55,7 +57,7 @@ content:
     region: content
   field_contact:
     type: entity_reference_entity_view
-    weight: 7
+    weight: 8
     region: content
     label: above
     settings:
@@ -79,7 +81,7 @@ content:
     third_party_settings: {  }
   field_location:
     type: entity_reference_entity_view
-    weight: 8
+    weight: 9
     region: content
     label: above
     settings:
@@ -96,7 +98,7 @@ content:
             classes: {  }
   field_online_application:
     type: link
-    weight: 6
+    weight: 7
     region: content
     label: above
     settings:
@@ -108,7 +110,7 @@ content:
     third_party_settings: {  }
   field_related_content:
     type: entity_reference_label
-    weight: 10
+    weight: 11
     region: content
     label: above
     settings:
@@ -116,7 +118,7 @@ content:
     third_party_settings: {  }
   field_service_mode:
     type: entity_reference_revisions_entity_view
-    weight: 5
+    weight: 6
     label: hidden
     settings:
       view_mode: default
@@ -169,11 +171,19 @@ content:
     region: content
   field_topics:
     type: entity_reference_label
-    weight: 11
+    weight: 12
     region: content
     label: above
     settings:
       link: true
+    third_party_settings: {  }
+  field_webform:
+    type: webform_entity_reference_entity_view
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      source_entity: true
     third_party_settings: {  }
   toc_js:
     weight: 2

--- a/web/sites/default/config/core.entity_view_display.node.city_service.featured.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.featured.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
   module:
     - user
@@ -58,6 +59,7 @@ hidden:
   field_summary: true
   field_time_to_complete: true
   field_topics: true
+  field_webform: true
   group_content: true
   langcode: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.city_service.related.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.related.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
   module:
     - ds
@@ -105,6 +106,7 @@ hidden:
   field_summary: true
   field_time_to_complete: true
   field_topics: true
+  field_webform: true
   group_content: true
   langcode: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.city_service.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.search_result.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
   module:
     - ds
@@ -108,6 +109,7 @@ hidden:
   field_sort_weight: true
   field_time_to_complete: true
   field_topics: true
+  field_webform: true
   group_content: true
   langcode: true
   links: true

--- a/web/sites/default/config/core.entity_view_display.node.city_service.teaser.yml
+++ b/web/sites/default/config/core.entity_view_display.node.city_service.teaser.yml
@@ -26,6 +26,7 @@ dependencies:
     - field.field.node.city_service.field_summary
     - field.field.node.city_service.field_time_to_complete
     - field.field.node.city_service.field_topics
+    - field.field.node.city_service.field_webform
     - node.type.city_service
   module:
     - ds
@@ -97,6 +98,7 @@ hidden:
   field_sort_weight: true
   field_time_to_complete: true
   field_topics: true
+  field_webform: true
   group_content: true
   langcode: true
   links: true

--- a/web/sites/default/config/field.field.node.city_service.field_webform.yml
+++ b/web/sites/default/config/field.field.node.city_service.field_webform.yml
@@ -1,0 +1,33 @@
+uuid: e8888dd6-802f-49e1-ae17-bb2f75a7fb35
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_webform
+    - node.type.city_service
+  module:
+    - custom_add_another
+    - tmgmt_content
+    - webform
+third_party_settings:
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+  tmgmt_content:
+    excluded: false
+id: node.city_service.field_webform
+field_name: field_webform
+entity_type: node
+bundle: city_service
+label: Webform
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:webform'
+  handler_settings:
+    target_bundles: null
+    auto_create: false
+field_type: webform

--- a/web/sites/default/config/field.storage.node.field_webform.yml
+++ b/web/sites/default/config/field.storage.node.field_webform.yml
@@ -1,0 +1,24 @@
+uuid: 20a37da0-0932-4853-a1a0-994c5cda7546
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - webform
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_webform
+field_name: field_webform
+entity_type: node
+type: webform
+settings:
+  target_type: webform
+module: webform
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/sites/default/config/webform.webform.report_campsite_or_vehicle.yml
+++ b/web/sites/default/config/webform.webform.report_campsite_or_vehicle.yml
@@ -25,10 +25,8 @@ elements: |-
     '#type': container
     introductory_text:
       '#type': webform_markup
-      '#markup': |
-        <p>If this is a life-threatening emergency or to report a crime in progress, call 9-1-1.</p>
-
-        <p><span class="required-indicator">*</span> Required field<br />
+      '#markup': |-
+        <p>If this is a life-threatening emergency or to report a crime in progress, call 9-1-1.<br />
         &nbsp;</p>
   section_confidentiality:
     '#type': webform_section

--- a/web/themes/custom/cloudy/templates/content/city-service/node--city-service--full.html.twig
+++ b/web/themes/custom/cloudy/templates/content/city-service/node--city-service--full.html.twig
@@ -21,12 +21,14 @@
             'field_online_application',
             'field_address',
             'field_related_content',
-            'field_topics'
+            'field_topics',
+            'field_webform'
           )
         }}
         {# check to see if the old service mode experience or new body content experience is in use #}
         {% if (content.field_editor_experience[0]|render|striptags) == 'body' %}
           {{ content.field_body_content }}
+          {{ content.field_webform }}
         {% elseif
           (content.field_editor_experience[0]|render|striptags) == 'modes' %}
           {{ content.field_service_mode }}


### PR DESCRIPTION
There is one config file that may seem out of place. I removed the manually-added required field indicator in the campsite reporting form. It was showing two indicators, since the built-in one is also turned on.