### PR TITLE
CSM-160 Update portland_zendesk module to set assignee groups instead of individuals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,7 @@
         "drupal/unified_twig_ext": "^1.0",
         "drupal/video_embed_field": "^2.4",
         "drupal/views_bulk_edit": "^2.4",
-        "drupal/views_bulk_operations": "^3.9",
+        "drupal/views_bulk_operations": "^4.1",
         "drupal/views_data_export": "^1.0@beta",
         "drupal/views_geojson": "^1.0",
         "drupal/views_infinite_scroll": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcf5d7b9cfddb06a4265d28135f34427",
+    "content-hash": "a8fd0012ed4c364081793598ec09d9e3",
     "packages": [
         {
             "name": "algolia/places",
@@ -12800,17 +12800,17 @@
         },
         {
             "name": "drupal/views_bulk_operations",
-            "version": "3.13.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/views_bulk_operations.git",
-                "reference": "8.x-3.13"
+                "reference": "4.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/views_bulk_operations-8.x-3.13.zip",
-                "reference": "8.x-3.13",
-                "shasum": "70583d08b91be3b5e008f571589425c2176eb73b"
+                "url": "https://ftp.drupal.org/files/projects/views_bulk_operations-4.1.0.zip",
+                "reference": "4.1.0",
+                "shasum": "acb6891afda4f973f043155e4f53e1b7d8ffe63d"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -12824,8 +12824,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.13",
-                    "datestamp": "1619697066",
+                    "version": "4.1.0",
+                    "datestamp": "1646055586",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -22949,5 +22949,5 @@
         "ext-dom": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -160,7 +160,7 @@ class ZendeskHandler extends WebformHandlerBase
         // Individual users shouldn't be stored in config, which has to be deployed,
         // in case there is an urgent change required. However, if tickets are to be
         // creatd as Solved, they need to have an individual assignee. Using the
-        // service account would be acceptable and necessar in this case.
+        // service account would be acceptable and necessary in this case.
         
         $client = new ZendeskClient();
 
@@ -174,7 +174,6 @@ class ZendeskHandler extends WebformHandlerBase
         asort($groups);
 
         // get list of all admin and agent users to populate assignee field
-        // get list of all users who are either agents or admins
         $response_agents = $client->users()->findAll([ 'role' => 'agent' ]);
         $response_admins = $client->users()->findAll([ 'role' => 'admin' ]);
         $users = array_merge( $response_agents->users, $response_admins->users );

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -79,7 +79,7 @@ class ZendeskHandler extends WebformHandlerBase
       'tags' => 'drupal webform',
       'priority' => 'normal',
       'status' => 'new',
-      'assignee_id' => '',
+      'group_id' => '',
       'type' => 'question',
       'collaborators' => '',
       'custom_fields' => '',
@@ -294,16 +294,16 @@ class ZendeskHandler extends WebformHandlerBase
       // prep assignees field
       // if found group assignees from Zendesk, populate dropdown.
       // otherwise provide field to specify assignee ID
-      $form['assignee_id'] = [
-        '#title' => $this->t('Ticket Assignee'),
-        '#description' => $this->t('The id of the intended assignee'),
-        '#default_value' => $this->configuration['assignee_id'],
+      $form['group_id'] = [
+        '#title' => $this->t('Ticket Group'),
+        '#description' => $this->t('The id of the intended group'),
+        '#default_value' => $this->configuration['group_id'],
         '#required' => false
       ];
       if(!empty($assignees) ){
-        $form['assignee_id']['#type'] = 'select';
-        $form['assignee_id']['#options'] = ['' => '-- none --'] + $assignees;
-        $form['assignee_id']['#description'] = $this->t('The email address the assignee');
+        $form['group_id']['#type'] = 'select';
+        $form['group_id']['#options'] = ['' => '-- none --'] + $assignees;
+        $form['group_id']['#description'] = $this->t('The email address the assignee');
       }
 
       $form['collaborators'] = [

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -27,41 +27,6 @@ use Drupal\portland_zendesk\Utils\Utility;
  *   cardinality = \Drupal\webform\Plugin\WebformHandlerInterface::CARDINALITY_UNLIMITED,
  *   results = \Drupal\webform\Plugin\WebformHandlerInterface::RESULTS_PROCESSED,
  * )
- *
- * This handler needs to do the following:
- * - Allow specifying which webform field holds the zendesk ticket ID
- * - Retrieve the ticket identified in the field using $client->tickets()->find($id); 
- * - Update ticket: https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket
- * - Update tag lists: https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#updating-tag-lists
- * - How do we determine which fields we need to update?
- *    - Need two fields: Ticket Fields and Ticket Custom Fields
- *    - Use the Ticket Custom Fields field in the handler config
- *    - Use Drupal placeholders to add values
- *    - Only what's listed here gets updated
- * - On load of the handler config form, retrieve the ticket object using the api
- *    - Make the ticket structure viewable in the UI (like the custom Field Reference accordion?)
- * 
- * - General tab, remove:
- *    - Subject - REMOVE
- *    - Ticket Body - Change to comment
- *    - Ticket CCs - REMOVE
- *    - Requester Name - REMOVE
- *    - Requester Email Address - REMOVE
- *    - Ticket Type - REMOVE, can be included in texy field list
- *    - Ticket Priority - REMOVE, can be included in texy field list
- *    - Ticket Assignee - REMOVE, can be included in texy field list
- * 
- * Fields from ticket object we might want to populate:
- *  type
- *  priority
- *  status
- *  group_id
- *  zendesk ticket id field
- *  ticket tags
- *  custom_fields
- *  comment - it looks like setting the comment property on ticket update json will add it to the thread
- *    https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/?_ga=2.3553525.417292175.1637041656-1860072951.1623776472#example-body-2
- *  tokens link
  * 
  * The handler also validates that the right ticket is being updated. Each ticket includes the original report webform UUID.
  * The UUID is passed into a hidden field in the resolution form when the company agent click the link in their notification email.
@@ -152,7 +117,7 @@ class ZendeskUpdateHandler extends WebformHandlerBase
       // Individual users shouldn't be stored in config, which has to be deployed,
       // in case there is an urgent change required. However, if tickets are to be
       // creatd as Solved, they need to have an individual assignee. Using the
-      // service account would be acceptable and necessar in this case.
+      // service account would be acceptable and necessary in this case.
       
       $client = new ZendeskClient();
 

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -55,7 +55,7 @@ use Drupal\portland_zendesk\Utils\Utility;
  *  type
  *  priority
  *  status
- *  assignee_id
+ *  group_id
  *  zendesk ticket id field
  *  ticket tags
  *  custom_fields
@@ -106,7 +106,7 @@ class ZendeskUpdateHandler extends WebformHandlerBase
           'tags' => '',
           'priority' => '',
           'status' => '',
-          'assignee_id' => '',
+          'group_id' => '',
           'type' => '',
           'collaborators' => '',
           'custom_fields' => '',
@@ -250,19 +250,19 @@ class ZendeskUpdateHandler extends WebformHandlerBase
       '#required' => false
     ];
 
-    // prep assignees field
+    // prep group field
     // if found group assignees from Zendesk, populate dropdown.
     // otherwise provide field to specify assignee ID
-    $form['assignee_id'] = [
-      '#title' => $this->t('Ticket Assignee'),
-      '#description' => $this->t('The id of the intended assignee'),
-      '#default_value' => $this->configuration['assignee_id'],
+    $form['group_id'] = [
+      '#title' => $this->t('Ticket Group'),
+      '#description' => $this->t('The id of the intended group'),
+      '#default_value' => $this->configuration['group_id'],
       '#required' => false
     ];
     if(!empty($assignees) ){
-      $form['assignee_id']['#type'] = 'select';
-      $form['assignee_id']['#options'] = ['' => 'Do not update'] + $assignees;
-      $form['assignee_id']['#description'] = $this->t('The email address the assignee');
+      $form['group_id']['#type'] = 'select';
+      $form['group_id']['#options'] = ['' => 'Do not update'] + $assignees;
+      $form['group_id']['#description'] = $this->t('The email address the assignee');
     }
 
     $form['collaborators'] = [

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -149,14 +149,12 @@ class ZendeskUpdateHandler extends WebformHandlerBase
       // initiate api client
       $client = new ZendeskClient();
 
-      // get list of all users who are either agents or admins
-      $response_agents = $client->users()->findAll([ 'role' => 'agent' ]);
-      $response_admins = $client->users()->findAll([ 'role' => 'admin' ]);
-      $users = array_merge( $response_agents->users, $response_admins->users );
+      // get list of all groups
+      $response = $client->groups()->findAll();
 
-      // store found agents
-      foreach($users as $user){
-        $assignees[ $user->id ] = $user->name;
+      // store found groups
+      foreach($response->groups as $group){
+          $assignees[ $group->id ] = $group->name;
       }
 
       // order agents by name
@@ -253,23 +251,18 @@ class ZendeskUpdateHandler extends WebformHandlerBase
     ];
 
     // prep assignees field
-    // if found assignees from Zendesk, populate dropdown.
+    // if found group assignees from Zendesk, populate dropdown.
     // otherwise provide field to specify assignee ID
     $form['assignee_id'] = [
       '#title' => $this->t('Ticket Assignee'),
-      '#description' => $this->t('Select an assignee for the updated ticket or enter an email address (must be a Zendesk user). Or select None to leave the ticket assigned to the current assignee.'),
+      '#description' => $this->t('The id of the intended assignee'),
       '#default_value' => $this->configuration['assignee_id'],
       '#required' => false
     ];
     if(!empty($assignees) ){
-      $form['assignee_id']['#type'] = 'webform_select_other';
-      $form['assignee_id']['#options'] = $assignees;
-    }
-    else {
-      $form['assignee_id']['#type'] = 'textfield';
-      $form['assignee_id']['#attribute'] = [
-          'type' => 'number'
-      ];
+      $form['assignee_id']['#type'] = 'select';
+      $form['assignee_id']['#options'] = ['' => 'Do not update'] + $assignees;
+      $form['assignee_id']['#description'] = $this->t('The email address the assignee');
     }
 
     $form['collaborators'] = [

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -100,18 +100,19 @@ class ZendeskUpdateHandler extends WebformHandlerBase
    */
   public function defaultConfiguration()
   {
-      return [
-          'comment' => '',
-          'comment_private' => false,
-          'tags' => '',
-          'priority' => '',
-          'status' => '',
-          'group_id' => '',
-          'type' => '',
-          'collaborators' => '',
-          'custom_fields' => '',
-          'ticket_id_field' => '',
-      ];
+    return [
+      'comment' => '',
+      'comment_private' => false,
+      'tags' => '',
+      'priority' => '',
+      'status' => '',
+      'group_id' => '',
+      'assignee_id' => '',
+      'type' => '',
+      'collaborators' => '',
+      'custom_fields' => '',
+      'ticket_id_field' => '',
+    ];
   }
 
   /**
@@ -143,18 +144,36 @@ class ZendeskUpdateHandler extends WebformHandlerBase
     ];
 
     $assignees = [];
+    $groups = [];
 
     try {
-      // get available assignees from zendesk
-      // initiate api client
+      // Get available groups and assignees from zendesk.
+      // NOTE: Typically we don't want to use individual users here, only groups.
+      // Individual users shouldn't be stored in config, which has to be deployed,
+      // in case there is an urgent change required. However, if tickets are to be
+      // creatd as Solved, they need to have an individual assignee. Using the
+      // service account would be acceptable and necessar in this case.
+      
       $client = new ZendeskClient();
 
       // get list of all groups
-      $response = $client->groups()->findAll();
-
+      $response_groups = $client->groups()->findAll();
       // store found groups
-      foreach($response->groups as $group){
-          $assignees[ $group->id ] = $group->name;
+      foreach($response_groups->groups as $group){
+        $groups[ $group->id ] = $group->name;
+      }
+      // order groups by name
+      asort($groups);
+
+      // get list of all admin and agent users to populate assignee field
+      // get list of all users who are either agents or admins
+      $response_agents = $client->users()->findAll([ 'role' => 'agent' ]);
+      $response_admins = $client->users()->findAll([ 'role' => 'admin' ]);
+      $users = array_merge( $response_agents->users, $response_admins->users );
+
+      // store found agents
+      foreach($users as $user){
+        $assignees[ $user->id ] = $user->name;
       }
 
       // order agents by name
@@ -180,7 +199,7 @@ class ZendeskUpdateHandler extends WebformHandlerBase
         $message = nl2br(htmlentities($e->getMessage()));
 
         // Log error message.
-        $this->getLogger()->error('Retrieval of assignees for @form webform Zendesk handler failed. @exception: @message. Click to edit @link.', [
+        $this->getLogger()->error('Retrieval of groups or assignees for @form webform Zendesk handler failed. @exception: @message. Click to edit @link.', [
             '@exception' => get_class($e),
             '@form' => $this->getWebform()->label(),
             '@message' => $message,
@@ -250,28 +269,48 @@ class ZendeskUpdateHandler extends WebformHandlerBase
       '#required' => false
     ];
 
-    // prep group field
-    // if found group assignees from Zendesk, populate dropdown.
-    // otherwise provide field to specify assignee ID
+    // prep groups field
+    // if found groups from Zendesk, populate dropdown.
     $form['group_id'] = [
       '#title' => $this->t('Ticket Group'),
       '#description' => $this->t('The id of the intended group'),
       '#default_value' => $this->configuration['group_id'],
       '#required' => false
     ];
-    if(!empty($assignees) ){
+    if(!empty($groups) ){
       $form['group_id']['#type'] = 'select';
-      $form['group_id']['#options'] = ['' => 'Do not update'] + $assignees;
-      $form['group_id']['#description'] = $this->t('The email address the assignee');
+      $form['group_id']['#options'] = ['' => '-- None --'] + $groups;
+      $form['group_id']['#description'] = $this->t('The group to which the ticket should be assigned. Set either Ticket Group or Ticket Assignee, but not both.');
+    }
+
+    // prep assignees field
+    // if found assignees from Zendesk, populate dropdown.
+    // otherwise provide field to specify assignee ID
+    $form['assignee_id'] = [
+      '#title' => $this->t('Ticket Assignee'),
+      '#description' => $this->t('The id of the intended assignee'),
+      '#default_value' => $this->configuration['assignee_id'],
+      '#required' => false
+    ];
+    if(! empty($assignees) ){
+      $form['assignee_id']['#type'] = 'webform_select_other';
+      $form['assignee_id']['#options'] = ['' => '-- None --'] + $assignees;
+      $form['assignee_id']['#description'] = $this->t('The assignee to which the ticket should be assigned. Set either Ticket Group or Ticket Assignee, but not both. Typically tickets created by webforms should not be assigned to individual users, but tickets that are created as Solved must have an individual assignee. In this case, use the Portland.gov Support service account.');
+    }
+    else {
+      $form['assignee_id']['#type'] = 'textfield';
+      $form['assignee_id']['#attribute'] = [
+        'type' => 'number'
+      ];
     }
 
     $form['collaborators'] = [
-    '#type' => 'textfield',
-    '#title' => $this->t('Ticket CCs'),
-    '#description' => $this->t('Users to add as cc\'s when creating a ticket.'),
-    '#default_value' => $this->configuration['collaborators'],
-    '#multiple' => true,
-    '#required' => false
+      '#type' => 'textfield',
+      '#title' => $this->t('Ticket CCs'),
+      '#description' => $this->t('Users to add as cc\'s when creating a ticket.'),
+      '#default_value' => $this->configuration['collaborators'],
+      '#multiple' => true,
+      '#required' => false
     ];
 
     $form['comment'] = [

--- a/web/sites/default/config/webform.webform.report_e_scooter.yml
+++ b/web/sites/default/config/webform.webform.report_e_scooter.yml
@@ -535,6 +535,7 @@ handlers:
       collaborators: ''
       custom_fields: "1900004448785: '[webform_submission:values:report_company:raw]'\r\n1500012743961: '[webform_submission:values:report_location:location_address]'\r\n1900004448725: '[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]'\r\n1500012801562: '[webform_submission:values:company_sla]'\r\n1500012801542: '[webform_submission:values:report_asset_id]'\r\n1500007391541: '[webform_submission:values:computed_contact_type]'\r\n1500013095781: '[webform_submission:uuid]'"
       ticket_id_field: report_ticket_id
+      group_id: '1500006561502'
   zendesk_create_ticket_riding_on_sidewalk:
     id: zendesk
     label: 'Create Zendesk Ticket - Riding on Sidewalk'
@@ -559,6 +560,7 @@ handlers:
       collaborators: ''
       custom_fields: "1900004448785: '[webform_submission:values:report_company:raw]'\r\n1500012743961: '[webform_submission:values:report_location:location_address]'\r\n1900004448725: '[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]'\r\n1500012801562: '[webform_submission:values:company_sla]'\r\n1500012801542: '[webform_submission:values:report_asset_id]'\r\n1500007391541: '[webform_submission:values:agent_contact_type]'\r\n1500013095781: '[webform_submission:uuid]'"
       ticket_id_field: report_ticket_id
+      group_id: ''
   email_notification_company:
     id: email
     label: 'Email notification to scooter company'

--- a/web/sites/default/config/webform.webform.report_e_scooter.yml
+++ b/web/sites/default/config/webform.webform.report_e_scooter.yml
@@ -571,6 +571,8 @@ handlers:
       enabled:
         ':input[name="report_issue[radios]"]':
           '!value': 'riding on sidewalk'
+        ':input[name="computed_recipient"]':
+          filled: true
     weight: 3
     settings:
       states:
@@ -611,6 +613,8 @@ handlers:
       enabled:
         ':input[name="report_issue[radios]"]':
           value: 'riding on sidewalk'
+        ':input[name="computed_recipient"]':
+          filled: true
     weight: 4
     settings:
       states:

--- a/web/sites/default/config/webform.webform.report_e_scooter.yml
+++ b/web/sites/default/config/webform.webform.report_e_scooter.yml
@@ -560,7 +560,7 @@ handlers:
       collaborators: ''
       custom_fields: "1900004448785: '[webform_submission:values:report_company:raw]'\r\n1500012743961: '[webform_submission:values:report_location:location_address]'\r\n1900004448725: '[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]'\r\n1500012801562: '[webform_submission:values:company_sla]'\r\n1500012801542: '[webform_submission:values:report_asset_id]'\r\n1500007391541: '[webform_submission:values:agent_contact_type]'\r\n1500013095781: '[webform_submission:uuid]'"
       ticket_id_field: report_ticket_id
-      group_id: ''
+      group_id: '1500006561502'
   email_notification_company:
     id: email
     label: 'Email notification to scooter company'

--- a/web/sites/default/config/webform.webform.report_e_scooter.yml
+++ b/web/sites/default/config/webform.webform.report_e_scooter.yml
@@ -554,7 +554,7 @@ handlers:
       comment: "<p>The following e-scooter issue was reported to the City of Portland. [webform_submission:values:computed_urgency_text]</p>\r\n\r\n<p><strong>What is the issue with the e-scooter?</strong> [webform_submission:values:report_issue]</p>\r\n\r\n<p><strong>E-scooter company:</strong> [webform_submission:values:report_company:raw]</p>\r\n\r\n<p><strong>Is the e-scooter blocking a sidewalk, trail, bike lane, driveway, street, transit stop or other type of transportation lane?</strong> [webform_submission:values:computed_blocking]</p>\r\n\r\n<p><strong>Is the e-scooter parked on private property?</strong> [webform_submission:values:computed_private_property]</p>\r\n\r\n<p><strong>E-scooter ID:</strong> [webform_submission:values:report_asset_id]</p>\r\n\r\n<p><strong>Location:</strong><br />\r\nAddress: <a href=\"https://www.google.com/maps/place/[webform_submission:values:report_location:location_address]\">[webform_submission:values:report_location:location_address]</a><br />\r\nLat/Lon: <a href=\"https://www.google.com/maps/place/[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]\">[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]</a><br />\r\nPlace name: [webform_submission:values:report_location:place_name]<br />\r\nAdditional details: [webform_submission:values:report_location:location_details]</p>\r\n\r\n<p>Suppress Ticket Confirmation: TRUE</p>\r\n\r\n[webform_submission:values:agent_summary]"
       tags: ''
       priority: normal
-      status: new
+      status: solved
       assignee_id: ''
       type: problem
       collaborators: ''

--- a/web/sites/default/config/webform.webform.report_e_scooter.yml
+++ b/web/sites/default/config/webform.webform.report_e_scooter.yml
@@ -555,12 +555,12 @@ handlers:
       tags: ''
       priority: normal
       status: solved
-      assignee_id: ''
+      assignee_id: '1505212728301'
       type: problem
       collaborators: ''
       custom_fields: "1900004448785: '[webform_submission:values:report_company:raw]'\r\n1500012743961: '[webform_submission:values:report_location:location_address]'\r\n1900004448725: '[webform_submission:values:report_location:location_lat],[webform_submission:values:report_location:location_lon]'\r\n1500012801562: '[webform_submission:values:company_sla]'\r\n1500012801542: '[webform_submission:values:report_asset_id]'\r\n1500007391541: '[webform_submission:values:agent_contact_type]'\r\n1500013095781: '[webform_submission:uuid]'"
       ticket_id_field: report_ticket_id
-      group_id: '1500006561502'
+      group_id: ''
   email_notification_company:
     id: email
     label: 'Email notification to scooter company'

--- a/web/sites/default/config/webform.webform.zendesk_api_test.yml
+++ b/web/sites/default/config/webform.webform.zendesk_api_test.yml
@@ -55,8 +55,7 @@ elements: |-
   ticket_id:
     '#type': textfield
     '#title': 'Ticket ID'
-    '#description': 'This field is non-editable and gets auto populated with the ID of the new Zendesk ticket.'
-    '#readonly': true
+    '#description': 'If left blank, a new Zenesk ticket is created, and this field gets auto populated with the ticket ID after submission. If you enter an existing Zendesk ticket ID, the update handler will be invoked to update the existing ticket, adding a private note and marking it as Solved.'
   suppress_ticket_confirmation:
     '#type': select
     '#title': 'Suppress Ticket Confirmation'
@@ -249,10 +248,13 @@ handlers:
   zendesk_new_ticket:
     id: zendesk
     label: 'Zendesk new ticket'
-    notes: ''
+    notes: 'Sends a form submission to Zendesk to create a support ticket. This handler must fire after any other validation handlers, and it should not be used for forms that allow users to update their original submission. Updating will create a new Zendesk ticket, which is most likely not the desired behavior. Enabled if no ticket ID is provided.'
     handler_id: zendesk_new_ticket
     status: true
-    conditions: {  }
+    conditions:
+      enabled:
+        ':input[name="ticket_id"]':
+          empty: true
     weight: 0
     settings:
       requester_name: contact_name
@@ -267,4 +269,27 @@ handlers:
       collaborators: ''
       custom_fields: ''
       ticket_id_field: '[webform_submission:values:ticket_id]'
+      group_id: '4549352062487'
+  zendesk_update_ticket:
+    id: zendesk_update_ticket
+    label: 'Zendesk update ticket'
+    notes: 'Updates an existing Zendesk support ticket. Enabled if a Zendesk ticket ID has been provided.'
+    handler_id: zendesk_update_ticket
+    status: true
+    conditions:
+      enabled:
+        ':input[name="ticket_id"]':
+          filled: true
+    weight: 0
+    settings:
+      comment: 'This ticket has been updated by the Zendesk Update Handler from the portland_zendesk module.'
+      comment_private: 1
+      tags: ''
+      priority: ''
+      status: solved
+      group_id: '4549352062487'
+      type: ''
+      collaborators: ''
+      custom_fields: ''
+      ticket_id_field: ticket_id
 variants: {  }

--- a/web/sites/default/config/webform.webform.zendesk_api_test.yml
+++ b/web/sites/default/config/webform.webform.zendesk_api_test.yml
@@ -200,48 +200,63 @@ settings:
 access:
   create:
     roles:
-      - anonymous
-      - authenticated
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   view_any:
-    roles: {  }
+    roles:
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   update_any:
-    roles: {  }
+    roles:
+      - administrator
     users: {  }
     permissions: {  }
   delete_any:
-    roles: {  }
+    roles:
+      - administrator
     users: {  }
     permissions: {  }
   purge_any:
-    roles: {  }
+    roles:
+      - administrator
     users: {  }
     permissions: {  }
   view_own:
-    roles: {  }
+    roles:
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   update_own:
-    roles: {  }
+    roles:
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   delete_own:
-    roles: {  }
+    roles:
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   administer:
-    roles: {  }
+    roles:
+      - administrator
     users: {  }
     permissions: {  }
   test:
-    roles: {  }
+    roles:
+      - support_agent
+      - administrator
     users: {  }
     permissions: {  }
   configuration:
-    roles: {  }
+    roles:
+      - administrator
     users: {  }
     permissions: {  }
 handlers:


### PR DESCRIPTION
* ZendeskHandler.php and ZendeskUpdateHandler.php were updated to support both a Ticket Group and Ticket Assignee field
* The E-scooter report webform was updated to set the group on creation
* E-scooter Riding on Sidewalk reports configured to create ticket as Solved and assign to service account user
* Logic added to e-scooter form config to disable sending vendor notifications if no computed address is present (in the case of user not knowing which company)
* Zendesk API Test webform updated to only allow access to Administrator and Support Agent roles
* API Test webform updated to support updating tickets if ticket ID is provided, allowing both API handlers (create and update) to be tested
* Updated views_bulk_operations module because it's unsupported and blocking builds