### PR TITLE
ROW Compliance | Form 1.4

### DIFF
--- a/web/modules/custom/portland/modules/portland_address_verifier/js/addressVerifierView.js
+++ b/web/modules/custom/portland/modules/portland_address_verifier/js/addressVerifierView.js
@@ -27,6 +27,7 @@ const MUST_PROVIDE_ADDRESS_MESSAGE = "You must enter an address or partial addre
 const UNVERIFIED_WARNING_MESSAGE = "We're unable to verify this address. If you're certain this is the full, correct address, you may proceed without verification."
 const VERIFIED_MESSAGE = "Address is verified!";
 
+
 AddressVerifierView.prototype.renderAddressVerifier = function () {
 
     var self = this; // preserve refernece to "this" for use inside functions.
@@ -123,6 +124,9 @@ AddressVerifierView.prototype._setUpInputFieldAndAutocomplete = function () {
             self.$input.val(ui.item.fullAddress);
             self.$input.autocomplete('close');
             self._setVerified(self.$checkmark, self.$button, self.$element, ui.item);
+            if (self.settings.lookup_taxlot) {
+                self._getTaxLotNumber(ui.item);
+            }
             return false; // returning true causes the field to be cleared
         },
         response: function (event, ui) {
@@ -337,3 +341,13 @@ AddressVerifierView.prototype.updateAddressUI = function (address) {
     alert('Putting the validated address in the UI');
 };
 
+AddressVerifierView.prototype._getTaxLotNumber = function (item) {
+    var lat = item.lat;
+    var lon = item.lon;
+    this.model.reverseGeocode(lat, lon, this.handleTaxlotId, this.$element);
+}
+
+AddressVerifierView.prototype.handleTaxlotId = function (taxlotId, $element) {
+    $element.find('#location_taxlot_id').val(taxlotId);
+    alert($element.find('#location_taxlot_id').val());
+}

--- a/web/modules/custom/portland/modules/portland_address_verifier/src/Element/PortlandAddressVerifier.php
+++ b/web/modules/custom/portland/modules/portland_address_verifier/src/Element/PortlandAddressVerifier.php
@@ -166,6 +166,11 @@ class PortlandAddressVerifier extends WebformCompositeBase {
       '#title' => t('Coordinates Y'),
       '#attributes' => [ 'id' => 'location_y']
     ];
+    $element['location_taxlot_id'] = [
+      '#type' => 'hidden',
+      '#title' => t('Taxlot ID'),
+      '#attributes' => [ 'id' => 'location_taxlot_id']
+    ];
     $element['location_address_label'] = [
       '#type' => 'hidden',
       '#title' => t('Address Label'),

--- a/web/modules/custom/portland/modules/portland_address_verifier/src/Plugin/WebformElement/PortlandAddressVerifier.php
+++ b/web/modules/custom/portland/modules/portland_address_verifier/src/Plugin/WebformElement/PortlandAddressVerifier.php
@@ -89,6 +89,9 @@ class PortlandAddressVerifier extends WebformCompositeBase {
 
     $verifyButtonText = array_key_exists('#verify_button_text', $element) ? $element['#verify_button_text'] : "Verify";
     $element['#attached']['drupalSettings']['webform']['portland_address_verifier']['verify_button_text'] = $verifyButtonText;
+
+    $lookupTaxlot = array_key_exists('#lookup_taxlot', $element) && strtolower($element['#lookup_taxlot']) == "1";
+    $element['#attached']['drupalSettings']['webform']['portland_address_verifier']['lookup_taxlot'] = $lookupTaxlot;
   }
 
 }

--- a/web/sites/default/config/subpathauto.settings.yml
+++ b/web/sites/default/config/subpathauto.settings.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: VSBsC1hsGPM2gNULMlhwxRDW_cJD6BVggQ8f9d9fZUk
 depth: 3
-denylist: "/council/documents"
+denylist: /council/documents
 redirect_support: true

--- a/web/sites/default/config/webform.webform.report_parks_incident.yml
+++ b/web/sites/default/config/webform.webform.report_parks_incident.yml
@@ -385,6 +385,8 @@ elements: |-
   support_agent_use_only:
     '#type': portland_support_agent_widget
     '#title': 'Internal Use Only'
+    '#access_create_roles':
+      - authenticated
     '#zendesk_request_number__access': false
     '#employee_notes_panel__access': false
     '#escalate_issue__access': false

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -866,7 +866,7 @@ handlers:
           filled: true
     weight: -47
     settings:
-      comment: "<h3>This ticket requires additional traige</h3>\r\n<p>Please review this ticket to verify the email routing below is correct.</p>\r\n<p><strong>Computed recipient:</strong> [webform_submission:values:computed_email_recipient]</p>"
+      comment: '[webform_submission:values:computed_triage_message:html]'
       comment_private: 1
       tags: ''
       priority: ''

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -831,8 +831,6 @@ handlers:
       enabled:
         ':input[name="support_agent_use_only[test_submission]"]':
           checked: true
-        ':input[name="computed_email_recipient"]':
-          empty: true
     weight: -48
     settings:
       requester_name: contact_name
@@ -851,36 +849,6 @@ handlers:
       ticket_form_id: '20531514301207'
       recipient: ''
       ticket_fork_field: ''
-  submit_to_zendesk_311_for_triage:
-    id: zendesk
-    handler_id: submit_to_zendesk_311_for_triage
-    label: 'TEST: Submit to Zendesk (requires additional triage)'
-    notes: 'If routing is to an email address, send to 311 group for triage, then add a private note in an update with the computed email recipient and instrucitons.'
-    status: true
-    conditions:
-      enabled:
-        ':input[name="support_agent_use_only[test_submission]"]':
-          checked: true
-        ':input[name="computed_triage_message"]':
-          filled: true
-    weight: 2
-    settings:
-      requester_name: contact_name
-      requester_email: contact_email
-      subject: '[webform_submission:values:report_issue_type]'
-      comment: '[webform_submission:values:computed_description:html]'
-      tags: 'drupal webform [webform_submission:values:computed_tags]'
-      priority: normal
-      status: new
-      group_id: '4549352062487'
-      assignee_id: ''
-      type: incident
-      collaborators: ''
-      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']\r\n20710237949079: ['[webform_submission:values:computed_compliance_type]', 'computed_compliance_type']"
-      ticket_id_field: report_ticket_id
-      ticket_form_id: '20531514301207'
-      recipient: ''
-      ticket_fork_field: ''
   zendesk_update_request:
     id: zendesk_update_ticket
     handler_id: zendesk_update_request
@@ -891,7 +859,7 @@ handlers:
       enabled:
         ':input[name="computed_triage_message"]':
           filled: true
-    weight: 3
+    weight: -47
     settings:
       comment: "<h3>This ticket requires additional traige</h3>\r\n<p>Please review this ticket to verify the email routing below is correct.</p>\r\n<p><strong>Computed recipient:</strong> [webform_submission:values:computed_email_recipient]</p>"
       comment_private: 1
@@ -905,4 +873,34 @@ handlers:
       custom_fields: ''
       ticket_id_field: report_ticket_id
       ticket_form_id: '20531514301207'
+  submit_to_zendesk_requires_additional_triage:
+    id: zendesk
+    handler_id: submit_to_zendesk_requires_additional_triage
+    label: 'Submit to Zendesk (311 group, requires additional triage)'
+    notes: 'If there''s an "additional triage needed" message, send to 311 group for triage.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="computed_triage_message"]':
+          filled: true
+    weight: -49
+    settings:
+      requester_name: contact_name
+      requester_email: contact_email
+      subject: '[webform_submission:values:report_issue_type]'
+      comment: '[webform_submission:values:computed_description:html]'
+      tags: 'drupal webform [webform_submission:values:computed_tags]'
+      priority: normal
+      status: new
+      group_id: '360006087813'
+      assignee_id: ''
+      type: incident
+      collaborators: ''
+      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']\r\n20710237949079: ['[webform_submission:values:computed_compliance_type]', 'computed_compliance_type']"
+      ticket_id_field: report_ticket_id
+      ticket_form_id: '20531514301207'
+      recipient: ''
+      ticket_fork_field: ''
 variants: {  }

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -70,26 +70,6 @@ elements: |-
         'Unauthorized signage or other parking obstruction in the right-of-way': 'Unauthorized signage or other parking obstruction in the right-of-way'
         'Sidewalk in need of repair': 'Sidewalk in need of repair'
       '#required': true
-    computed_tags:
-      '#type': webform_computed_twig
-      '#title': 'Computed Tags'
-      '#display_on': none
-      '#mode': text
-      '#template': |-
-        {# Tags for Compliance Type Zendesk form field #}
-        {% set tags = "" %}
-        {% if data.report_issue_type == "Construction work zone item" %}
-          {% set tags = tags ~ "20710237949079_construction " %}
-        {% elseif data.report_issue_type == "Permanent structure" %}
-          {% set tags = tags ~ "20710237949079_permanent_structure " %}
-        {% elseif data.report_issue_type == "Temporary item" %}
-          {% set tags = tags ~ "20710237949079_temporary_item " %}
-        {% else %}
-          {% set tags = tags ~ "20710237949079_row_type_other " %}
-        {% endif %}
-        {{ tags }}
-      '#whitespace': trim
-      '#ajax': true
     report_vehicle_issue_type:
       '#type': radios
       '#title': 'What type of vehicle issue?'
@@ -824,7 +804,7 @@ handlers:
       requester_email: contact_email
       subject: '[webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
-      tags: 'drupal webform [webform_submission:values:computed_tags]'
+      tags: 'drupal webform'
       priority: normal
       status: new
       group_id: '20530977254295'
@@ -852,7 +832,7 @@ handlers:
       requester_email: contact_email
       subject: 'TEST: Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
-      tags: 'drupal webform [webform_submission:values:computed_tags]'
+      tags: 'drupal webform'
       priority: normal
       status: new
       group_id: '4549352062487'
@@ -906,7 +886,7 @@ handlers:
       requester_email: contact_email
       subject: '[webform_submission:values:report_issue_type]'
       comment: '[webform_submission:values:computed_description:html]'
-      tags: 'drupal webform [webform_submission:values:computed_tags]'
+      tags: 'drupal webform 311_row_triage'
       priority: normal
       status: new
       group_id: '360006087813'

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -605,8 +605,8 @@ elements: |-
     '#template': |
       {% if data.computed_email_recipient != "" or data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure" %}
         <h3>This ticket requires additional triage</h3>
+        <p><strong>Attention 311 CSR:</strong> this ticket came from the ROW Obstruction form and may need further triage/investigation to ensure it reaches the appropriate resolving entity. If you have any issues tracking down who this should be forwarded to, contact John Dutt.</p>
         {% if data.computed_email_recipient != "" %}
-          <p><strong>Attention 311 CSR:</strong> this ticket came from the ROW Obstruction form and may need further triage/investigation to ensure it reaches the appropriate resolving entity. If you have any issues tracking down who this should be forwarded to, contact John Dutt.</p>
           <p><strong>Computed recipient:</strong> {{ data.computed_email_recipient }}</p>
         {% endif %}
       {% endif %}

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -604,7 +604,7 @@ elements: |-
     '#display_on': none
     '#mode': html
     '#template': |
-      {% if data.computed_email_recipient != "" or data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure" %}
+      {% if (data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure") and data.report_vegetation_source != "Private property" %}
         <h3>This ticket requires additional triage</h3>
         <p><strong>Attention 311 CSR:</strong> this ticket came from the ROW Obstruction form and may need further triage/investigation to ensure it reaches the appropriate resolving entity. If you have any issues tracking down who this should be forwarded to, contact John Dutt.</p>
         {% if data.computed_email_recipient != "" %}
@@ -612,6 +612,15 @@ elements: |-
         {% endif %}
       {% endif %}
     '#whitespace': spaceless
+    '#ajax': true
+  computed_requires_additional_triage:
+    '#type': webform_computed_twig
+    '#title': 'Requires Additional Triage?'
+    '#access_create_roles':
+      - authenticated
+    '#mode': text
+    '#template': '{% if (data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure") and data.report_vegetation_source != "Private property" %}Yes{% else %}No{% endif %}'
+    '#whitespace': trim
     '#ajax': true
 css: ''
 javascript: ''
@@ -909,4 +918,92 @@ handlers:
       ticket_form_id: '20531514301207'
       recipient: ''
       ticket_fork_field: ''
+  email:
+    id: email
+    handler_id: email
+    label: 'Submit by email'
+    notes: 'Sends the report by email to the recipient specified in the computed_email_recipient field unless marked for additional triage.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="computed_email_recipient"]':
+          filled: true
+        ':input[name="computed_triage_message"]':
+          empty: true
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+    weight: 0
+    settings:
+      states:
+        - completed
+      to_mail: '[webform_submission:values:computed_email_recipient]'
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: noreply@portlandoregon.gov
+      from_options: {  }
+      from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
+      body: '<p><em>This email was sent by Portland.gov. Do no reply.</em></p><p>[webform_submission:values:computed_description:html]</p>'
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  test_submit_by_email:
+    id: email
+    handler_id: test_submit_by_email
+    label: 'TEST: Submit by email'
+    notes: 'Sends a test email to gregory.clapp@portlandoregon.gov.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="computed_email_recipient"]':
+          filled: true
+        ':input[name="computed_triage_message"]':
+          empty: true
+        ':input[name="support_agent_use_only[test_submission]"]':
+          checked: true
+    weight: 5
+    settings:
+      states:
+        - completed
+      to_mail: gregory.clapp@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: noreply@portlandoregon.gov
+      from_options: {  }
+      from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
+      body: '<p><strong>This is a test. This email would normally have been sent to&nbsp;[webform_submission:values:computed_email_recipient:html].</strong></p><p>[webform_submission:values:computed_description:html]</p>'
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
 variants: {  }

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -602,11 +602,11 @@ elements: |-
     '#title': 'Computed Triage Message'
     '#display_on': none
     '#mode': html
-    '#template': |-
+    '#template': |
       {% if data.computed_email_recipient != "" or data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure" %}
         <h3>This ticket requires additional triage</h3>
         {% if data.computed_email_recipient != "" %}
-          <p>Please review this ticket to verify the email routing below is correct.</p>
+          <p><strong>Attention 311 CSR:</strong> this ticket came from the ROW Obstruction form and may need further triage/investigation to ensure it reaches the appropriate resolving entity. If you have any issues tracking down who this should be forwarded to, contact John Dutt.</p>
           <p><strong>Computed recipient:</strong> {{ data.computed_email_recipient }}</p>
         {% endif %}
       {% endif %}

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -299,7 +299,7 @@ elements: |-
             value: 'Something else, or unsure'
         - or
         - ':input[name="report_signage_type"]':
-            value: 'Unauthorized No Parking signs or obstruction to prevent parking'
+            value: 'Unauthorized No Parking signs or obstruction to prevent parking, including unauthorized curb painting'
         - or
         - ':input[name="report_temporary_item"]':
             value: Mulch
@@ -373,7 +373,7 @@ elements: |-
                 value: 'A-board sign'
       contact_home_address:
         '#type': textfield
-        '#title': 'Home Address'
+        '#title': 'Your Home Address'
         '#description': '<p>Please provide a complete, valid address.</p>'
         '#description_display': before
         '#states':
@@ -415,8 +415,9 @@ elements: |-
       contact_email:
         '#type': textfield
         '#title': Email
-        '#description': '<p><span style="-webkit-text-stroke-width:0px;background-color:rgb(255, 255, 255);color:rgb(21, 25, 30);display:inline !important;float:none;font-family:&quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;font-size:14px;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-decoration-thickness:initial;text-indent:0px;text-transform:none;white-space:normal;widows:2;word-spacing:0px;">We will only use your email address to respond to your report if needed.</span></p>'
+        '#description': '<p>We will only use your email address to respond to your report if needed.</p>'
         '#description_display': before
+        '#required': true
         '#pattern': '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
         '#pattern_error': 'Please enter a correctly formatted email address, such as myname@example.com.'
     section_public_records_statement:

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -578,6 +578,7 @@ elements: |-
   computed_compliance_type:
     '#type': webform_computed_twig
     '#title': 'Computed Compliance Type'
+    '#display_on': none
     '#mode': text
     '#template': |
       {% if data.report_issue_type == "Construction work zone item" %}
@@ -590,6 +591,21 @@ elements: |-
         20710237949079_row_type_other
       {% endif %}
     '#whitespace': trim
+    '#ajax': true
+  computed_triage_message:
+    '#type': webform_computed_twig
+    '#title': 'Computed Triage Message'
+    '#display_on': none
+    '#mode': html
+    '#template': |-
+      {% if data.computed_email_recipient != "" or data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure" %}
+        <h3>This ticket requires additional traige</h3>
+        {% if data.computed_email_recipient != "" %}
+          <p>Please review this ticket to verify the email routing below is correct.</p>
+          <p><strong>Computed recipient:</strong> {{ data.computed_email_recipient }}</p>
+        {% endif %}
+      {% endif %}
+    '#whitespace': spaceless
     '#ajax': true
 css: ''
 javascript: ''
@@ -845,7 +861,7 @@ handlers:
       enabled:
         ':input[name="support_agent_use_only[test_submission]"]':
           checked: true
-        ':input[name="computed_email_recipient"]':
+        ':input[name="computed_triage_message"]':
           filled: true
     weight: 2
     settings:
@@ -873,7 +889,7 @@ handlers:
     status: true
     conditions:
       enabled:
-        ':input[name="computed_email_recipient"]':
+        ':input[name="computed_triage_message"]':
           filled: true
     weight: 3
     settings:

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -143,6 +143,7 @@ elements: |-
         'Extension cord': 'Extension cord'
         'Hazardous waste': 'Hazardous waste -- Human feces, used syringes, etc.'
         Other: Other
+        'Messy sidewalk': 'Messy sidewalk -- Gravel, mud, debris, etc.'
       '#other__description': 'Please describe'
       '#states':
         visible:
@@ -298,7 +299,7 @@ elements: |-
             value: 'Outdoor seating, tables, dining structure'
         - or
         - ':input[name="report_tree_issue"]':
-            value: 'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign'
+            value: 'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign, or visibility at an intersection'
         - or
         - ':input[name="report_tree_issue"]':
             value: 'Vegetation blocking a streetlight'
@@ -338,6 +339,7 @@ elements: |-
         '#type': portland_location_picker
         '#title': 'Location of the obstruction'
         '#location_search__title': Location
+        '#location_lat__required': true
         '#place_name__access': false
         '#location_details__access': false
         '#location_details__title': 'Obstruction Details'
@@ -384,11 +386,11 @@ elements: |-
             - or
             - ':input[name="report_signage_type"]':
                 value: 'A-board sign'
-      contact_email:
+      contact_home_address:
         '#type': textfield
-        '#title': Email
-        '#pattern': '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-        '#pattern_error': 'Please enter a correctly formatted email address, such as myname@example.com.'
+        '#title': 'Home Address'
+        '#description': '<p>Please provide a complete, valid address.</p>'
+        '#description_display': before
         '#states':
           required:
             - ':input[name="report_temporary_item"]':
@@ -409,6 +411,29 @@ elements: |-
         '#type': textfield
         '#title': Phone
         '#input_mask': '(999) 999-9999'
+        '#states':
+          required:
+            - ':input[name="report_temporary_item"]':
+                value: Mulch
+            - or
+            - ':input[name="report_temporary_item"]':
+                value: 'A-board sign'
+            - or
+            - ':input[name="report_outdoor_dining_item"]':
+                value: 'A-board sign'
+            - or
+            - ':input[name="report_vegetation_source"]':
+                value: 'Private property'
+            - or
+            - ':input[name="report_signage_type"]':
+                value: 'A-board sign'
+      contact_email:
+        '#type': textfield
+        '#title': Email
+        '#description': '<p><span style="-webkit-text-stroke-width:0px;background-color:rgb(255, 255, 255);color:rgb(21, 25, 30);display:inline !important;float:none;font-family:&quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;font-size:14px;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-decoration-thickness:initial;text-indent:0px;text-transform:none;white-space:normal;widows:2;word-spacing:0px;">We will only use your email address to respond to your report if needed.</span></p>'
+        '#description_display': before
+        '#pattern': '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        '#pattern_error': 'Please enter a correctly formatted email address, such as myname@example.com.'
     section_public_records_statement:
       '#type': webform_section
       '#title': 'Public Records Statement'
@@ -529,8 +554,8 @@ elements: |-
       {% if data.report_location.location_lat and data.report_location.location_lon %}
         Lat/Lon: <a href="https://www.google.com/maps/place/{{ data.report_location.location_lat }},{{ data.report_location.location_lon }}">{{ data.report_location.location_lat }},{{ data.report_location.location_lon }}</a><br>
       {% endif %}
-      {% if data.report_location.location_details %}
-        {{ data.report_location.location_details }}
+      {% if data.report_location.location_attributes %}
+        {{ data.report_location.location_attributes }}
       {% endif %}
     '#ajax': true
   computed_compliance_subtype:
@@ -547,6 +572,22 @@ elements: |-
         {{ data.report_temporary_item is iterable ? "" : data.report_temporary_item }}
       {% elseif data.report_issue_type == "Trees or vegetation" %}
         {{ data.report_tree_issue is iterable ? "" : data.report_tree_issue }}
+      {% endif %}
+    '#whitespace': trim
+    '#ajax': true
+  computed_compliance_type:
+    '#type': webform_computed_twig
+    '#title': 'Computed Compliance Type'
+    '#mode': text
+    '#template': |
+      {% if data.report_issue_type == "Construction work zone item" %}
+        20710237949079_construction
+      {% elseif data.report_issue_type == "Permanent structure" %}
+        20710237949079_permanent_structure
+      {% elseif data.report_issue_type == "Temporary item" %}
+        20710237949079_temporary_item
+      {% else %}
+        20710237949079_row_type_other
       {% endif %}
     '#whitespace': trim
     '#ajax': true
@@ -759,53 +800,11 @@ handlers:
       assignee_id: ''
       type: incident
       collaborators: ''
-      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']"
+      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']\r\n20710237949079: ['[webform_submission:values:computed_compliance_type]', 'computed_compliance_type']"
       ticket_id_field: report_ticket_id
       ticket_form_id: '20531514301207'
       recipient: ''
       ticket_fork_field: ''
-  email:
-    id: email
-    handler_id: email
-    label: 'Submit by email'
-    notes: 'Sends the report by email to the recipient specified in the computed_email_recipient field.'
-    status: true
-    conditions:
-      enabled:
-        ':input[name="computed_email_recipient"]':
-          filled: true
-        ':input[name="support_agent_use_only[test_submission]"]':
-          unchecked: true
-    weight: -47
-    settings:
-      states:
-        - completed
-      to_mail: '[webform_submission:values:computed_email_recipient]'
-      to_options: {  }
-      bcc_mail: ''
-      bcc_options: {  }
-      cc_mail: ''
-      cc_options: {  }
-      from_mail: noreply@portlandoregon.gov
-      from_options: {  }
-      from_name: _default
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
-      subject: 'Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
-      body: "<p><em>This email was sent by Portland.gov. Do no reply.</em></p>\r\n\r\n<p>[webform_submission:values:computed_description:html]</p>"
-      excluded_elements: {  }
-      ignore_access: false
-      exclude_empty: true
-      exclude_empty_checkbox: false
-      exclude_attachments: false
-      html: true
-      attachments: false
-      twig: false
-      theme_name: ''
-      parameters: {  }
-      debug: false
   test_submit_to_zendesk:
     id: zendesk
     handler_id: test_submit_to_zendesk
@@ -831,51 +830,63 @@ handlers:
       assignee_id: ''
       type: incident
       collaborators: ''
-      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']"
+      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n20710237949079: ['[webform_submission:values:computed_compliance_type]', 'computed_compliance_type']\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']"
       ticket_id_field: report_ticket_id
       ticket_form_id: '20531514301207'
       recipient: ''
       ticket_fork_field: ''
-  submit_by_email:
-    id: email
-    handler_id: submit_by_email
-    label: 'TEST: Submit by email'
-    notes: 'Sends a test email to gregory.clapp@portlandoregon.gov.'
+  submit_to_zendesk_311_for_triage:
+    id: zendesk
+    handler_id: submit_to_zendesk_311_for_triage
+    label: 'TEST: Submit to Zendesk (requires additional triage)'
+    notes: 'If routing is to an email address, send to 311 group for triage, then add a private note in an update with the computed email recipient and instrucitons.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          checked: true
+        ':input[name="computed_email_recipient"]':
+          filled: true
+    weight: 2
+    settings:
+      requester_name: contact_name
+      requester_email: contact_email
+      subject: '[webform_submission:values:report_issue_type]'
+      comment: '[webform_submission:values:computed_description:html]'
+      tags: 'drupal webform [webform_submission:values:computed_tags]'
+      priority: normal
+      status: new
+      group_id: '4549352062487'
+      assignee_id: ''
+      type: incident
+      collaborators: ''
+      custom_fields: "6353388345367: 'report_row_obstruction'\r\n5581480390679: ['[webform_submission:values:report_location:location_lat]', 'report_location:location_lat']\r\n5581490332439: ['[webform_submission:values:report_location:location_lon]', 'report_location:location_lon']\r\n13407901552407: ['[webform_submission:values:report_location:location_x]', 'report_location:location_x']\r\n13407918835095: ['[webform_submission:values:report_location:location_y]', 'report_location:location_y']\r\n1500012743961: ['[webform_submission:values:report_location:location_address]', 'report_location:location_address']\r\n1500013095781: '[webform_submission:uuid]'\r\n21326872476311: ['[webform_submission:values:computed_compliance_subtype]', 'computed_compliance_subtype']\r\n7557381052311: ['[webform_submission:values:report_obstruction_details]', 'report_obstruction_details']\r\n20710237949079: ['[webform_submission:values:computed_compliance_type]', 'computed_compliance_type']"
+      ticket_id_field: report_ticket_id
+      ticket_form_id: '20531514301207'
+      recipient: ''
+      ticket_fork_field: ''
+  zendesk_update_request:
+    id: zendesk_update_ticket
+    handler_id: zendesk_update_request
+    label: 'Update ticket with triage instructions'
+    notes: ''
     status: true
     conditions:
       enabled:
         ':input[name="computed_email_recipient"]':
           filled: true
-        ':input[name="support_agent_use_only[test_submission]"]':
-          checked: true
-    weight: 4
+    weight: 3
     settings:
-      states:
-        - completed
-      to_mail: gregory.clapp@portlandoregon.gov
-      to_options: {  }
-      bcc_mail: ''
-      bcc_options: {  }
-      cc_mail: ''
-      cc_options: {  }
-      from_mail: noreply@portlandoregon.gov
-      from_options: {  }
-      from_name: _default
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
-      subject: 'TEST: Obstruction in the right-of-way: [webform_submission:values:report_issue_type]'
-      body: "<p><strong>This is a test. This email would normally have been sent to&nbsp;[webform_submission:values:computed_email_recipient:html].</strong></p>\r\n\r\n<p>[webform_submission:values:computed_description:html]</p>"
-      excluded_elements: {  }
-      ignore_access: false
-      exclude_empty: true
-      exclude_empty_checkbox: false
-      exclude_attachments: false
-      html: true
-      attachments: false
-      twig: false
-      theme_name: ''
-      parameters: {  }
-      debug: false
+      comment: "<h3>This ticket requires additional traige</h3>\r\n<p>Please review this ticket to verify the email routing below is correct.</p>\r\n<p><strong>Computed recipient:</strong> [webform_submission:values:computed_email_recipient]</p>"
+      comment_private: 1
+      tags: ''
+      priority: ''
+      status: ''
+      group_id: ''
+      assignee_id: ''
+      type: ''
+      collaborators: ''
+      custom_fields: ''
+      ticket_id_field: report_ticket_id
+      ticket_form_id: '20531514301207'
 variants: {  }

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -604,7 +604,7 @@ elements: |-
     '#mode': html
     '#template': |-
       {% if data.computed_email_recipient != "" or data.report_tree_issue == "None of the above" or data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" or data.report_vegetation_source == "Park or natural area" or data.report_vegetation_source == "Something else, or unsure" %}
-        <h3>This ticket requires additional traige</h3>
+        <h3>This ticket requires additional triage</h3>
         {% if data.computed_email_recipient != "" %}
           <p>Please review this ticket to verify the email routing below is correct.</p>
           <p><strong>Computed recipient:</strong> {{ data.computed_email_recipient }}</p>

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -62,7 +62,7 @@ elements: |-
       '#title': 'What type of issue or object are you reporting?'
       '#options':
         Vehicle: 'Vehicle -- Including dumpsters, PODS, trailers'
-        'Construction work zone item': 'Construction work zone item -- Staging, fencing, miscellaneous equipment, etc. '
+        'Construction work zone item': 'Construction work zone item -- Staging, fencing, utility cuts, traffic control and miscellaneous equipment'
         'Permanent structure': 'Permanent structure -- Fences, planters, sheds, trash can enclosures, etc.'
         'Temporary item': 'Temporary item -- Mulch piles, basketball hoops, sports items, electrical cords, trash cans, etc.'
         'Outdoor dining': 'Outdoor dining -- Outdoor seating, tables, sandwich boards, dining structure, etc.'
@@ -107,14 +107,14 @@ elements: |-
         'Construction equipment': 'Construction equipment -- Heavy equipment, machinery, tools, etc.'
         Fencing: Fencing
         Materials: 'Materials -- Building supplies, wood piles, scrap piles, etc.'
-        'Cuts in the roadway surface': 'Cuts in the roadway surface -- Intentional cuts to access utilities, usually in straight lines'
+        'Cuts in the roadway surface/missing manhole covers': 'Cuts in the roadway surface/missing manhole covers -- Intentional cuts to access utilities, usually in straight lines'
         'Traffic control equipment': 'Traffic control equipment -- Cones, delineators, flaggers, barricades'
         Other: Other
+      '#required': true
       '#states':
         visible:
           ':input[name="report_issue_type"]':
             value: 'Construction work zone item'
-      '#required': true
     report_permanent_structure:
       '#type': radios
       '#title': 'What type of permanent structure?'
@@ -164,7 +164,7 @@ elements: |-
       '#title': 'What tree or vegetation issue are you trying to report?'
       '#options':
         'A tree or large branch that has fallen and is now a hazard in the street or sidewalk': 'A tree or large branch that has fallen and is now a hazard in the street or sidewalk'
-        'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign': 'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign'
+        'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign, or visibility at an intersection': 'A tree or vegetation that is blocking view of a traffic signal, traffic or street sign, or visibility at an intersection'
         'Vegetation blocking a streetlight': 'Vegetation blocking a streetlight'
         'Vegetation growing into the sidewalk, public pathway, bike lane, or other travel lane': 'Vegetation growing into the sidewalk, public pathway, bike lane, or other travel lane -- For example, hanging from above or growing in from the side'
         'None of the above': 'None of the above'
@@ -195,14 +195,14 @@ elements: |-
       '#type': radios
       '#title': 'What type of signage?'
       '#options':
-        'Unauthorized No Parking signs or obstruction to prevent parking': 'Unauthorized No Parking signs or obstruction to prevent parking'
+        'Unauthorized No Parking signs or obstruction to prevent parking, including unauthorized curb painting': 'Unauthorized No Parking signs or obstruction to prevent parking, including unauthorized curb painting'
         'A-board sign': 'A-board sign'
         'Unauthorized signs on utility poles': 'Unauthorized signs on utility poles'
+      '#required': true
       '#states':
         visible:
           ':input[name="report_issue_type"]':
             value: 'Unauthorized signage or other parking obstruction in the right-of-way'
-      '#required': true
     markup_vehicle:
       '#type': webform_markup
       '#states':
@@ -427,7 +427,7 @@ elements: |-
       '#submit__label': Submit
   computed_email_recipient:
     '#type': webform_computed_twig
-    '#title': 'Email Routing:'
+    '#title': 'Email Routing'
     '#title_display': inline
     '#admin_title': 'Computed Email Recipient'
     '#access_create_roles':
@@ -439,7 +439,7 @@ elements: |-
         sidewalkrepair@portlandoregon.gov
       {% elseif data.report_temporary_item == "Mulch" or data.report_temporary_item == "A-board sign" or data.report_outdoor_dining_item == "A-board sign" or data.report_vegetation_source == "Private property" or data.report_signage_type == "A-board sign" %}
         codec@portlandoregon.gov
-      {% elseif data.report_construction_work_zone_item == "Cuts in the roadway surface" %}
+      {% elseif data.report_construction_work_zone_item == "Cuts in the roadway surface/missing manhole covers" %}
         pbotutilityinspectors@portlandoregon.gov
       {% elseif data.report_permanent_structure == "Outdoor seating, tables, dining structures" %}
         OutdoorDiningPDX@portlandoregon.gov
@@ -447,13 +447,13 @@ elements: |-
         wasteinfo@portlandoregon.gov
       {% elseif data.report_outdoor_dining_item == "Outdoor seating, tables, dining structure" %}
         OutdoorDiningPDX@portlandoregon.gov
-      {% elseif data.report_tree_issue == "A tree or vegetation that is blocking view of a traffic signal, traffic or street sign" %}
+      {% elseif data.report_tree_issue == "A tree or vegetation that is blocking view of a traffic signal, traffic or street sign, or visibility at an intersection" %}
         tom.jensen@portlandoregon.gov
       {% elseif data.report_tree_issue == "Vegetation blocking a streetlight" %}
         streetlighting@portlandoregon.gov
       {% elseif data.report_vegetation_source == "Other publicly owned land" %}
         pdxroads@portlandoregon.gov
-      {% elseif data.report_signage_type == "Unauthorized No Parking signs or obstructions to prevent parking" %}
+      {% elseif data.report_signage_type == "Unauthorized No Parking signs or obstruction to prevent parking, including unauthorized curb painting" %}
         PBOTparkingcontrol@portlandoregon.gov
       {% elseif data.report_vegetation_source == "Parking strip, median, or other parts of the street or right-of-way" %}
         pdxroads@portlandoregon.gov

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -450,6 +450,7 @@ elements: |-
       '#title': 'Support Agent Use Only'
       '#access_create_roles':
         - authenticated
+      '#zendesk_request_number__access': false
       '#escalate_issue__access': false
     actions:
       '#type': webform_actions

--- a/web/sites/default/config/webform.webform.report_row_obstruction.yml
+++ b/web/sites/default/config/webform.webform.report_row_obstruction.yml
@@ -100,6 +100,7 @@ elements: |-
         visible:
           ':input[name="report_issue_type"]':
             value: Vehicle
+      '#required': true
     report_construction_work_zone_item:
       '#type': radios
       '#title': 'What type of construction work zone item?'
@@ -142,9 +143,10 @@ elements: |-
         'Basketball hoop/sports equipment': 'Basketball hoop/sports equipment'
         'Extension cord': 'Extension cord'
         'Hazardous waste': 'Hazardous waste -- Human feces, used syringes, etc.'
-        Other: Other
         'Messy sidewalk': 'Messy sidewalk -- Gravel, mud, debris, etc.'
+        Other: Other
       '#other__description': 'Please describe'
+      '#required': true
       '#states':
         visible:
           ':input[name="report_issue_type"]':
@@ -324,6 +326,9 @@ elements: |-
         - or
         - ':input[name="report_temporary_item"]':
             value: 'A-board sign'
+        - or
+        - ':input[name="report_temporary_item"]':
+            value: 'Messy sidewalk'
         - or
         - ':input[name="report_outdoor_dining_item"]':
             value: 'A-board sign'


### PR DESCRIPTION
This branch includes an update to the Address Verifier widget that adds an API call to retrieve the taxlot ID number. I thought it would be needed for the ROW form, but turns out it's not. However, I decided to leave the functionality in so it can be used later. It has to be activated using a custom parameter. 

There is also one update to the parks incident reporting form, to hide the Internal Use Only block from anonymous users.