### PR TITLE
PGOV-1012 Fix FPDR pension calculator

### DIFF
--- a/web/libraries_js/fpdr/pensionCalc.js
+++ b/web/libraries_js/fpdr/pensionCalc.js
@@ -102,16 +102,14 @@
                     $('#edit-hired-before--wrapper').hide();
             };
 
-            $(window).once().on('load', function () {
-                // Initialize hiredBefore field and add change listeners
-                showHideHiredBefore();
-                $('#edit-hire-date-month,#edit-hire-date-year').change(showHideHiredBefore);
+            // Initialize hiredBefore field and add change listeners
+            showHideHiredBefore();
+            $('#edit-hire-date-month,#edit-hire-date-year').change(showHideHiredBefore);
 
-                $('#edit-calculated-pension-results').hide();
+            $('#edit-calculated-pension-results').hide();
 
-                // Link calculatePension() to button click
-                $('#edit-actions-submit').click(calculatePension);
-            });
+            // Link calculatePension() to button click
+            $('#edit-actions-submit').click(calculatePension);
         }
     };
 })(jQuery, Drupal);


### PR DESCRIPTION
once is unnecessary here because the script is loaded from an import_js function within the webform, so the HTML will always be loaded by that point.