### PR TITLE
SIT-977 Update park maintenance form to identify park zone region name

### DIFF
--- a/web/modules/custom/portland/modules/portland_location_picker/README.md
+++ b/web/modules/custom/portland/modules/portland_location_picker/README.md
@@ -148,6 +148,8 @@ These properties are set in the Advanced tab of the Location Picker element. Dat
 
 - ***location_types*** - NOT IMPLEMENTED. Configurable to contain a list of location type codes that are used by the parent form. Can be used to inform widget functionaltiy. For example, if only "park" is included, only parks-specific functionality is enabled.
 
+- ***region_id_property_name*** - The property name of the feature property that holds the region value we want to capture. Assumes the value is located at features[x].properties[y][regionIdPropertyName]. Defaults to 'region_id.'
+
 ### Example of custom properties
 
 This is the advanced properties configuration used in the Report a Problem with a Public Trash Can reporting form. The first six properties are used to manipulate how the widget and its subelements are rendered. The remaining properties are from the list above and are used to configure the geoJSON layers and how the user interacts with them.

--- a/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
+++ b/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
@@ -120,6 +120,7 @@
         var requireCityLimits = drupalSettings.webform && drupalSettings.webform.portland_location_picker.require_city_limits === true ? true : false;
         var requireCityLimitsPlusParks = drupalSettings.webform && drupalSettings.webform.portland_location_picker.require_city_limits_plus_parks === true ? true : false;
         var disablePlaceNameAutofill = drupalSettings.webform && drupalSettings.webform.portland_location_picker.disable_place_name_autofill === true ? true : false;
+        var regionIdPropertyName = drupalSettings.webform && drupalSettings.webform.portland_location_picker.region_id_property_name ? drupalSettings.webform.portland_location_picker.region_id_property_name : "region_id";
 
         var boundaryUrl = drupalSettings.webform ? drupalSettings.webform.portland_location_picker.boundary_url : "";
         var displayBoundary = drupalSettings.webform && drupalSettings.webform.portland_location_picker.display_boundary === false ? false : true;
@@ -868,7 +869,7 @@
           var inLayer = leafletPip.pointInLayer(latlng, testLayer, false);
           if (inLayer.length > 0) {
             // NOTE: The following code would be problematic if we allow multiple copies of the widget or alternate naming conventions.
-            $('input[name=' + elementId + '\\[location_region_id\\]]').val(inLayer[0].feature.properties.region_id);
+            $('input[name=' + elementId + '\\[location_region_id\\]]').val(inLayer[0].feature.properties[regionIdPropertyName]);
           } else {
             // clear region_id field
             $('input[name=' + elementId + '\\[location_region_id\\]]').val("");

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -158,6 +158,7 @@ class PortlandLocationPicker extends WebformCompositeBase {
     $requireCityLimitsPlusParks = array_key_exists('#require_city_limits_plus_parks', $element) ? $element['#require_city_limits_plus_parks'] : FALSE;
     $locationTypes = array_key_exists('#location_types', $element) ? $element['#location_types'] : 'park,row,stream,street,taxlot,trail,waterbody';
     $disablePlaceNameAutofill = array_key_exists('#disable_place_name_autofill', $element) ? $element['#disable_place_name_autofill'] : FALSE;
+    $regionIdPropertyName = array_key_exists('#region_id_property_name', $element) ? $element['#region_id_property_name'] : 'region_id';
     
     $boundaryUrl = array_key_exists('#boundary_url', $element) ? $element['#boundary_url'] : 'https://www.portlandmaps.com/arcgis/rest/services/Public/Boundaries/MapServer/0/query?where=1%3D1&objectIds=35&outFields=*&returnGeometry=true&f=geojson';
     $displayBoundary = array_key_exists('#display_boundary', $element) ? $element['#display_boundary'] : TRUE;
@@ -183,6 +184,8 @@ class PortlandLocationPicker extends WebformCompositeBase {
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['require_city_limits_plus_parks'] = $requireCityLimitsPlusParks;
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['location_types'] = $locationTypes;
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['disable_place_name_autofill'] = $disablePlaceNameAutofill;
+    $element['#attached']['drupalSettings']['webform']['portland_location_picker']['region_id_property_name'] = $regionIdPropertyName;
+
 
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['boundary_url'] = $boundaryUrl;
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['display_boundary'] = $displayBoundary;

--- a/web/sites/default/config/webform.webform.report_park_maintenance_issue.yml
+++ b/web/sites/default/config/webform.webform.report_park_maintenance_issue.yml
@@ -146,7 +146,6 @@ elements: |-
       '#place_name__description_display': invisible
       '#require_boundary': false
       '#display_boundary': false
-      '#feature_layer_visible_zoom': 12
       '#primary_layer_behavior': informational
       '#primary_layer_type': region-hidden
       '#primary_layer_source': 'https://www.portlandmaps.com/arcgis/rest/services/Public/Parks_Administrative_Boundaries/MapServer/1/query?where=1%3D1&f=geojson'

--- a/web/sites/default/config/webform.webform.report_park_maintenance_issue.yml
+++ b/web/sites/default/config/webform.webform.report_park_maintenance_issue.yml
@@ -146,6 +146,11 @@ elements: |-
       '#place_name__description_display': invisible
       '#require_boundary': false
       '#display_boundary': false
+      '#feature_layer_visible_zoom': 12
+      '#primary_layer_behavior': informational
+      '#primary_layer_type': region-hidden
+      '#primary_layer_source': 'https://www.portlandmaps.com/arcgis/rest/services/Public/Parks_Administrative_Boundaries/MapServer/1/query?where=1%3D1&f=geojson'
+      '#region_id_property_name': Name
     report_location_notes:
       '#type': textfield
       '#title': 'Location Notes'


### PR DESCRIPTION
* Configure form to use new regions GeoJSON layer and capture region ID
* Refactor location widget to allow webform editors to specify the name of the property that contains the region value we want to capture (defaults to 'region_id')