### PR TITLE
PGOV-1363 Contact Elected Official form v2.2 updates

### DIFF
--- a/web/sites/default/config/webform.webform.contact_elected_official_2025.yml
+++ b/web/sites/default/config/webform.webform.contact_elected_official_2025.yml
@@ -1081,7 +1081,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1134,7 +1134,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1205,7 +1205,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1276,7 +1276,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1347,7 +1347,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1418,7 +1418,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1489,7 +1489,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }
@@ -1560,7 +1560,7 @@ handlers:
       exclude_empty_checkbox: true
       exclude_attachments: false
       html: true
-      attachments: false
+      attachments: true
       twig: false
       theme_name: ''
       parameters: {  }

--- a/web/sites/default/config/webform.webform.contact_elected_official_2025.yml
+++ b/web/sites/default/config/webform.webform.contact_elected_official_2025.yml
@@ -1096,7 +1096,7 @@ handlers:
       enabled:
         ':input[name="support_agent_use_only[test_submission]"]':
           checked: true
-    weight: -48
+    weight: -49
     settings:
       states:
         - completed
@@ -1139,11 +1139,11 @@ handlers:
       theme_name: ''
       parameters: {  }
       debug: false
-  send_email_to_all_officials:
+  send_email_to_mayor:
     id: email
-    handler_id: send_email_to_all_officials
-    label: 'Send email to ALL officials'
-    notes: 'Sends a duplicate message to the mayor, auditor, and all districts. Includes a note that the same message has been sent to all officials.'
+    handler_id: send_email_to_mayor
+    label: 'Send email to Mayor'
+    notes: 'Sends a message to the mayor. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
     status: true
     conditions:
       enabled:
@@ -1151,11 +1151,11 @@ handlers:
           unchecked: true
         ':input[name="request_purpose"]':
           value: 'Provide comment or feedback to all elected officials'
-    weight: -49
+    weight: -48
     settings:
       states:
         - completed
-      to_mail: '[webform_submission:values:computed_recipient]'
+      to_mail: mayor@portlandoregon.gov
       to_options: {  }
       bcc_mail: ''
       bcc_options: {  }
@@ -1171,12 +1171,383 @@ handlers:
       subject: '[webform_submission:values:computed_subject]'
       body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
       excluded_elements:
+        prepopulate: prepopulate
+        card: card
         introductory_text: introductory_text
         report_location: report_location
         markup_district_1: markup_district_1
         markup_district_2: markup_district_2
         markup_district_3: markup_district_3
         markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
+        testimony_instructions: testimony_instructions
+        contact_country: contact_country
+        your_address: your_address
+        public_records_statement_text: public_records_statement_text
+        computed_subject: computed_subject
+        computed_recipient: computed_recipient
+        computed_confirmation_message: computed_confirmation_message
+      ignore_access: true
+      exclude_empty: true
+      exclude_empty_checkbox: true
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  send_email_to_auditor:
+    id: email
+    handler_id: send_email_to_auditor
+    label: 'Send email to Auditor'
+    notes: 'Sends a message to the Auditor. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="request_purpose"]':
+          value: 'Provide comment or feedback to all elected officials'
+    weight: -47
+    settings:
+      states:
+        - completed
+      to_mail: auditorsoffice@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:contact_email_address:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:contact_name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:computed_subject]'
+      body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
+      excluded_elements:
+        prepopulate: prepopulate
+        card: card
+        introductory_text: introductory_text
+        report_location: report_location
+        markup_district_1: markup_district_1
+        markup_district_2: markup_district_2
+        markup_district_3: markup_district_3
+        markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
+        testimony_instructions: testimony_instructions
+        contact_country: contact_country
+        your_address: your_address
+        public_records_statement_text: public_records_statement_text
+        computed_subject: computed_subject
+        computed_recipient: computed_recipient
+        computed_confirmation_message: computed_confirmation_message
+      ignore_access: true
+      exclude_empty: true
+      exclude_empty_checkbox: true
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  send_email_to_district_2:
+    id: email
+    handler_id: send_email_to_district_2
+    label: 'Send email to District 2'
+    notes: 'Sends a message to the District 2 councilors. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="request_purpose"]':
+          value: 'Provide comment or feedback to all elected officials'
+    weight: -44
+    settings:
+      states:
+        - completed
+      to_mail: councildistrict2@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:contact_email_address:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:contact_name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:computed_subject]'
+      body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
+      excluded_elements:
+        prepopulate: prepopulate
+        card: card
+        introductory_text: introductory_text
+        report_location: report_location
+        markup_district_1: markup_district_1
+        markup_district_2: markup_district_2
+        markup_district_3: markup_district_3
+        markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
+        testimony_instructions: testimony_instructions
+        contact_country: contact_country
+        your_address: your_address
+        public_records_statement_text: public_records_statement_text
+        computed_subject: computed_subject
+        computed_recipient: computed_recipient
+        computed_confirmation_message: computed_confirmation_message
+      ignore_access: true
+      exclude_empty: true
+      exclude_empty_checkbox: true
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  send_email_to_district_3:
+    id: email
+    handler_id: send_email_to_district_3
+    label: 'Send email to District 3'
+    notes: 'Sends a message to the District 3 councilors. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="request_purpose"]':
+          value: 'Provide comment or feedback to all elected officials'
+    weight: -43
+    settings:
+      states:
+        - completed
+      to_mail: councildistrict3@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:contact_email_address:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:contact_name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:computed_subject]'
+      body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
+      excluded_elements:
+        prepopulate: prepopulate
+        card: card
+        introductory_text: introductory_text
+        report_location: report_location
+        markup_district_1: markup_district_1
+        markup_district_2: markup_district_2
+        markup_district_3: markup_district_3
+        markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
+        testimony_instructions: testimony_instructions
+        contact_country: contact_country
+        your_address: your_address
+        public_records_statement_text: public_records_statement_text
+        computed_subject: computed_subject
+        computed_recipient: computed_recipient
+        computed_confirmation_message: computed_confirmation_message
+      ignore_access: true
+      exclude_empty: true
+      exclude_empty_checkbox: true
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  send_email_to_district_4:
+    id: email
+    handler_id: send_email_to_district_4
+    label: 'Send email to District 4'
+    notes: 'Sends a message to the District 4 councilors. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="request_purpose"]':
+          value: 'Provide comment or feedback to all elected officials'
+    weight: -42
+    settings:
+      states:
+        - completed
+      to_mail: councildistrict4@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:contact_email_address:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:contact_name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:computed_subject]'
+      body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
+      excluded_elements:
+        prepopulate: prepopulate
+        card: card
+        introductory_text: introductory_text
+        report_location: report_location
+        markup_district_1: markup_district_1
+        markup_district_2: markup_district_2
+        markup_district_3: markup_district_3
+        markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
+        testimony_instructions: testimony_instructions
+        contact_country: contact_country
+        your_address: your_address
+        public_records_statement_text: public_records_statement_text
+        computed_subject: computed_subject
+        computed_recipient: computed_recipient
+        computed_confirmation_message: computed_confirmation_message
+      ignore_access: true
+      exclude_empty: true
+      exclude_empty_checkbox: true
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  send_email_to_district_1:
+    id: email
+    handler_id: send_email_to_district_1
+    label: 'Send email to District 1'
+    notes: 'Sends a message to the District 1 councilors. Only used in the "send to all" use case. Otherwise, the recipient is calculated using the computed_recipient field.'
+    status: true
+    conditions:
+      enabled:
+        ':input[name="support_agent_use_only[test_submission]"]':
+          unchecked: true
+        ':input[name="request_purpose"]':
+          value: 'Provide comment or feedback to all elected officials'
+    weight: -45
+    settings:
+      states:
+        - completed
+      to_mail: councildistrict1@portlandoregon.gov
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:contact_email_address:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:contact_name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:computed_subject]'
+      body: '<p style="color:red;"><strong>This message has been sent to the Mayor, Auditor, and all district inboxes.</strong></p><p>[webform_submission:values:html]</p>'
+      excluded_elements:
+        prepopulate: prepopulate
+        card: card
+        introductory_text: introductory_text
+        report_location: report_location
+        markup_district_1: markup_district_1
+        markup_district_2: markup_district_2
+        markup_district_3: markup_district_3
+        markup_district_4: markup_district_4
+        markup_avalos: markup_avalos
+        markup_dunphy: markup_dunphy
+        markup_smith: markup_smith
+        markup_ryan: markup_ryan
+        markup_pirtle_guiney: markup_pirtle_guiney
+        markup_kanal: markup_kanal
+        markup_morillo: markup_morillo
+        markup_novick: markup_novick
+        markup_lane: markup_lane
+        markup_zimmerman: markup_zimmerman
+        markup_green: markup_green
+        markup_clark: markup_clark
+        markup_wilson: markup_wilson
+        markup_rede: markup_rede
         testimony_instructions: testimony_instructions
         contact_country: contact_country
         your_address: your_address


### PR DESCRIPTION
* Added email handler for each inbox to be used in send-all use case, instead of using delimited list of emails in one handler. This is to fix the issue with Zendesk only generating one ticket.