### PR TITLE
CSM-173 Update build script to also remove csm environments on merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,8 @@ build_and_deploy: &build_and_deploy
               JIRA_STORY_ID=${BASH_REMATCH[2]}
             # Squash and Merge on other feature branches
             # Example: POWR-3058 Delete all related multi-devs when a branch is merged
+            # Should also match for CSM prefix
+            # Example: CSM-3058 Delete all related multi-devs when a branch is merged
             elif [[ $lowercase_last_log =~ ^((powr|csm)-[0-9]+)[[:space:]]+.+$ ]]; then
               echo "Found story ID from squash and merge commit message: '${BASH_REMATCH[1]}'";
               JIRA_STORY_ID=${BASH_REMATCH[1]}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ build_and_deploy: &build_and_deploy
               JIRA_STORY_ID=${BASH_REMATCH[2]}
             # Squash and Merge on other feature branches
             # Example: POWR-3058 Delete all related multi-devs when a branch is merged
-            elif [[ $lowercase_last_log =~ ^(powr-[0-9]+)[[:space:]]+.+$ ]]; then
+            elif [[ $lowercase_last_log =~ ^((powr|csm)-[0-9]+)[[:space:]]+.+$ ]]; then
               echo "Found story ID from squash and merge commit message: '${BASH_REMATCH[1]}'";
               JIRA_STORY_ID=${BASH_REMATCH[1]}
             else


### PR DESCRIPTION
Once this is merged, we need to check whether the csm-173 multidev is deleted before closing the story.

Also, there is a csm-173a branch that needs to be merged, and verify that that multidev is also deleted.