### PR TITLE
CS-383 bug fix to prevent test tickets from appearing on the graffiti map

### DIFF
--- a/web/sites/default/config/views.view.zendesk_tickets.yml
+++ b/web/sites/default/config/views.view.zendesk_tickets.yml
@@ -608,7 +608,7 @@ display:
       query:
         type: views_query
         options:
-          ticket_query: 'type:ticket status:open status:solved custom_field_6807910266391:Yes custom_field_6353388345367:report_graffiti'
+          ticket_query: 'type:ticket status:open status:solved custom_field_6807910266391:Yes custom_field_6353388345367:report_graffiti -group:4549352062487'
       relationships: {  }
       header: {  }
       footer: {  }


### PR DESCRIPTION
Very small change; added a Zendesk API query parameter to exclude graffiti tickets from the Developer Test Group in the view that feeds the graffiti map.