### PR TITLE
SIT-959 bug fix for Cable Complaints resolution form

### DIFF
--- a/web/sites/default/config/webform.webform.cable_complaint_resolution.yml
+++ b/web/sites/default/config/webform.webform.cable_complaint_resolution.yml
@@ -330,7 +330,7 @@ handlers:
     weight: -49
     settings:
       comment: "The issue has been reported resolved by the cable company representative [webform_submission:values:company_representative].<br><br>\r\nResolution: [webform_submission:values:computed_resolution]"
-      comment_private: 0
+      comment_private: 1
       tags: ''
       priority: ''
       status: solved

--- a/web/sites/default/config/webform.webform.report_cable_complaint.yml
+++ b/web/sites/default/config/webform.webform.report_cable_complaint.yml
@@ -109,7 +109,7 @@ elements: |-
     '#title': 'Resolution URL'
     '#display_on': none
     '#mode': text
-    '#template': "{{ webform_token('[site:url-brief]', webform_submission, [], options) }}/form/cable-complaint-resolution?report_service_provider={{ data.report_service_provider }}&report_account_number={{ data.report_account_number }}&report_issue_type={{ data.report_issue_type }}&contact_zip_code={{ data.contact_zip_code }}&contact_name={{ data.contact_name }}&contact_email={{ data.contact_email }}&contact_phone={{ data.contact_phone }}&report_issue_description={{ data.report_issue_description }}"
+    '#template': "{{ webform_token('[site:url-brief]', webform_submission, [], options) }}/form/cable-complaint-resolution?report_service_provider={{ data.report_service_provider|url_encode }}&report_account_number={{ data.report_account_number|url_encode }}&report_issue_type={{ data.report_issue_type|url_encode }}&contact_zip_code={{ data.contact_zip_code|url_encode }}&contact_name={{ data.contact_name|url_encode }}&contact_email={{ data.contact_email|url_encode }}&contact_phone={{ data.contact_phone|url_encode }}&report_issue_description={{ data.report_issue_description|url_encode }}"
     '#whitespace': trim
     '#store': true
     '#ajax': true

--- a/web/sites/default/config/webform.webform.report_cable_complaint.yml
+++ b/web/sites/default/config/webform.webform.report_cable_complaint.yml
@@ -118,14 +118,7 @@ elements: |-
     '#title': 'Computed Recipient'
     '#display_on': none
     '#mode': text
-    '#template': |-
-      {% if data.report_service_provider == "Xfinity (Comcast)" %}
-      sheri_acker@comcast.com,executive_customerrelations@comcast.com
-      {% elseif data.report_service_provider == "Ziply (Frontier)" %}
-      jessica.epley@ziply.com,complaints.northwest@ziplyfiber.com
-      {% elseif data.report_service_provider == "CenturyLink" %}
-      jared.wiener@lumen.com,uswpuc@centurylink.com
-      {% endif %}
+    '#template': 'gregory.clapp@portlandoregon.gov,gregoryscottclapp@gmail.com'
     '#whitespace': trim
     '#store': true
     '#ajax': true
@@ -500,7 +493,7 @@ handlers:
     conditions: {  }
     weight: 0
     settings:
-      comment: 'Resolution URL: <a href="https://[webform_submission:values:resolution_url]&amp;report_ticket_id=[webform_submission:values:report_ticket_id]&amp;original_submission_key=[webform_submission:uuid]">https://[webform_submission:values:resolution_url]&amp;report_ticket_id=[webform_submission:values:report_ticket_id]&amp;original_submission_key=[webform_submission:uuid]</a>'
+      comment: 'Resolution URL: <a href="https://[webform_submission:values:resolution_url]&report_ticket_id=[webform_submission:values:report_ticket_id]&original_submission_key=[webform_submission:uuid]">https://[webform_submission:values:resolution_url]&report_ticket_id=[webform_submission:values:report_ticket_id]&original_submission_key=[webform_submission:uuid]</a>'
       comment_private: 1
       tags: ''
       priority: ''
@@ -509,7 +502,7 @@ handlers:
       assignee_id: ''
       type: ''
       collaborators: ''
-      custom_fields: "6355783758871: 'https://[webform_submission:values:resolution_url]&amp;report_ticket_id=[webform_submission:values:report_ticket_id]&amp;original_submission_key=[webform_submission:uuid]'"
+      custom_fields: "6355783758871: 'https://[webform_submission:values:resolution_url]&report_ticket_id=[webform_submission:values:report_ticket_id]&original_submission_key=[webform_submission:uuid]'"
       ticket_id_field: report_ticket_id
       ticket_form_id: '16814795517079'
 variants: {  }

--- a/web/sites/default/config/webform.webform.report_cable_complaint.yml
+++ b/web/sites/default/config/webform.webform.report_cable_complaint.yml
@@ -109,7 +109,7 @@ elements: |-
     '#title': 'Resolution URL'
     '#display_on': none
     '#mode': text
-    '#template': "{{ webform_token('[site:url-brief]', webform_submission, [], options) }}/form/cable-complaint-resolution?report_service_provider={{ data.report_service_provider }}&report_account_number={{ data.report_account_number }}&report_issue_type={{ data.report_issue_type }}&contact_zip_code={{ data.contact_zip_code }}&report_issue_description={{ data.report_issue_description }}&contact_name={{ data.contact_name }}&contact_email={{ data.contact_email }}&contact_phone={{ data.contact_phone }}"
+    '#template': "{{ webform_token('[site:url-brief]', webform_submission, [], options) }}/form/cable-complaint-resolution?report_service_provider={{ data.report_service_provider }}&report_account_number={{ data.report_account_number }}&report_issue_type={{ data.report_issue_type }}&contact_zip_code={{ data.contact_zip_code }}&contact_name={{ data.contact_name }}&contact_email={{ data.contact_email }}&contact_phone={{ data.contact_phone }}&report_issue_description={{ data.report_issue_description }}"
     '#whitespace': trim
     '#store': true
     '#ajax': true
@@ -118,7 +118,14 @@ elements: |-
     '#title': 'Computed Recipient'
     '#display_on': none
     '#mode': text
-    '#template': 'gregory.clapp@portlandoregon.gov,gregoryscottclapp@gmail.com'
+    '#template': |-
+      {% if data.report_service_provider == "Xfinity (Comcast)" %}
+      sheri_acker@comcast.com,executive_customerrelations@comcast.com
+      {% elseif data.report_service_provider == "Ziply (Frontier)" %}
+      jessica.epley@ziply.com,complaints.northwest@ziplyfiber.com
+      {% elseif data.report_service_provider == "CenturyLink" %}
+      jared.wiener@lumen.com,uswpuc@centurylink.com
+      {% endif %}
     '#whitespace': trim
     '#store': true
     '#ajax': true

--- a/web/sites/default/config/webform.webform.report_parks_issue.yml
+++ b/web/sites/default/config/webform.webform.report_parks_issue.yml
@@ -1217,7 +1217,10 @@ handlers:
     label: 'TEST: Zendesk new Rangers request - NORMAL priority'
     notes: ''
     status: true
-    conditions: {  }
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          checked: true
     weight: -47
     settings:
       requester_name: contact_name


### PR DESCRIPTION
* Add url_encode filter to all element values being used in the Resolution URL
* Make resolution comment on ticket a private note
* UNRELATED: Add missing conditional logic to prevent Park Safety reports from going into Developer Test Group when test submission box is not checked