### PR TITLE
CSM-140 added Agent Use Only field block to feedback form

### DIFF
--- a/web/sites/default/config/webform.webform.website_feedback.yml
+++ b/web/sites/default/config/webform.webform.website_feedback.yml
@@ -140,10 +140,10 @@ elements: |-
         '#title': 'Agent Summary'
         '#display_on': none
         '#template': |-
-          {% if data.agent_email %}<p>Agent Email: {{ data.agent_email }}</p>{% endif %}
+          {% if uid %}<p>Agent Email: {{ data.agent_email }}</p>{% endif %}
           {% if data.agent_ticket_number %}<p>Ticket Number: {{ data.agent_ticket_number }}</p>{% endif %}
           {% if data.agent_action_taken %}<p>Action Taken: {{ data.agent_action_taken }}</p>{% endif %}
-          <p>Contact Type: {{ data.agent_contact_type }}</p>
+          <p>Contact Type: {% if data.agent_contact_type %}{{ data.agent_contact_type }}{% else %}Webform{% endif %}</p>
           <p>Ticket Type: {{ data.agent_ticket_type }}</p>
         '#ajax': true
     actions:
@@ -159,15 +159,6 @@ elements: |-
     '#type': hidden
     '#title': 'IP Address'
     '#default_value': '[current-user:ip-address]'
-  computed_email_address:
-    '#type': webform_computed_twig
-    '#title': 'Computed email address'
-    '#display_on': none
-    '#mode': text
-    '#template': '{% if data.email_address %}{{ data.email_address }}{% else %}anonymous@portlandoregon.gov{% endif %}'
-    '#whitespace': trim
-    '#store': true
-    '#ajax': true
 css: 'd-flex justify-content-around'
 javascript: ''
 settings:
@@ -274,7 +265,7 @@ settings:
   draft_pending_multiple_message: ''
   confirmation_type: inline
   confirmation_title: ''
-  confirmation_message: "<h2>Thank you for submitting your feedback, we appreciate your help!</h2>\r\nYou should receive an email confirmation in just a moment. You may reply to that email to add additional information or comments to your feedback.<br />\r\n<br />\r\nName:&nbsp;[webform_submission:values:your_name]<br />\r\n<br />\r\nType of feedback:&nbsp;[webform_submission:values:subject]<br />\r\n<br />\r\nLast page viewed:&nbsp;<a href=\"[webform_submission:values:page_you_last_viewed]\">[webform_submission:values:page_you_last_viewed]</a><br />\r\n<br />\r\nFeedback:&nbsp;[webform_submission:values:feedback]"
+  confirmation_message: "<h2>Thank you for submitting your feedback, we appreciate your help!</h2>\r\nYou should receive an email confirmation in just a moment. You may reply to that email to add additional information or comments to your feedback.<br />\r\n<br />\r\nName:&nbsp;[webform_submission:values:your_name]<br />\r\n<br />\r\nEmail:&nbsp;[webform_submission:values:email_address]<br />\r\n<br />\r\nType of feedback:&nbsp;[webform_submission:values:subject]<br />\r\n<br />\r\nLast page viewed:&nbsp;<a href=\"[webform_submission:values:page_you_last_viewed]\">[webform_submission:values:page_you_last_viewed]</a><br />\r\n<br />\r\nFeedback:&nbsp;[webform_submission:values:feedback]"
   confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
@@ -384,7 +375,7 @@ handlers:
       cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
-      from_mail: '[webform_submission:values:email_address]'
+      from_mail: '[webform_submission:values:email_address:raw]'
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'
@@ -425,7 +416,7 @@ handlers:
       cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
-      from_mail: '[webform_submission:values:email_address]'
+      from_mail: '[webform_submission:values:email_address:raw]'
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'

--- a/web/sites/default/config/webform.webform.website_feedback.yml
+++ b/web/sites/default/config/webform.webform.website_feedback.yml
@@ -121,16 +121,30 @@ elements: |-
           invisible:
             ':input[name="agent_ticket_number"]':
               filled: true
-        '#default_value': Webform
+      agent_ticket_type:
+        '#type': webform_computed_twig
+        '#title': 'Ticket Type'
+        '#display_on': none
+        '#mode': text
+        '#template': |-
+          {% if data.subject == "I have a question" %}
+          Question
+          {% elseif data.subject == "I cannot find what I'm looking for" or data.subject == "The information looks incorrect" %}
+          Problem
+          {% elseif data.subject == "The page looks broken" %}
+          Incident
+          {% endif %}
+        '#whitespace': spaceless
       agent_summary:
         '#type': webform_computed_twig
         '#title': 'Agent Summary'
         '#display_on': none
         '#template': |-
-          <p>Agent Email: {{ data.agent_email }}</p>
-          <p>Ticket Number: {{ data.agent_ticket_number }}</p>
-          <p>Action Taken: {{ data.agent_action_taken }}</p>
+          {% if data.agent_email %}<p>Agent Email: {{ data.agent_email }}</p>{% endif %}
+          {% if data.agent_ticket_number %}<p>Ticket Number: {{ data.agent_ticket_number }}</p>{% endif %}
+          {% if data.agent_action_taken %}<p>Action Taken: {{ data.agent_action_taken }}</p>{% endif %}
           <p>Contact Type: {{ data.agent_contact_type }}</p>
+          <p>Ticket Type: {{ data.agent_ticket_type }}</p>
         '#ajax': true
     actions:
       '#type': webform_actions
@@ -370,11 +384,11 @@ handlers:
       cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
-      from_mail: '[webform_submission:values:computed_email_address]'
+      from_mail: '[webform_submission:values:email_address]'
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'
-      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]</p>\r\n\r\n[webform_submission:values:agent_summary]"
+      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]</p>\r\n[webform_submission:values:agent_summary]"
       excluded_elements:
         agent_summary: agent_summary
       ignore_access: false
@@ -411,11 +425,11 @@ handlers:
       cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
-      from_mail: '[webform_submission:values:computed_email_address]'
+      from_mail: '[webform_submission:values:email_address]'
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'
-      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]<br />\r\n<br />\r\n[webform_submission:values:agent_summary]</p>"
+      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]<br />\r\n<br />\r\n[webform_submission:values:agent_summary]</p>"
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/web/sites/default/config/webform.webform.website_feedback.yml
+++ b/web/sites/default/config/webform.webform.website_feedback.yml
@@ -69,16 +69,69 @@ elements: |-
       '#description': 'You can change this address if you would rather comment on a different page.'
       '#autocomplete': 'off'
       '#default_value': '[server:HTTP_REFERER]'
-    ip_address:
-      '#type': hidden
-      '#title': 'IP Address'
-      '#default_value': '[current-user:ip-address]'
-    zendesk_ticket_id:
-      '#type': hidden
-      '#title': 'Zendesk ticket id'
     public_records_statement:
       '#type': webform_markup
       '#markup': 'The information you provide in this form is considered a public record under Oregon&rsquo;s <a data-renderer-mark="true" href="https://www.doj.state.or.us/oregon-department-of-justice/public-records/attorney-generals-public-records-and-meetings-manual/i-public-records/#:~:text=Under%20Oregon''s%20Public%20Records%20Law,committee%20of%20the%20Legislative%20Assembly" title="https://www.doj.state.or.us/oregon-department-of-justice/public-records/attorney-generals-public-records-and-meetings-manual/i-public-records/#:~:text=Under%20Oregon''s%20Public%20Records%20Law,committee%20of%20the%20Legislative%20Assembly">Public Records Law</a> and is available to the public on request.'
+    section_agent_use_only:
+      '#type': webform_section
+      '#title': 'Agent Use Only'
+      '#attributes':
+        style: 'padding: 15px; background-color: #cccccc;'
+      '#access_create_roles':
+        - support_agent
+        - administrator
+      '#access_update_roles':
+        - support_agent
+        - administrator
+      '#access_view_roles':
+        - support_agent
+        - administrator
+      agent_email:
+        '#type': textfield
+        '#title': 'Agent Email'
+        '#default_value': '[current-user:display-name] <[current-user:mail]>'
+      agent_ticket_number:
+        '#type': number
+        '#title': 'Ticket Number'
+        '#min': 1000
+        '#max': 999999999
+      agent_action_taken:
+        '#type': radios
+        '#title': 'Action Taken'
+        '#options':
+          Resolved: Resolved
+          Referred: Referred
+        '#options_display': side_by_side
+        '#states':
+          invisible:
+            ':input[name="agent_ticket_number"]':
+              filled: true
+      agent_contact_type:
+        '#type': radios
+        '#title': 'Contact Type'
+        '#options':
+          Phone: Phone
+          Email: Email
+          Webform: Webform
+          'In Person': 'In Person'
+          Webchat: Webchat
+          'Social Media': 'Social Media'
+        '#options_display': side_by_side
+        '#states':
+          invisible:
+            ':input[name="agent_ticket_number"]':
+              filled: true
+        '#default_value': Webform
+      agent_summary:
+        '#type': webform_computed_twig
+        '#title': 'Agent Summary'
+        '#display_on': none
+        '#template': |-
+          <p>Agent Email: {{ data.agent_email }}</p>
+          <p>Ticket Number: {{ data.agent_ticket_number }}</p>
+          <p>Action Taken: {{ data.agent_action_taken }}</p>
+          <p>Contact Type: {{ data.agent_contact_type }}</p>
+        '#ajax': true
     actions:
       '#type': webform_actions
       '#title': 'Submit button(s)'
@@ -88,6 +141,10 @@ elements: |-
       '#submit__attributes':
         class:
           - w-50
+  ip_address:
+    '#type': hidden
+    '#title': 'IP Address'
+    '#default_value': '[current-user:ip-address]'
   computed_email_address:
     '#type': webform_computed_twig
     '#title': 'Computed email address'
@@ -317,8 +374,9 @@ handlers:
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'
-      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]</p>"
-      excluded_elements: {  }
+      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]</p>\r\n\r\n[webform_submission:values:agent_summary]"
+      excluded_elements:
+        agent_summary: agent_summary
       ignore_access: false
       exclude_empty: true
       exclude_empty_checkbox: false
@@ -357,7 +415,7 @@ handlers:
       from_options: {  }
       from_name: '[webform_submission:values:your_name:raw]'
       subject: '[webform_submission:values:subject:raw] - [webform_submission:values:feedback]'
-      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]</p>"
+      body: "<p>Subject: [webform_submission:values:subject]</p>\r\n\r\n<p>Feedback: [webform_submission:values:feedback]</p>\r\n\r\n<p>Name: [webform_submission:values:your_name]</p>\r\n\r\n<p>Email: [webform_submission:values:computed_email_address]</p>\r\n\r\n<p>Page last viewed: [webform_submission:values:page_you_last_viewed]</p>\r\n\r\n<p>Submitted on: [webform_submission:created]</p>\r\n\r\n<p>User agent: [server:HTTP_USER_AGENT]<br />\r\n<br />\r\n[webform_submission:values:agent_summary]</p>"
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true


### PR DESCRIPTION
Updates to the Website Feedback form:

* Added Agent Use Only field block
* Removed Reason for Contact, replaced with Ticket Type and conditional logic to set value
* Tweaks to body of email submission to Webform with new fields

Triggers have been added to Zendesk to set Contact Type and Ticket Type in an abstract way, for any ticket created by email handler.