### PR TITLE
CSM-186 Updates to support ParkScan replacement

### DIFF
--- a/web/sites/default/config/core.entity_form_display.node.park_facility.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.park_facility.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -55,7 +56,7 @@ third_party_settings:
       label: 'Social Media'
       region: content
       parent_name: ''
-      weight: 14
+      weight: 13
       format_type: details
       format_settings:
         classes: ''
@@ -74,7 +75,7 @@ third_party_settings:
       label: 'Map Information'
       region: content
       parent_name: ''
-      weight: 16
+      weight: 15
       format_type: details
       format_settings:
         classes: ''
@@ -92,7 +93,7 @@ third_party_settings:
       label: 'Administrative Fields (Site Admins Only)'
       region: content
       parent_name: ''
-      weight: 24
+      weight: 23
       format_type: details_sidebar
       format_settings:
         classes: 'border border-danger'
@@ -107,7 +108,7 @@ third_party_settings:
       label: 'Paths and Redirects'
       region: content
       parent_name: ''
-      weight: 21
+      weight: 20
       format_type: details
       format_settings:
         classes: ''
@@ -123,7 +124,7 @@ third_party_settings:
       label: 'Location Status (not implemented yet)'
       region: content
       parent_name: ''
-      weight: 9
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -138,7 +139,7 @@ third_party_settings:
       label: 'Accessibility Notes'
       region: content
       parent_name: ''
-      weight: 13
+      weight: 12
       format_type: details
       format_settings:
         classes: ''
@@ -153,7 +154,7 @@ third_party_settings:
       label: History
       region: content
       parent_name: ''
-      weight: 15
+      weight: 14
       format_type: details
       format_settings:
         classes: ''
@@ -167,7 +168,7 @@ third_party_settings:
       label: 'Open Hours'
       region: content
       parent_name: ''
-      weight: 11
+      weight: 9
       format_type: details
       format_settings:
         classes: ''
@@ -179,10 +180,11 @@ third_party_settings:
     group_contacts:
       children:
         - field_contact
+        - field_contact_email
       label: Contacts
       region: content
       parent_name: ''
-      weight: 12
+      weight: 10
       format_type: details
       format_settings:
         classes: ''
@@ -198,7 +200,7 @@ third_party_settings:
       label: 'Location and Located Within'
       region: content
       parent_name: ''
-      weight: 8
+      weight: 6
       format_type: details
       format_settings:
         classes: ''
@@ -214,7 +216,7 @@ third_party_settings:
       label: Neighborhood
       region: content
       parent_name: ''
-      weight: 10
+      weight: 8
       format_type: details
       format_settings:
         classes: ''
@@ -229,7 +231,7 @@ third_party_settings:
       label: Amenities
       region: content
       parent_name: ''
-      weight: 17
+      weight: 16
       format_type: details
       format_settings:
         classes: ''
@@ -244,7 +246,7 @@ third_party_settings:
       label: Documents
       region: content
       parent_name: ''
-      weight: 18
+      weight: 17
       format_type: details
       format_settings:
         classes: ''
@@ -259,7 +261,7 @@ third_party_settings:
       label: Popularity
       region: content
       parent_name: ''
-      weight: 20
+      weight: 19
       format_type: details
       format_settings:
         classes: ''
@@ -274,7 +276,7 @@ third_party_settings:
       label: 'Reservations Available'
       region: content
       parent_name: ''
-      weight: 19
+      weight: 18
       format_type: details
       format_settings:
         classes: ''
@@ -350,6 +352,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_contact_email:
+    type: string_textfield
+    weight: 26
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_documents:
     type: entity_reference_autocomplete
     weight: 18
@@ -370,7 +380,7 @@ content:
     third_party_settings: {  }
   field_featured_media:
     type: entity_browser_entity_reference
-    weight: 6
+    weight: 4
     region: content
     settings:
       entity_browser: featured_image
@@ -417,7 +427,7 @@ content:
         maxlength_js_truncate_html: false
   field_images:
     type: entity_browser_entity_reference
-    weight: 7
+    weight: 5
     region: content
     settings:
       entity_browser: featured_image
@@ -511,7 +521,7 @@ content:
     third_party_settings: {  }
   field_portlandmaps_id:
     type: string_textfield
-    weight: 16
+    weight: 17
     region: content
     settings:
       size: 60
@@ -551,7 +561,7 @@ content:
     third_party_settings: {  }
   field_reviewer:
     type: entity_reference_autocomplete
-    weight: 22
+    weight: 21
     region: content
     settings:
       match_operator: CONTAINS
@@ -604,7 +614,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 23
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/web/sites/default/config/core.entity_view_display.node.park_facility.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.park_facility.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -324,6 +325,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_contact_email: true
   field_pog_property_id: true
   field_popular_weight: true
   field_portlandmaps_id: true

--- a/web/sites/default/config/core.entity_view_display.node.park_facility.featured.yml
+++ b/web/sites/default/config/core.entity_view_display.node.park_facility.featured.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -93,6 +94,7 @@ hidden:
   field_body_content: true
   field_city_section: true
   field_contact: true
+  field_contact_email: true
   field_documents: true
   field_facebook: true
   field_featured_media: true

--- a/web/sites/default/config/core.entity_view_display.node.park_facility.related.yml
+++ b/web/sites/default/config/core.entity_view_display.node.park_facility.related.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -87,6 +88,7 @@ hidden:
   field_body_content: true
   field_city_section: true
   field_contact: true
+  field_contact_email: true
   field_documents: true
   field_facebook: true
   field_featured_media: true

--- a/web/sites/default/config/core.entity_view_display.node.park_facility.search_result.yml
+++ b/web/sites/default/config/core.entity_view_display.node.park_facility.search_result.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -111,6 +112,7 @@ hidden:
   field_body_content: true
   field_city_section: true
   field_contact: true
+  field_contact_email: true
   field_documents: true
   field_facebook: true
   field_history: true

--- a/web/sites/default/config/core.entity_view_display.node.park_facility.teaser.yml
+++ b/web/sites/default/config/core.entity_view_display.node.park_facility.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.park_facility.field_body_content
     - field.field.node.park_facility.field_city_section
     - field.field.node.park_facility.field_contact
+    - field.field.node.park_facility.field_contact_email
     - field.field.node.park_facility.field_documents
     - field.field.node.park_facility.field_facebook
     - field.field.node.park_facility.field_featured_media
@@ -111,6 +112,7 @@ hidden:
   field_body_content: true
   field_city_section: true
   field_contact: true
+  field_contact_email: true
   field_documents: true
   field_facebook: true
   field_history: true

--- a/web/sites/default/config/field.field.node.park_facility.field_contact_email.yml
+++ b/web/sites/default/config/field.field.node.park_facility.field_contact_email.yml
@@ -1,0 +1,28 @@
+uuid: 374aaa14-a4e6-40c1-8f48-7abef980b1d6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_contact_email
+    - node.type.park_facility
+  module:
+    - custom_add_another
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+  custom_add_another:
+    custom_add_another: ''
+    custom_remove: ''
+id: node.park_facility.field_contact_email
+field_name: field_contact_email
+entity_type: node
+bundle: park_facility
+label: 'Contact Email'
+description: 'This is the internal email address used to report issues at the park. It''s never displayed on the website and only used for routing support tickets.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/web/sites/default/config/field.storage.node.field_contact_email.yml
+++ b/web/sites/default/config/field.storage.node.field_contact_email.yml
@@ -1,0 +1,25 @@
+uuid: 66484c0a-86ca-4f29-b513-bfa15c6bd1a6
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_contact_email
+field_name: field_contact_email
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/sites/default/config/search_api.index.full_index.yml
+++ b/web/sites/default/config/search_api.index.full_index.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.storage.group.field_topics
     - field.storage.node.field_solicitation_date
     - field.storage.node.field_construction_estimate
+    - field.storage.node.field_contact_email
     - field.storage.node.field_community_actions
     - field.storage.node.field_body_content
     - field.storage.node.field_city_section
@@ -250,6 +251,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_construction_type
+  field_contact_email:
+    label: 'Contact Email'
+    datasource_id: 'entity:node'
+    property_path: field_contact_email
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_contact_email
   field_contract_scope:
     label: 'Contract Scope'
     datasource_id: 'entity:node'

--- a/web/sites/default/config/views.view.park_finder.yml
+++ b/web/sites/default/config/views.view.park_finder.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_city_section
+    - field.storage.node.field_contact_email
     - field.storage.node.field_geolocation
     - field.storage.node.field_park_location_type
     - field.storage.node.field_size_in_acres
@@ -1636,6 +1637,77 @@ display:
             use_highlighting: false
             multi_type: separator
             multi_separator: ', '
+        field_contact_email:
+          id: field_contact_email
+          table: search_api_datasource_full_index_entity_node
+          field: field_contact_email
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: false
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
       arguments:
         content_id:
           id: content_id
@@ -1705,5 +1777,6 @@ display:
         - url
         - 'user.node_grants:view'
       tags:
+        - 'config:field.storage.node.field_contact_email'
         - 'config:field.storage.node.field_geolocation'
         - 'config:search_api.index.full_index'

--- a/web/sites/default/config/webform.webform.report_a_park_issue.yml
+++ b/web/sites/default/config/webform.webform.report_a_park_issue.yml
@@ -1,0 +1,204 @@
+uuid: 19963773-2f48-4bf6-8145-955cd9244e7d
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 60
+template: false
+archive: false
+id: report_a_park_issue
+title: 'Report a Park Issue'
+description: ''
+category: Report
+elements: |-
+  report_location:
+    '#type': portland_location_picker
+    '#title': Location
+    '#location_type__access': false
+    '#waterway_instructions__access': false
+    '#location_private_owner__access': false
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }


### PR DESCRIPTION
* Associating a contact email address with each park that can be consumed by the location widget for routing purposes