### PR TITLE
PGOV-1344 fix error in CKEditor document browser

### DIFF
--- a/web/modules/custom/portland/modules/portland_ecouncil/portland_ecouncil.module
+++ b/web/modules/custom/portland/modules/portland_ecouncil/portland_ecouncil.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
 
@@ -144,9 +145,12 @@ function _hide_deprecated_field_values(array &$form) {
 /**
  * Implements hook_field_group_build_pre_render_alter().
  */
-function portland_ecouncil_field_group_form_process_build_alter(array &$form, FormStateInterface $form_state) {
+function portland_ecouncil_field_group_form_process_build_alter(array &$element, FormStateInterface $form_state, array &$form) {
+  $form_object = $form_state->getFormObject();
+  if (!$form_object instanceof EntityFormInterface) return;
+
   /** @var \Drupal\node\Entity\Node */
-  $node = $form_state->getFormObject()->getEntity();
+  $node = $form_object->getEntity();
   if ($node->bundle() === 'council_document') {
     _check_council_president_state($form, $node);
     _hide_council_document_types($form);

--- a/web/sites/default/config/views.view.electeds.yml
+++ b/web/sites/default/config/views.view.electeds.yml
@@ -2444,6 +2444,44 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        field_active_elected_official_value:
+          id: field_active_elected_official_value
+          table: group__field_active_elected_official
+          field: field_active_elected_official_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: OR
         groups:

--- a/web/sites/default/config/views.view.manage_council_documents.yml
+++ b/web/sites/default/config/views.view.manage_council_documents.yml
@@ -15260,7 +15260,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a class="button button--primary" href="{{ edit_node }}#council-president-only">Add</a>'
+            text: '<a class="button button--primary" href="{{ edit_node }}?destination={{ path(''<current>'')|url_encode }}#council-president-only">Add</a>'
             make_link: false
             path: ''
             absolute: false

--- a/web/themes/custom/cloudy/templates/field/file-link.html.twig
+++ b/web/themes/custom/cloudy/templates/field/file-link.html.twig
@@ -55,7 +55,7 @@
   <span>
   {% else %}
   {# class is used for GA4 event tracking #}
-  <a class="document--download" href="{{ (document_link is empty) ? url : document_link }}" target="_blank">
+  <a class="document--download" href="{{ (document_link is empty) ? url : document_link }}">
   {% endif %}
 		<span class="visually-hidden">{{ file_desc }}</span>
 		<i class="fas {{ icon_name }} text-body"></i>

--- a/web/themes/custom/cloudy/templates/field/file-link.html.twig
+++ b/web/themes/custom/cloudy/templates/field/file-link.html.twig
@@ -54,7 +54,8 @@
   {% if url starts with '/system/files/webform' and not logged_in %}
   <span>
   {% else %}
-  <a href="{{ (document_link is empty) ? url : document_link }}" target="_blank">
+  {# class is used for GA4 event tracking #}
+  <a class="document--download" href="{{ (document_link is empty) ? url : document_link }}" target="_blank">
   {% endif %}
 		<span class="visually-hidden">{{ file_desc }}</span>
 		<i class="fas {{ icon_name }} text-body"></i>


### PR DESCRIPTION
- don't show inactive electeds in agenda item voting list
- redirect back to council president view after adding recommendation
- add back document--download class to file-link template, used for GA4 tracking
  - Also remove target=”_blank” that was added in a previous PR