### PR TITLE
POWR-4016 Create translator role and permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -284,7 +284,8 @@
                 "3126343 - Scheduler needs to maintain its base fields properly": "https://www.drupal.org/files/issues/2020-07-08/3126343-11.patch"
             },
             "drupal/tmgmt": {
-                "3145253 - Use of deprecated theme function": "https://www.drupal.org/files/issues/2021-06-24/deprecated-theme-function-3145253-11.patch"            
+                "3145253 - Use of deprecated theme function": "https://www.drupal.org/files/issues/2021-06-24/deprecated-theme-function-3145253-11.patch",
+                "3250019 - The 'taxonomy_menu.menu_link' entity type does not exist": "https://www.drupal.org/files/issues/2022-01-28/tmgmt-3250019-1.patch"
             }
         },
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7f9e2a790649ff30783ceb556a8cdc9",
+    "content-hash": "5fd07798952941725c9ef36533bda5c2",
     "packages": [
         {
             "name": "algolia/places",
@@ -79,12 +79,12 @@
             "version": "v1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/uxsolutions/bootstrap-datepicker.git",
+                "url": "git@github.com:eternicode/bootstrap-datepicker.git",
                 "reference": "fb8776d65825068b9f914ab37d6fd847c951f488"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uxsolutions/bootstrap-datepicker/zipball/fb8776d65825068b9f914ab37d6fd847c951f488",
+                "url": "https://api.github.com/repos/eternicode/bootstrap-datepicker/zipball/fb8776d65825068b9f914ab37d6fd847c951f488",
                 "reference": "fb8776d65825068b9f914ab37d6fd847c951f488"
             },
             "require": {
@@ -2060,6 +2060,10 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
+                {
+                    "name": "Centarro",
+                    "homepage": "https://www.drupal.org/user/3661446"
+                },
                 {
                     "name": "bojanz",
                     "homepage": "https://www.drupal.org/user/86106"
@@ -4378,7 +4382,7 @@
                 "drupal/core": "^8.8 || ^9"
             },
             "require-dev": {
-                "drupal/entity_browser": "^2.5"
+                "drupal/entity_browser": "*"
             },
             "suggest": {
                 "enyo/dropzone": "Required to use drupal/dropzonejs. DropzoneJS is an open source library that provides drag’n’drop file uploads with image previews."
@@ -7327,8 +7331,16 @@
             ],
             "authors": [
                 {
+                    "name": "Jeff Cardwell",
+                    "homepage": "https://www.drupal.org/user/2913129"
+                },
+                {
                     "name": "bkosborne",
                     "homepage": "https://www.drupal.org/user/788032"
+                },
+                {
+                    "name": "gravelpot",
+                    "homepage": "https://www.drupal.org/user/748208"
                 },
                 {
                     "name": "mark_fullmer",
@@ -8947,10 +8959,6 @@
                     "name": "Lucas Hedding",
                     "homepage": "https://www.drupal.org/u/heddn",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "mikeryan",
-                    "homepage": "https://www.drupal.org/user/4420"
                 }
             ],
             "description": "Enhancements to core migration support.",

--- a/web/sites/default/config/field.field.group.advisory_group.field_address.yml
+++ b/web/sites/default/config/field.field.group.advisory_group.field_address.yml
@@ -19,7 +19,7 @@ bundle: advisory_group
 label: 'Mailing address'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/web/sites/default/config/field.field.group.program.field_address.yml
+++ b/web/sites/default/config/field.field.group.program.field_address.yml
@@ -19,7 +19,7 @@ bundle: program
 label: 'Mailing address'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/web/sites/default/config/field.field.group.project.field_address.yml
+++ b/web/sites/default/config/field.field.group.project.field_address.yml
@@ -19,7 +19,7 @@ bundle: project
 label: 'Mailing address'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/web/sites/default/config/group.role.advisory_group-4f5146610.yml
+++ b/web/sites/default/config/group.role.advisory_group-4f5146610.yml
@@ -1,0 +1,17 @@
+uuid: 00fd2081-5130-4af8-906d-fc0ffd72a6b8
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.advisory_group
+  enforced:
+    config:
+      - user.role.translator
+id: advisory_group-4f5146610
+label: Translator
+weight: 7
+internal: true
+audience: outsider
+group_type: advisory_group
+permissions_ui: false
+permissions: {  }

--- a/web/sites/default/config/group.role.bureau_office-4f5146610.yml
+++ b/web/sites/default/config/group.role.bureau_office-4f5146610.yml
@@ -1,0 +1,17 @@
+uuid: 5388a79c-5be4-4e9f-8684-e46f6d34a646
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.bureau_office
+  enforced:
+    config:
+      - user.role.translator
+id: bureau_office-4f5146610
+label: Translator
+weight: 7
+internal: true
+audience: outsider
+group_type: bureau_office
+permissions_ui: false
+permissions: {  }

--- a/web/sites/default/config/group.role.elected_official-4f5146610.yml
+++ b/web/sites/default/config/group.role.elected_official-4f5146610.yml
@@ -1,0 +1,17 @@
+uuid: d832d3c2-4d7d-494c-9d3b-8c0fcd2ea338
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.elected_official
+  enforced:
+    config:
+      - user.role.translator
+id: elected_official-4f5146610
+label: Translator
+weight: 7
+internal: true
+audience: outsider
+group_type: elected_official
+permissions_ui: false
+permissions: {  }

--- a/web/sites/default/config/group.role.program-4f5146610.yml
+++ b/web/sites/default/config/group.role.program-4f5146610.yml
@@ -1,0 +1,17 @@
+uuid: 8f2dc18a-7e6e-4d62-99ad-525a3a328148
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.program
+  enforced:
+    config:
+      - user.role.translator
+id: program-4f5146610
+label: Translator
+weight: 7
+internal: true
+audience: outsider
+group_type: program
+permissions_ui: false
+permissions: {  }

--- a/web/sites/default/config/group.role.project-4f5146610.yml
+++ b/web/sites/default/config/group.role.project-4f5146610.yml
@@ -1,0 +1,17 @@
+uuid: 8e5e27d7-723b-4713-bed3-4f2b3c778a8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.project
+  enforced:
+    config:
+      - user.role.translator
+id: project-4f5146610
+label: Translator
+weight: 7
+internal: true
+audience: outsider
+group_type: project
+permissions_ui: false
+permissions: {  }

--- a/web/sites/default/config/language/vi/views.view.content_translations.yml
+++ b/web/sites/default/config/language/vi/views.view.content_translations.yml
@@ -1,4 +1,6 @@
 display:
   default:
     display_options:
-      title: 'Bản dịch'
+      header:
+        area_text_custom:
+          content: '<h2>Bản dịch</h2>'

--- a/web/sites/default/config/language/zh-hans/views.view.content_translations.yml
+++ b/web/sites/default/config/language/zh-hans/views.view.content_translations.yml
@@ -1,4 +1,6 @@
 display:
   default:
     display_options:
-      title: 翻译
+      header:
+        area_text_custom:
+          content: '<h2>翻译</h2>'

--- a/web/sites/default/config/system.action.user_add_role_action.translator.yml
+++ b/web/sites/default/config/system.action.user_add_role_action.translator.yml
@@ -1,0 +1,14 @@
+uuid: bdee49fb-d2f3-4872-a1a9-0d6d2d5efb2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.translator
+  module:
+    - user
+id: user_add_role_action.translator
+label: 'Add the Translator role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: translator

--- a/web/sites/default/config/system.action.user_remove_role_action.translator.yml
+++ b/web/sites/default/config/system.action.user_remove_role_action.translator.yml
@@ -1,0 +1,14 @@
+uuid: 847ad556-c856-4f6a-9cf8-9b937764ebb2
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.translator
+  module:
+    - user
+id: user_remove_role_action.translator
+label: 'Remove the Translator role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: translator

--- a/web/sites/default/config/user.role.administrator.yml
+++ b/web/sites/default/config/user.role.administrator.yml
@@ -6,6 +6,6 @@ _core:
   default_config_hash: 2EL4nOaSWrCYL11npXSGwLjX_DJoj2riIUqGaNyZFWU
 id: administrator
 label: Administrator
-weight: 6
+weight: 7
 is_admin: true
 permissions: {  }

--- a/web/sites/default/config/user.role.alert_editor.yml
+++ b/web/sites/default/config/user.role.alert_editor.yml
@@ -9,7 +9,7 @@ third_party_settings:
     description: ''
 id: alert_editor
 label: 'Alert editor'
-weight: 2
+weight: 3
 is_admin: null
 permissions:
   - 'access draggableviews'

--- a/web/sites/default/config/user.role.neighborhood_editor.yml
+++ b/web/sites/default/config/user.role.neighborhood_editor.yml
@@ -9,7 +9,7 @@ third_party_settings:
     description: 'Allow users to edit the Neighborhood and coalition vocabularies.'
 id: neighborhood_editor
 label: 'Neighborhood editor'
-weight: 3
+weight: 4
 is_admin: null
 permissions:
   - 'edit terms in coalition'

--- a/web/sites/default/config/user.role.sitewide_editor.yml
+++ b/web/sites/default/config/user.role.sitewide_editor.yml
@@ -9,7 +9,7 @@ third_party_settings:
     description: 'Staff that get permissions to edit content across the site, regardless of group membership.'
 id: sitewide_editor
 label: 'Sitewide editor'
-weight: 4
+weight: 5
 is_admin: null
 permissions:
   - 'access content overview'

--- a/web/sites/default/config/user.role.support_agent.yml
+++ b/web/sites/default/config/user.role.support_agent.yml
@@ -9,6 +9,6 @@ third_party_settings:
     description: ''
 id: support_agent
 label: 'Support Agent'
-weight: 5
+weight: 6
 is_admin: null
 permissions: {  }

--- a/web/sites/default/config/user.role.translator.yml
+++ b/web/sites/default/config/user.role.translator.yml
@@ -1,0 +1,18 @@
+uuid: 63de6a3e-399d-45d2-a96c-ee7b006a265a
+langcode: en
+status: true
+dependencies:
+  module:
+    - lightning_core
+third_party_settings:
+  lightning_core:
+    description: 'Users who are allowed to create and edit translated content.'
+id: translator
+label: Translator
+weight: 2
+is_admin: null
+permissions:
+  - 'create content translations'
+  - 'delete content translations'
+  - 'translate editable entities'
+  - 'update content translations'


### PR DESCRIPTION
I'm also including a Translation Management patch that will allow us create a translation job and export the actions and topcis taxonomy terms. (Due to previous bug we had to manually export them to CSV.)