### PR TITLE
SIT-1034 ROW Obstruction updates

### DIFF
--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -388,10 +388,6 @@ elements: |-
       markup_public_records_statement:
         '#type': webform_markup
         '#markup': '<p>Information you provide to the City is a public record and may be subject to release under Oregon’s <a data-renderer-mark="true" href="https://www.doj.state.or.us/oregon-department-of-justice/public-records/attorney-generals-public-records-and-meetings-manual/i-public-records/#:~:text=Under%20Oregon''s%20Public%20Records%20Law,committee%20of%20the%20Legislative%20Assembly" title="https://www.doj.state.or.us/oregon-department-of-justice/public-records/attorney-generals-public-records-and-meetings-manual/i-public-records/#:~:text=Under%20Oregon''s%20Public%20Records%20Law,committee%20of%20the%20Legislative%20Assembly">Public Records Law</a>. This law classifies certain information as available to the public on request. See our <a data-renderer-mark="true" href="/help/about/privacy" title="https://www.portland.gov/help/about/privacy">privacy statement</a> for more information.</p>'
-    actions:
-      '#type': webform_actions
-      '#title': 'Submit button(s)'
-      '#submit__label': Submit
     support_agent_use_only:
       '#type': portland_support_agent_widget
       '#title': 'Support Agent Use Only'
@@ -400,7 +396,7 @@ elements: |-
       '#escalate_issue__access': false
     computed_email_recipient:
       '#type': webform_computed_twig
-      '#title': computed_email_recipient
+      '#title': 'Computed Email Recipient'
       '#display_on': none
       '#mode': text
       '#template': |-
@@ -423,6 +419,39 @@ elements: |-
         {% endif %}
       '#whitespace': trim
       '#ajax': true
+    computed_email_recipient_authenticated:
+      '#type': webform_computed_twig
+      '#title': 'Computed Email Recipient (authenticated)'
+      '#title_display': none
+      '#admin_notes': "<p>This is a duplicate of the Computed Email Recipient used in email routing except that it's visible to authenticated users. It must always contain exactly the same code and logic as the original.</p>"
+      '#access_create_roles':
+        - authenticated
+      '#display_on': form
+      '#mode': html
+      '#template': |-
+        <strong>Email routing:</strong> {% if data.report_construction_work_zone_item == "Cuts in the roadway surface" %}
+          pbotutilityinspectors@portlandoregon.gov
+        {% elseif data.report_permanent_structure == "Outdoor seating, tables, dining structures" %}
+          OutdoorDiningPDX@portlandoregon.gov
+        {% elseif data.report_temporary_item == "Garbage/recycling bins" %}
+          wasteinfo@portlandoregon.gov
+        {% elseif data.report_outdoor_dining_item == "Outdoor seating, tables, dining structure" %}
+          OutdoorDiningPDX@portlandoregon.gov
+        {% elseif data.report_tree_issue == "A tree or vegetation that is blocking view of a traffic signal, traffic or street sign" %}
+          tom.jensen@portlandoregon.gov
+        {% elseif data.report_tree_issue == "Vegetation blocking a streetlight" %}
+          streetlighting@portlandoregon.gov
+        {% elseif data.report_vegetation_source == "Other publicly owned land" %}
+          pdxroads@portlandoregon.gov
+        {% elseif data.report_signage_type == "Unauthorized No Parking signs or obstructions to prevent parking" %}
+          PBOTparkingcontrol@portlandoregon.gov
+        {% endif %}
+      '#whitespace': trim
+      '#ajax': true
+    actions:
+      '#type': webform_actions
+      '#title': 'Submit button(s)'
+      '#submit__label': Submit
   report_ticket_id:
     '#type': hidden
     '#title': 'Report Ticket Id'

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -67,7 +67,7 @@ elements: |-
         'Temporary item': 'Temporary item -- Mulch piles, basketball hoops, sports items, electrical cords, trash cans, etc.'
         'Outdoor dining': 'Outdoor dining -- Outdoor seating, tables, sandwich boards, dining structure, etc.'
         'Trees or vegetation': 'Trees or vegetation'
-        'Unauthorized signage in the right of way': 'Unauthorized signage in the right-of-way'
+        'Unauthorized signage in the right-of-way': 'Unauthorized signage in the right-of-way'
       '#required': true
     computed_tags:
       '#type': webform_computed_twig
@@ -177,7 +177,7 @@ elements: |-
       '#title': 'Where is the tree or vegetation growing from?'
       '#options':
         'Private property': 'Private property'
-        'Parking strip, median, or other parts of the street or right of way': 'Parking strip, median, or other parts of the street or right-of-way'
+        'Parking strip, median, or other parts of the street or right-of-way': 'Parking strip, median, or other parts of the street or right-of-way'
         'Park or natural area': 'Park or natural area'
         'Something else, or unsure': 'Something else, or unsure -- Please describe in the Obstruction Details box below'
       '#other__option_label': 'Unsure or something else...'
@@ -200,7 +200,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="report_issue_type"]':
-            value: 'Unauthorized signage in the right of way'
+            value: 'Unauthorized signage in the right-of-way'
       '#required': true
     markup_vehicle:
       '#type': webform_markup
@@ -332,7 +332,7 @@ elements: |-
             value: 'Vegetation blocking a streetlight'
         - or
         - ':input[name="report_vegetation_source"]':
-            value: 'Parking strip, median, or other parts of the street or right of way'
+            value: 'Parking strip, median, or other parts of the street or right-of-way'
         - or
         - ':input[name="report_vegetation_source"]':
             value: 'Park or natural area'

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -16,7 +16,7 @@ uid: 60
 template: false
 archive: false
 id: report_row_obstruction
-title: 'Report an Obstruction on a Street, Sidewalk, or Other Right of Way'
+title: 'Report an Obstruction on a Street, Sidewalk, or Other Right-of-Way'
 description: ''
 categories:
   - Report
@@ -67,7 +67,7 @@ elements: |-
         'Temporary item': 'Temporary item -- Mulch piles, basketball hoops, sports items, electrical cords, trash cans, etc.'
         'Outdoor dining': 'Outdoor dining -- Outdoor seating, tables, sandwich boards, dining structure, etc.'
         'Trees or vegetation': 'Trees or vegetation'
-        'Unauthorized signage in the right of way': 'Unauthorized signage in the right of way'
+        'Unauthorized signage in the right of way': 'Unauthorized signage in the right-of-way'
       '#required': true
     computed_tags:
       '#type': webform_computed_twig
@@ -177,7 +177,7 @@ elements: |-
       '#title': 'Where is the tree or vegetation growing from?'
       '#options':
         'Private property': 'Private property'
-        'Parking strip, median, or other parts of the street or right of way': 'Parking strip, median, or other parts of the street or right of way'
+        'Parking strip, median, or other parts of the street or right of way': 'Parking strip, median, or other parts of the street or right-of-way'
         'Park or natural area': 'Park or natural area'
         'Something else, or unsure': 'Something else, or unsure -- Please describe in the Obstruction Details box below'
       '#other__option_label': 'Unsure or something else...'
@@ -351,7 +351,7 @@ elements: |-
         '#place_name__access': false
         '#location_details__access': false
         '#location_details__title': 'Obstruction Details'
-        '#location_details__help': 'Please tell us as much as you can about how this obstruction is impacting the right of way.'
+        '#location_details__help': 'Please tell us as much as you can about how this obstruction is impacting the right-of-way.'
         '#location_type__access': false
         '#location_private_owner__access': false
       report_photo:
@@ -461,7 +461,7 @@ elements: |-
     '#display_on': none
     '#mode': html
     '#template': |
-      <p><strong>Obstruction in the Right of Way</strong></p>
+      <p><strong>Obstruction in the Right-of-Way</strong></p>
 
       <p>{% if data.report_issue_type and data.report_issue_type is not iterable %}
         {{ data.report_issue_type }} &#151;
@@ -742,7 +742,7 @@ handlers:
     settings:
       requester_name: contact_name
       requester_email: contact_email
-      subject: 'Obstruction in the right of way: [webform_submission:values:report_issue_type]'
+      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
       tags: 'drupal webform [webform_submission:values:computed_tags]'
       priority: normal
@@ -785,7 +785,7 @@ handlers:
       return_path: ''
       sender_mail: ''
       sender_name: ''
-      subject: 'Obstruction in the right of way: [webform_submission:values:report_issue_type]'
+      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       body: "<p><em>This email was sent by Portland.gov. Do no reply.</em></p>\r\n\r\n<p>[webform_submission:values:computed_description:html]</p>"
       excluded_elements: {  }
       ignore_access: false
@@ -814,7 +814,7 @@ handlers:
     settings:
       requester_name: contact_name
       requester_email: contact_email
-      subject: 'TEST: Obstruction in the right of way: [webform_submission:values:report_issue_type]'
+      subject: 'TEST: Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
       tags: 'drupal webform [webform_submission:values:computed_tags]'
       priority: normal
@@ -846,7 +846,7 @@ handlers:
     settings:
       requester_name: contact_name
       requester_email: contact_email
-      subject: 'Obstruction in the right of way: [webform_submission:values:report_issue_type]'
+      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
       tags: 'drupal webform [webform_submission:values:computed_tags]'
       priority: normal
@@ -889,7 +889,7 @@ handlers:
       return_path: ''
       sender_mail: ''
       sender_name: ''
-      subject: 'TEST: Obstruction in the right of way: [webform_submission:values:report_issue_type]'
+      subject: 'TEST: Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       body: "<p><strong>This is a test. This email would normally have been sent to&nbsp;[webform_submission:values:computed_email_recipient:html].</strong></p>\r\n\r\n<p>[webform_submission:values:computed_description:html]</p>"
       excluded_elements: {  }
       ignore_access: false

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -396,40 +396,15 @@ elements: |-
       '#escalate_issue__access': false
     computed_email_recipient:
       '#type': webform_computed_twig
-      '#title': 'Computed Email Recipient'
-      '#display_on': none
-      '#mode': text
-      '#template': |-
-        {% if data.report_construction_work_zone_item == "Cuts in the roadway surface" %}
-          pbotutilityinspectors@portlandoregon.gov
-        {% elseif data.report_permanent_structure == "Outdoor seating, tables, dining structures" %}
-          OutdoorDiningPDX@portlandoregon.gov
-        {% elseif data.report_temporary_item == "Garbage/recycling bins" %}
-          wasteinfo@portlandoregon.gov
-        {% elseif data.report_outdoor_dining_item == "Outdoor seating, tables, dining structure" %}
-          OutdoorDiningPDX@portlandoregon.gov
-        {% elseif data.report_tree_issue == "A tree or vegetation that is blocking view of a traffic signal, traffic or street sign" %}
-          tom.jensen@portlandoregon.gov
-        {% elseif data.report_tree_issue == "Vegetation blocking a streetlight" %}
-          streetlighting@portlandoregon.gov
-        {% elseif data.report_vegetation_source == "Other publicly owned land" %}
-          pdxroads@portlandoregon.gov
-        {% elseif data.report_signage_type == "Unauthorized No Parking signs or obstructions to prevent parking" %}
-          PBOTparkingcontrol@portlandoregon.gov
-        {% endif %}
-      '#whitespace': trim
-      '#ajax': true
-    computed_email_recipient_authenticated:
-      '#type': webform_computed_twig
-      '#title': 'Computed Email Recipient (authenticated)'
-      '#title_display': none
-      '#admin_notes': "<p>This is a duplicate of the Computed Email Recipient used in email routing except that it's visible to authenticated users. It must always contain exactly the same code and logic as the original.</p>"
+      '#title': 'Email Routing:'
+      '#title_display': inline
+      '#admin_title': 'Computed Email Recipient'
       '#access_create_roles':
         - authenticated
       '#display_on': form
-      '#mode': html
+      '#mode': text
       '#template': |-
-        <strong>Email routing:</strong> {% if data.report_construction_work_zone_item == "Cuts in the roadway surface" %}
+        {% if data.report_construction_work_zone_item == "Cuts in the roadway surface" %}
           pbotutilityinspectors@portlandoregon.gov
         {% elseif data.report_permanent_structure == "Outdoor seating, tables, dining structures" %}
           OutdoorDiningPDX@portlandoregon.gov


### PR DESCRIPTION
* Make computed email recipient element visible to authenticated users - had to create a 2nd copy of the element because disabling the original for anonymous users would break the routing
* Change all instances of "right of way" to be hyphenated