### PR TITLE
SIT-1094 Graffiti Form 2.2 - add park maintenance zone support

### DIFF
--- a/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
+++ b/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
@@ -461,7 +461,7 @@
                         for (var j = incidentsFeatures.length - 1; j >= 0; j--) {
 
                           // is the incident associated with the asset?
-                          if (primaryFeatures[i].properties.id == incidentsFeatures[j].properties.asset_id) {
+                          if (primaryFeatures[i].properties.id && primaryFeatures[i].properties.id == incidentsFeatures[j].properties.asset_id) {
                             // add incident details to asset details
                             primaryFeatures[i].properties.incidentDetail = incidentsFeatures[j].properties.detail;
                             primaryFeatures[i].properties.hasOpenIncident = incidentsFeatures[j].properties.status == "open" || incidentsFeatures[j].properties.status == "new";

--- a/web/sites/default/config/webform.webform.report_graffiti.yml
+++ b/web/sites/default/config/webform.webform.report_graffiti.yml
@@ -119,11 +119,13 @@ elements: |-
         id: location_widget
       '#location_map__description': '<!--<em>Existing graffiti reports are displayed with a red marker <img src="/modules/custom/portland/modules/portland_location_picker/images/map_marker_incident.png" alt="Red map marker icon" class="inline-icon"> when the map is fully zoomed in. New reports must be reviewed and may take up to 2 business days to appear on the map.</em>-->'
       '#location_lat__required': true
-      '#primary_layer_source': /api/tickets/graffiti
       '#primary_layer_behavior': informational
-      '#primary_layer_type': incident
+      '#primary_layer_type': region-hidden
+      '#primary_layer_source': 'https://www.portlandmaps.com/arcgis/rest/services/Public/Parks_Administrative_Boundaries/MapServer/1/query?where=1%3D1&f=geojson'
+      '#region_id_property_name': Name
       '#feature_layer_visible_zoom': 17
       '#require_boundary': true
+      '#incidents_layer_source': /api/tickets/graffiti
     container_report_details:
       '#type': container
       container_property_owner:


### PR DESCRIPTION
* Fixed a bug in the location widget that prevents an incidents layer from coexisting with a regions-type primary layer
* Added the park maintenance zones layer to the widget on graffiti reports