### PR TITLE
PGOV-1565 - PP&D Conditional Logic Demo (#3110)

### DIFF
--- a/web/modules/custom/portland/modules/portland_address_verifier/README.md
+++ b/web/modules/custom/portland/modules/portland_address_verifier/README.md
@@ -67,7 +67,16 @@ Default value: 0
 When populated, a second API call is made to the specified API URL with the x/y coordinates passed in the geometry parameter. All 3 properties (secondary_query_url, secondary_query_capture_property, and secondary_query_capture_field) must be set for this to work.
 
 **secondary_query_capture_property**<br>
-The path of the property to capture from the JSON returned by the secondary_query_url. All 3 properties (secondary_query_url, secondary_query_capture_property, and secondary_query_capture_field) must be set for this to work.
+A dot-notated string that defines the property path to retrieve a value from a nested JSON object. Supports:
+
+- **Nested properties** using dot syntax  
+  _Example:_ `zoning.base.0.code` or `features.1.attributes.name`
+
+- **Array access** using numeric indices directly in the path  
+  _Example:_ `features.0.attributes.name`
+
+The path must exactly match the structure of the JSON object. Arrays must be accessed using explicit numeric indexes.  
+This version does **not** support array mapping with empty brackets (`[]`). If any part of the path is invalid or missing, the function will return `undefined`.
 
 **secondary_query_capture_field**<br>
 The ID of the form field into which the captured value should be stored. All 3 properties (secondary_query_url, secondary_query_capture_property, and secondary_query_capture_field) must be set for this to work.
@@ -94,6 +103,15 @@ Default value: "A verified address is required. Please try again."
 
 **secondary_queries**<br>
 An array of queries to run when an address suggestion is selected or when an address is verified, in addition to built-in geolocation and address suggestion queries. When submitting to the PortlandMaps API, either a detail_id (taxlotId) or geometry (x, y) must be passed. See the examples below. 
+
+The path property is dot-notated string that defines the property path to retrieve a value from a nested JSON object. The path must exactly match the structure of the JSON object. If any part of the path is invalid or missing, the function will return `undefined`. Supports:
+- **Nested properties** using dot syntax  
+  _Example:_ `zoning.base[0].code`
+- **Array indexing** with bracket notation  
+  _Example:_ `features[2].attributes.name`
+- **Mapping over arrays** using empty brackets `[]`, which returns an array of values from each element  
+  _Example:_ `features[].attributes.name`
+
 <pre>
 secondary_queries:
   - api: 'https://www.portlandmaps.com/api/detail/'

--- a/web/modules/custom/portland/modules/portland_address_verifier/js/addressVerifierModel.js
+++ b/web/modules/custom/portland/modules/portland_address_verifier/js/addressVerifierModel.js
@@ -1,40 +1,40 @@
 AddressVerifierModel.locationItem = function (data, $element = null, isSingleton = false) {
 
-    // PortlandMaps sends incorrectly formatted address data if there is only 1 suggestion to return.
-    // If a singleton, the isSingleton flag will be true, and we'll do some kludgey string manipulation.
-    if (isSingleton) {
-        var arrAddress = data.address.split(', ');
-        data.address = arrAddress[0];
-    }
-    this.fullAddress = AddressVerifierModel.buildFullAddress(data.address, data.attributes.city, data.attributes.state, data.attributes.zip_code, data.unit).toUpperCase();
-    this.displayAddress = data.address.toUpperCase();// + ', ' + data.attributes.jurisdiction.toUpperCase();
-    this.street = data.address.toUpperCase();
-    this.streetNumber = data.attributes.address_number;
-    this.streetQuadrant = data.attributes.street_direction;
-    this.streetDirectionSuffix = data.attributes.street_direction_suffix ? data.attributes.street_direction_suffix.trim() : "";
-    this.streetName = data.attributes.street_name;
-    this.streetType = data.attributes.street_type;
-    if (this.streetDirectionSuffix) {
-        this.streetType += " " + this.streetDirectionSuffix;
-    }
-    this.city = data.attributes.city;
-    this.jurisdiction = data.attributes.jurisdiction;
-    this.state = data.attributes.state ? data.attributes.state.toUpperCase() : "";
-    this.zipCode = data.attributes.zip_code;
-    this.lat = data.attributes.lat;
-    this.lon = data.attributes.lon;
-    this.x = data.location.x;
-    this.y = data.location.y;
-    this.unit = "";
+  // PortlandMaps sends incorrectly formatted address data if there is only 1 suggestion to return.
+  // If a singleton, the isSingleton flag will be true, and we'll do some kludgey string manipulation.
+  if (isSingleton) {
+    var arrAddress = data.address.split(', ');
+    data.address = arrAddress[0];
+  }
+  this.fullAddress = AddressVerifierModel.buildFullAddress(data.address, data.attributes.city, data.attributes.state, data.attributes.zip_code, data.unit).toUpperCase();
+  this.displayAddress = data.address.toUpperCase();// + ', ' + data.attributes.jurisdiction.toUpperCase();
+  this.street = data.address.toUpperCase();
+  this.streetNumber = data.attributes.address_number;
+  this.streetQuadrant = data.attributes.street_direction;
+  this.streetDirectionSuffix = data.attributes.street_direction_suffix ? data.attributes.street_direction_suffix.trim() : "";
+  this.streetName = data.attributes.street_name;
+  this.streetType = data.attributes.street_type;
+  if (this.streetDirectionSuffix) {
+    this.streetType += " " + this.streetDirectionSuffix;
+  }
+  this.city = data.attributes.city;
+  this.jurisdiction = data.attributes.jurisdiction;
+  this.state = data.attributes.state ? data.attributes.state.toUpperCase() : "";
+  this.zipCode = data.attributes.zip_code;
+  this.lat = data.attributes.lat;
+  this.lon = data.attributes.lon;
+  this.x = data.location.x;
+  this.y = data.location.y;
+  this.unit = "";
 }
 
 const REVERSE_GEOCODE_URL = 'https://www.portlandmaps.com/api/intersects/?geometry=%7B%20%22x%22:%20${x},%20%22y%22:%20${y},%20%22spatialReference%22:%20%7B%20%22wkid%22:%20%223857%22%7D%20%7D&include=all&detail=1&api_key=${apiKey}';
 
 function AddressVerifierModel(jQuery, element, apiKey) {
-    this.$ = jQuery;
-    this.element = element;
-    this.apiKey = apiKey;
-    this.intersectsLocation = null;
+  this.$ = jQuery;
+  this.element = element;
+  this.apiKey = apiKey;
+  this.intersectsLocation = null;
 }
 
 AddressVerifierModel.prototype.fetchAutocompleteItems = function (addrSearch, $element) {
@@ -87,54 +87,70 @@ AddressVerifierModel.prototype.fetchAutocompleteItems = function (addrSearch, $e
 };
 
 AddressVerifierModel.prototype._getSphericalMercCoords = function (lat, lon) {
-    // Radius of the Earth in meters
-    const R = 6378137;
+  // Radius of the Earth in meters
+  const R = 6378137;
 
-    // Convert the longitude from degrees to radians
-    const x = lon * (Math.PI / 180) * R;
+  // Convert the longitude from degrees to radians
+  const x = lon * (Math.PI / 180) * R;
 
-    // Convert the latitude from degrees to radians
-    const latRad = lat * (Math.PI / 180);
+  // Convert the latitude from degrees to radians
+  const latRad = lat * (Math.PI / 180);
 
-    // Calculate the y value using the Mercator projection formula
-    const y = R * Math.log(Math.tan((Math.PI / 4) + (latRad / 2)));
+  // Calculate the y value using the Mercator projection formula
+  const y = R * Math.log(Math.tan((Math.PI / 4) + (latRad / 2)));
 
-    return { x, y };
+  return { x, y };
 }
 
 AddressVerifierModel.locationItem.prototype.parseStreetData = function (street) {
-    // Assuming street is in the format "1234 NW Main St"
-    const streetParts = street.split(' ');
-    this.streetNumber = streetParts.shift();
-    this.streetQuadrant = streetParts.shift();
-    this.streetName = streetParts.join(' ');
+  // Assuming street is in the format "1234 NW Main St"
+  const streetParts = street.split(' ');
+  this.streetNumber = streetParts.shift();
+  this.streetQuadrant = streetParts.shift();
+  this.streetName = streetParts.join(' ');
 };
 
 // static functions
 
+AddressVerifierModel.logClientErrorToDrupal = function (errorMessage, fileName, lineNumber, stackTrace = '') {
+  fetch('/log-api-error', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': drupalSettings.ajaxPageState.csrfToken
+    },
+    body: JSON.stringify({
+      message: errorMessage,
+      file: fileName,
+      line: lineNumber,
+      stack: stackTrace
+    })
+  });
+}
+
 AddressVerifierModel.buildFullAddress = function (address, city, state, zip, unit = null) {
-    var fullAddress = address;
-    fullAddress += unit ? ", " + unit : "";
-    fullAddress += ", " + city + ", " + state + " " + zip;
-    return fullAddress;
+  var fullAddress = address;
+  fullAddress += unit ? ", " + unit : "";
+  fullAddress += ", " + city + ", " + state + " " + zip;
+  return fullAddress;
 }
 
 AddressVerifierModel.buildMailingLabel = function (item, $element, useHtml = false) {
-    var lineBreak = useHtml ? "<br>" : "\r\n";
-    var unit = $element.find('#unit_number').val();
-    var label = item.street;
-    if (item.unit) {
-        label += " " + unit.toUpperCase();
-    }
-    label += lineBreak + item.city + ", " + item.state + " " + item.zipCode;
-    return label;
+  var lineBreak = useHtml ? "<br>" : "\r\n";
+  var unit = $element.find('#unit_number').val();
+  var label = item.street;
+  if (item.unit) {
+    label += " " + unit.toUpperCase();
+  }
+  label += lineBreak + item.city + ", " + item.state + " " + item.zipCode;
+  return label;
 }
 
 AddressVerifierModel.prototype.updateLocationFromIntersects = function (lat, lon, item, callback, view) {
-    var xy = this._getSphericalMercCoords(lat, lon);
-    url = REVERSE_GEOCODE_URL;
-    url = url.replace('${x}', xy.x).replace('${y}', xy.y).replace('${apiKey}', this.apiKey);
-    // var self = this;
+  var xy = this._getSphericalMercCoords(lat, lon);
+  let url = REVERSE_GEOCODE_URL;
+  url = url.replace('${x}', xy.x).replace('${y}', xy.y).replace('${apiKey}', this.apiKey);
+  // var self = this;
 
     this.$.ajax({
         url: url, success: function (results, textStatus, jqXHR) {
@@ -166,9 +182,10 @@ AddressVerifierModel.prototype.updateLocationFromIntersects = function (lat, lon
 AddressVerifierModel.prototype.callSecondaryQuery = function (url, x, y, callback, view, capturePath, captureField, $) {
     url = url + "&geometry=" + x + "," + y;
     this.$.ajax({
-        url: url, success: function (response) {
-            if (textStatus == "success" && results.status && results.status == "success" && !view.settings.error_test) {
-                callback(response, view, capturePath, captureField, $);
+        url: url, success: function (results, textStatus, jqXHR) {
+            // some secondary queries return a status object, some do not, so check for the existence of results.status.
+            if (textStatus == "success" && (!results.status || results.status && results.status == "success" && !view.settings.error_test)) {
+                callback(results, view, capturePath, captureField, $);
             } else {
                 if (!self._serverError) {
                     view._showStatusModal(`<p>${SERVER_ERROR_MESSAGE}<br><br>Status: ${jqXHR?.status || 'Unknown'}`);
@@ -189,7 +206,30 @@ AddressVerifierModel.prototype.callSecondaryQuery = function (url, x, y, callbac
     });
 }
 
-AddressVerifierModel.getPropertyByPath = function (obj, path, parse = "stringify", omit_nulls = false) {
+AddressVerifierModel.getPropertyByPath = function (jsonObject, path) {
+    const keys = path.split('.');
+
+    return keys.reduce((obj, key) => {
+        // Automatically use the first element if the current object is an array
+        if (Array.isArray(obj)) {
+            obj = obj[0];
+        }
+
+        if (!obj) return undefined;
+        // Check if the key includes an array index, like 'features[0]'
+        const arrayIndexMatch = key.match(/(.+)\[(\d+)\]$/);
+
+        if (arrayIndexMatch) {
+            const arrayKey = arrayIndexMatch[1];
+            const index = parseInt(arrayIndexMatch[2], 10);
+            return obj[arrayKey] && obj[arrayKey][index] !== undefined ? obj[arrayKey][index] : undefined;
+        } else {
+            return obj[key] !== undefined ? obj[key] : undefined;
+        }
+    }, jsonObject);
+};
+
+AddressVerifierModel.getPropertyByPathNew = function (obj, path, parse = "stringify", omit_nulls = false) {
     const parts = path.split('.');
 
     function extract(o, keys) {

--- a/web/modules/custom/portland/modules/portland_webforms/portland_webforms.routing.yml
+++ b/web/modules/custom/portland/modules/portland_webforms/portland_webforms.routing.yml
@@ -19,3 +19,19 @@ webform_report_forms.csv:
     _title: 'Webform Report'
   requirements:
     _user_is_logged_in: 'TRUE'
+log_client_error:
+  path: '/log-api-error'
+  defaults:
+    _controller: '\Drupal\portland_webforms\Controller\ExternalApiErrorLoggerController::log'
+    _title: 'Client Error Logger'
+  methods: [POST]
+  requirements:
+    _access: 'TRUE'
+log_client_error_429:
+  path: '/log-api-error/test-429'
+  defaults:
+    _controller: '\Drupal\portland_webforms\Controller\ExternalApiErrorLoggerController::http429'
+    _title: 'Simulate 429'
+  methods: [GET]
+  requirements:
+    _access: 'TRUE'

--- a/web/modules/custom/portland/modules/portland_webforms/src/Controller/ExternalApiErrorLoggerController.php
+++ b/web/modules/custom/portland/modules/portland_webforms/src/Controller/ExternalApiErrorLoggerController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\portland_webforms\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Drupal\Core\Controller\ControllerBase;
+
+class ExternalApiErrorLoggerController extends ControllerBase
+{
+    public function log(Request $request)
+    {
+        $allowed_tlds = ['portland.gov', 'lndo.site'];
+
+        $origin = $request->headers->get('Origin') ?? $request->headers->get('Referer');
+        $origin_host = parse_url($origin, PHP_URL_HOST);
+
+        // Check if the host ends with any allowed TLD
+        $is_allowed = FALSE;
+        foreach ($allowed_tlds as $tld) {
+            if ($origin_host && str_ends_with($origin_host, $tld)) {
+                $is_allowed = TRUE;
+                break;
+            }
+        }
+
+        if (!$is_allowed) {
+            return new JsonResponse(['error' => 'Forbidden'], 403);
+        }
+
+        $data = json_decode($request->getContent(), TRUE);
+        if (!empty($data['message'])) {
+            \Drupal::logger('external_api')->error('API Error: @message in @file at line @line. Stack: @stack', [
+                '@message' => $data['message'],
+                '@file' => $data['file'] ?? 'unknown',
+                '@line' => $data['line'] ?? 'n/a',
+                '@stack' => $data['stack'] ?? '',
+            ]);
+        }
+
+        return new JsonResponse(['status' => 'logged']);
+    }
+
+    /**
+     * Simulated 429 response for testing. Use path /log-client-error/test-429.
+     */
+    public function http429()
+    {
+        return new Response('Simulated 429 Too Many Requests error', 429);
+    }
+}

--- a/web/modules/custom/portland/modules/portland_webforms/src/Plugin/WebformElement/PortlandNodeFetcher.php
+++ b/web/modules/custom/portland/modules/portland_webforms/src/Plugin/WebformElement/PortlandNodeFetcher.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\portland_webforms\Plugin\WebformElement;
+
+use Drupal\webform\Plugin\WebformElementBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Render\Markup;
+
+/**
+ * Provides a 'portland_node_fetcher' webform element.
+ *
+ * @WebformElement(
+ *   id = "portland_node_fetcher",
+ *   label = @Translation("Portland Node Fetcher"),
+ *   description = @Translation("Displays a configured node alias path."),
+ *   category = @Translation("Custom")
+ * )
+ */
+class PortlandNodeFetcher extends WebformElementBase
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function defineDefaultProperties(): array
+    {
+        return [
+            'node_alias_path' => '',
+        ] + parent::defineDefaultProperties();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildConfigurationForm(array $form, FormStateInterface $form_state): array
+    {
+        $form = parent::buildConfigurationForm($form, $form_state);
+        $element = $form_state->get('element');
+
+        // ✅ Pull the previously saved config from the full element array
+        $form['node_alias_path'] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('Node alias path'),
+            '#default_value' => $element['#node_alias_path'],
+            '#description' => $this->t('Enter a path like /about-us.'),
+            '#required' => TRUE,
+        ];
+        return $form;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void
+    {
+        parent::submitConfigurationForm($form, $form_state);
+
+        $user_input = $form_state->getUserInput();
+        if (isset($user_input['node_alias_path'])) {
+            $form_state->setValue('node_alias_path', $user_input['node_alias_path']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInfo(): array
+    {
+        return [
+            '#input' => FALSE,
+            '#markup' => '',
+            '#theme_wrappers' => ['container'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL)
+    {
+        $alias = $element['#node_alias_path'] ?? NULL;
+
+        if ($alias) {
+            $internal_path = \Drupal::service('path_alias.manager')->getPathByAlias($alias);
+            if (preg_match('/^\/node\/(\d+)$/', $internal_path, $matches)) {
+                $nid = $matches[1];
+                $node = Node::load($nid);
+                if ($node instanceof Node) {
+                    // Attach the node entity to the element for debugging or internal use.
+                    $element['#node'] = $node;
+
+                    // Flatten all field values and add them to temporary data.
+                    $values = [];
+                    foreach ($node->getFields() as $field_name => $field) {
+                        if ($field->count() === 1) {
+                            $values[$field_name] = $field->value;
+                        } else {
+                            $values[$field_name] = [];
+                            foreach ($field as $item) {
+                                $values[$field_name][] = $item->value;
+                            }
+                        }
+                    }
+
+                    $values['node_alias_path'] = $alias;
+
+                    // Add to submission data, available in Twig via `data.fetch_node`.
+                    if ($webform_submission) {
+                        $webform_submission->setData(['fetch_node' => $values] + $webform_submission->getData());
+                    }
+                }
+            }
+        }
+
+        // Suppress output in form.
+        $element['#markup'] = Markup::create('');
+
+        parent::prepare($element, $webform_submission);
+    }
+}

--- a/web/sites/default/config/core.entity_form_display.node.page.default.yml
+++ b/web/sites/default/config/core.entity_form_display.node.page.default.yml
@@ -326,6 +326,7 @@ content:
     weight: 18
     region: content
     settings:
+      geometry_validation: false
       map:
         leaflet_map: portlandmaps_color
         height: 400
@@ -366,6 +367,8 @@ content:
         control: false
         options: '{"position":"topleft","pseudoFullscreen":false}'
       path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"false","fillColor":"*","fillOpacity":"0","radius":"6"}'
+      feature_properties:
+        values: ''
       locate:
         control: false
         options: '{"position": "topright", "setView": "untilPanOrZoom", "returnToPrevBounds":true, "keepCurrentZoomLevel": true, "strings": {"title": "Locate my position"}}'
@@ -384,9 +387,6 @@ content:
           delay: 800
           zoom: 16
           options: ''
-      geometry_validation: false
-      feature_properties:
-        values: ''
     third_party_settings: {  }
   field_has_parent:
     type: boolean_checkbox
@@ -743,10 +743,10 @@ content:
             state: visible
             reset: false
             condition: value
-            grouping: AND
-            values_set: 1
+            grouping: OR
+            values_set: 3
             value: ''
-            values: {  }
+            values: "1032\r\n40"
             value_form:
               -
                 target_id: '1032'

--- a/web/sites/default/config/core.entity_view_display.node.content_fragment.default.yml
+++ b/web/sites/default/config/core.entity_view_display.node.content_fragment.default.yml
@@ -22,6 +22,11 @@ targetEntityType: node
 bundle: content_fragment
 mode: default
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_body_content:
     type: text_default
     label: hidden

--- a/web/sites/default/config/core.entity_view_display.node.content_fragment.teaser.yml
+++ b/web/sites/default/config/core.entity_view_display.node.content_fragment.teaser.yml
@@ -22,6 +22,11 @@ targetEntityType: node
 bundle: content_fragment
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   field_english_pronunciation:
     type: string
     label: visually_hidden

--- a/web/sites/default/config/field.field.node.page.field_webform.yml
+++ b/web/sites/default/config/field.field.node.page.field_webform.yml
@@ -16,7 +16,7 @@ field_name: field_webform
 entity_type: node
 bundle: page
 label: Webform
-description: "If a Portland.gov webform was created for this service, select it from the list below to embed it directly into the service page. If you're unsure, contact a member of the Website Support team at webforms@portlandoregon.gov for assistance."
+description: "If a Portland.gov webform was created for use with this service or guide, select it from the list below to embed it directly into the page. Guides don't typically have webforms, but there are some cases where they are used for their conditional logic, to guide users through decision trees. If you're unsure, contact a member of the Website Support team at webforms@portlandoregon.gov for assistance."
 required: false
 translatable: false
 default_value: {  }

--- a/web/sites/default/config/user.role.glossary_editor.yml
+++ b/web/sites/default/config/user.role.glossary_editor.yml
@@ -3,10 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.content_fragment_browser
     - node.type.content_fragment
     - workflows.workflow.editorial
   module:
     - content_moderation
+    - entity_browser
     - lightning_core
     - lightning_scheduler
     - node
@@ -19,6 +21,7 @@ label: 'Glossary Editor'
 weight: 5
 is_admin: null
 permissions:
+  - 'access content_fragment_browser entity browser pages'
   - 'clone content_fragment content'
   - 'clone own content_fragment content'
   - 'create content_fragment content'

--- a/web/sites/default/config/views.view.entity_browser_content_components.yml
+++ b/web/sites/default/config/views.view.entity_browser_content_components.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_body_content
     - node.type.content_fragment
     - taxonomy.vocabulary.content_fragment_type
+    - user.role.glossary_editor
   content:
     - 'taxonomy_term:content_fragment_type:d91385f3-c200-4a3b-b975-74cc7ad7326b'
   module:
@@ -512,9 +513,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: role
         options:
-          perm: 'access content'
+          role:
+            glossary_editor: glossary_editor
       cache:
         type: tag
         options: {  }
@@ -846,7 +848,7 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
+        - user.roles
       tags:
         - 'config:field.storage.node.field_body_content'
   entity_browser_1:
@@ -868,6 +870,6 @@ display:
         - url
         - url.query_args
         - 'user.node_grants:view'
-        - user.permissions
+        - user.roles
       tags:
         - 'config:field.storage.node.field_body_content'

--- a/web/sites/default/config/webform.webform.permit_wizard_residential_decks.yml
+++ b/web/sites/default/config/webform.webform.permit_wizard_residential_decks.yml
@@ -20,10 +20,12 @@ description: ''
 categories:
   - 'Permit Wizard'
 elements: |-
+  test:
+    '#type': hidden
+    '#title': 'Test mode'
   returning_user:
     '#type': hidden
     '#title': 'Returning User?'
-    '#prepopulate': true
   welcome_back:
     '#type': webform_section
     '#title': 'Welcome back!'
@@ -34,723 +36,842 @@ elements: |-
     '#attributes':
       class:
         - mb-10
+        - bg-info
+        - p-3
+    '#title_attributes':
+      class:
+        - mt-0
+        - mb-0
     markup_welcome_back:
       '#type': webform_markup
-      '#markup': '<p>Please review your previous answers and re-submit to view your project plan. If you change your responses and want an updated link, provide your email address again.</p>'
-  markup:
-    '#type': webform_markup
+      '#wrapper_attributes':
+        class:
+          - mb-0
+          - mt-1
+      '#markup': '<p class="mb-0">This guide was created based on project details you previously provided. If you need to make changes, use the "Edit project details" button at the bottom of the page.</p>'
+  container_project_details:
+    '#type': container
     '#states':
-      visible:
+      invisible:
         ':input[name="returning_user"]':
-          empty: true
-    '#markup': "<p>Share information about your project, and we'll give you a list of requirements needed by the City of Portland in order to get your permit.</p>"
-  section_location:
-    '#type': webform_section
-    '#title': Location
-    '#attributes':
-      class:
-        - mb-10
-    q1_project_address:
-      '#type': portland_address_verifier
-      '#title': Address
-      '#required': true
-      '#location_address__required': true
-      '#location_city__required': true
-      '#location_state__required': true
-      '#location_zip__required': true
-      '#find_unincorporated': 1
-      '#require_portland_city_limits': 1
-      '#not_verified_remedy': 'A verified address is required. Please try again.'
-      '#lookup_taxlot': 1
-      '#secondary_queries':
-        - api: 'https://www.portlandmaps.com/api/detail/'
-          api_args:
-            - detail_type: zoning
-            - sections: zoning
-            - geometry: '{"x":${x}, "y":${y}}'
-            - api_key: AC3208DDEFB2FD0AE5F26D573C27252F
-          capture:
-            - path: 'zoning.overlay[].code'
-              field: hidden_zoning_overlays
-              parse: stringify
-            - path: 'zoning.historic_district[].code'
-              field: hidden_historic_district
-              parse: stringify
-            - path: 'zoning.national_register_district[].code'
-              field: hidden_national_register_district
-              parse: stringify
-            - path: 'zoning.conservation_district[].code'
-              field: hidden_conservation_district
-              parse: stringify
-            - path: historic_resource
-              field: hidden_historic_resource
-              parse: flatten
-              omit_null_properties: true
-        - api: 'https://www.portlandmaps.com/api/detail/'
-          api_args:
-            - detail_type: environmental-percent-slope
-            - sections: general
-            - geometry: '{"x":${x}, "y":${y}}'
-            - api_key: AC3208DDEFB2FD0AE5F26D573C27252F
-          capture:
-            - path: general.percent_slope
-              field: hidden_percent_slope
-    hidden_zoning_overlays:
-      '#type': hidden
-      '#title': 'Hidden Zoning Overlays'
-    hidden_historic_district:
-      '#type': hidden
-      '#title': 'Hidden Historic District'
-    hidden_national_register_district:
-      '#type': hidden
-      '#title': 'Hidden National Register District'
-    hidden_conservation_district:
-      '#type': hidden
-      '#title': 'Hidden Conservation District'
-    hidden_historic_resource:
-      '#type': hidden
-      '#title': 'Hidden Historic Resource'
-    hidden_percent_slope:
-      '#type': hidden
-      '#title': 'Hidden Percent Slope'
-    markup_01:
-      '#type': webform_markup
+          filled: true
+        ':input[name="edit_my_project[Edit my project]"]':
+          unchecked: true
+    section_location:
+      '#type': webform_section
+      '#title': Location
+      '#attributes':
+        class:
+          - mb-10
+      q1_project_address:
+        '#type': portland_address_verifier
+        '#title': Address
+        '#required': true
+        '#location_address__required': true
+        '#location_city__required': true
+        '#location_state__required': true
+        '#location_zip__required': true
+        '#find_unincorporated': 1
+        '#require_portland_city_limits': 1
+        '#not_verified_remedy': 'A verified address is required. Please try again.'
+        '#lookup_taxlot': 1
+        '#secondary_queries':
+          - api: 'https://www.portlandmaps.com/api/detail/'
+            api_args:
+              - detail_type: zoning
+              - sections: zoning
+              - geometry: '{"x":${x}, "y":${y}}'
+              - api_key: AC3208DDEFB2FD0AE5F26D573C27252F
+            capture:
+              - path: 'zoning.overlay[].code'
+                field: hidden_zoning_overlays
+                parse: stringify
+              - path: 'zoning.historic_district[].code'
+                field: hidden_historic_district
+                parse: stringify
+              - path: 'zoning.national_register_district[].code'
+                field: hidden_national_register_district
+                parse: stringify
+              - path: 'zoning.conservation_district[].code'
+                field: hidden_conservation_district
+                parse: stringify
+              - path: historic_resource
+                field: hidden_historic_resource
+                parse: flatten
+                omit_null_properties: true
+          - api: 'https://www.portlandmaps.com/api/detail/'
+            api_args:
+              - detail_type: environmental-percent-slope
+              - sections: general
+              - geometry: '{"x":${x}, "y":${y}}'
+              - api_key: AC3208DDEFB2FD0AE5F26D573C27252F
+            capture:
+              - path: general.percent_slope
+                field: hidden_percent_slope
+      hidden_zoning_overlays:
+        '#type': hidden
+        '#title': 'Hidden Zoning Overlays'
+      hidden_historic_district:
+        '#type': hidden
+        '#title': 'Hidden Historic District'
+      hidden_national_register_district:
+        '#type': hidden
+        '#title': 'Hidden National Register District'
+      hidden_conservation_district:
+        '#type': hidden
+        '#title': 'Hidden Conservation District'
+      hidden_historic_resource:
+        '#type': hidden
+        '#title': 'Hidden Historic Resource'
+      hidden_percent_slope:
+        '#type': hidden
+        '#title': 'Hidden Percent Slope'
+      markup_01:
+        '#type': webform_markup
+        '#states':
+          visible:
+            ':input[name="q1_project_address[location_verification_status]"]':
+              empty: true
+            ':input[name="edit_my_project[Edit my project]"]':
+              unchecked: true
+        '#markup': '<p><strong>Please enter and verify a property address in Portland to begin.</strong></p>'
+      markup_02:
+        '#type': webform_markup
+        '#states':
+          visible:
+            ':input[name="q1_project_address[location_verification_status]"]':
+              empty: true
+            ':input[name="edit_my_project[Edit my project]"]':
+              checked: true
+        '#markup': '<p><strong>Please re-verify your address to continue.</strong></p>'
+    section_property_details:
+      '#type': webform_section
+      '#title': 'Property Details'
+      '#description': '<p><em>Information provided by </em><a href="https://portlandmaps.com" target="_blank"><em>PortlandMaps</em></a><em>.</em></p>'
+      '#states':
+        invisible:
+          ':input[name="q1_project_address[location_verification_status]"]':
+            empty: true
+      '#attributes':
+        class:
+          - mb-10
+      property_id:
+        '#type': webform_computed_twig
+        '#title': 'Property ID'
+        '#title_display': inline
+        '#display_on': form
+        '#template': |-
+          {{ data.q1_project_address.location_taxlot_id
+           }}
+        '#whitespace': trim
+        '#ajax': true
+      q1_1_environmental_overlay_zone:
+        '#type': webform_computed_twig
+        '#title': 'Is the site in an environmental overlay zone?'
+        '#title_display': inline
+        '#display_on': form
+        '#mode': text
+        '#template': |-
+          {% set value = data.hidden_zoning_overlays %}
+          {% if 'c' in value or 'p' in value %}Yes{% else %}No{% endif %}
+        '#whitespace': trim
+        '#ajax': true
+      q1_2_greenway_overlay_zone:
+        '#type': webform_computed_twig
+        '#title': 'Is the site in a greenway overlay zone?'
+        '#title_display': inline
+        '#display_on': form
+        '#mode': text
+        '#template': |-
+          {% set value = data.hidden_zoning_overlays %}
+          {% if 'g' in value  %}Yes{% else %}No{% endif %}
+        '#whitespace': trim
+        '#ajax': true
+      q1_3_historic_landmark:
+        '#type': webform_computed_twig
+        '#title': 'Is the property a historic/conservation landmark or in a historic district?'
+        '#title_display': inline
+        '#display_on': form
+        '#mode': text
+        '#template': '{% if data.hidden_historic_district != "" or data.hidden_national_register_district != "" or data.hidden_conservation_district != "" or data.hidden_historic_resource != "" %}Yes{% else %}No{% endif %}'
+        '#whitespace': trim
+        '#ajax': true
+      q4_project_deck_site_slope:
+        '#type': webform_computed_twig
+        '#title': 'What is the slope of the property?'
+        '#wrapper_attributes':
+          class:
+            - d-none
+        '#display_on': form
+        '#mode': text
+        '#template': '{{ data.hidden_percent_slope }}'
+        '#whitespace': trim
+        '#ajax': true
+      slope_display:
+        '#type': webform_computed_twig
+        '#title': 'What is the slope of the property?'
+        '#title_display': inline
+        '#display_on': form
+        '#template': '{{ data.hidden_percent_slope }}%'
+        '#ajax': true
+    section_project_details:
+      '#type': webform_section
+      '#title': 'Project Details'
+      '#states':
+        invisible:
+          ':input[name="q1_project_address[location_verification_status]"]':
+            empty: true
+      '#attributes':
+        class:
+          - mb-10
+      q2_project_deck_height:
+        '#type': number
+        '#title': 'How high off the ground is the highest point of the deck’s walking surface?'
+        '#description': '<p>Measure (in inches) 3 feet from where the perimeter of the deck will be.</p>'
+        '#description_display': before
+        '#field_suffix': inches
+        '#required': true
+      q3_project_deck_builder:
+        '#type': radios
+        '#title': 'Who will be doing the construction?'
+        '#options':
+          'The property owner': 'The property owner'
+          'A hired contractor': 'A hired contractor'
+        '#required': true
+        '#prepopulate': true
+      q5_project_deck_near_waterbody:
+        '#type': radios
+        '#title': 'Is there a wetland or body of water near the worksite?'
+        '#options': yes_no_not_sure
+        '#required': true
+      q6_project_waterbody_distance:
+        '#type': number
+        '#title': 'How far away is the wetland or body of water from the worksite?'
+        '#description': '<p>Enter the distance in feet.</p>'
+        '#field_suffix': feet
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="q5_project_deck_near_waterbody"]':
+              value: 'Yes'
+      q7_project_using_powered_machinery:
+        '#type': radios
+        '#title': 'Will your project temporarily disturb more than 500 square feet of the ground?'
+        '#options': yes_no_not_sure
+        '#required': true
+      q8_project_deck_single_level:
+        '#type': radios
+        '#title': 'Are you building a single-level deck?'
+        '#description': "<p>A single-level deck is one flat surface, usually connected to the house. If your deck will have multiple sections at different heights, it's not single-level.</p>"
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q9_project_deck_connected_to_house:
+        '#type': radios
+        '#title': 'Will the deck connect to the outside wall of the house?'
+        '#description': '<p>This means the deck will be physically attached to the house, not free-standing.</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+      q10_project_deck_finish:
+        '#type': radios
+        '#title': 'Will you add tile, concrete, or other finish materials on top of the deck?'
+        '#description': '<p>Some decks are designed to hold finish materials like tile or concrete. These materials add extra weight, so your deck may need special design or permits.</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q11_project_deck_rectangular:
+        '#type': radios
+        '#title': 'Will the deck be rectangular in shape?'
+        '#description': '<p>This means your deck is shaped like a rectangle — not an L-shape, hexagon, or something more complex.</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q12_project_deck_one_row_posts:
+        '#type': radios
+        '#title': 'Will the deck have just one row of posts supporting the outer edge?'
+        '#description': '<p>This means the joists (the boards under the deck that support the surface) run straight from the house to a single beam (a heavy board that rests on posts). This is called a single-span deck, and the joists may cantilever (stick out a little past the beam).</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q13_project_deck_heavy:
+        '#type': radios
+        '#title': 'Will the deck need to hold something very heavy, like a hot tub?'
+        '#description': '<p>Some decks need to support concentrated weight (heavy items in one spot), like hot tubs, large planters, or heavy grills. This affects how the deck must be built to stay safe and strong.</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+      q14_project_deck_manufactured_handrails:
+        '#type': radios
+        '#title': 'Will the deck have manufactured handrails made of glass, cable, aluminum, or steel?'
+        '#description': '<p>This refers to handrail systems that are pre-made by a company, often called proprietary handrails.</p>'
+        '#description_display': before
+        '#prepopulate': true
+        '#options': yes_no_not_sure
+        '#required': true
+      q15_project_large_impervious_surface:
+        '#type': radios
+        '#title': 'Will the project add more than 1,000 square feet of impervious surface?'
+        '#description': '<p>Impervious surfaces are things like concrete, asphalt, or decks that stop water from soaking into the ground. We use this to understand how your project affects rainwater drainage.</p>'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+      q16_project_deck_has_roof:
+        '#type': radios
+        '#title': 'Will the deck have a solid, covered roof?'
+        '#description_display': before
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q17_project_deck_roof_over_200_sqft:
+        '#type': radios
+        '#title': 'Will the solid, covered roof be more than 200 square feet?'
+        '#description_display': before
+        '#prepopulate': true
+        '#options': yes_no_not_sure
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="q16_project_deck_has_roof"]':
+              value: 'Yes'
+      q18_project_septic_on_property:
+        '#type': radios
+        '#title': 'Is there a septic system or cesspool on the property?'
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q19_project_deck_septic_distance:
+        '#type': number
+        '#title': 'How far is the septic system or cesspool from the deck?'
+        '#description': '<p>Enter the distance (in feet) that the septic system or cesspool is away from the deck.</p>'
+        '#description_display': before
+        '#field_suffix': feet
+        '#prepopulate': true
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="q18_project_septic_on_property"]':
+              value: 'Yes'
+      q20_project_deck_large_trees:
+        '#type': radios
+        '#title': 'Are there trees measuring more than 8” in diameter near the worksite?'
+        '#options': yes_no_not_sure
+        '#required': true
+        '#prepopulate': true
+      q21_project_deck_trees_distance:
+        '#type': number
+        '#title': 'How far are the trees from the worksite?'
+        '#description': '<p>Enter the distance (in feet) that the trees are away from the project.</p>'
+        '#description_display': before
+        '#field_suffix': feet
+        '#prepopulate': true
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="q20_project_deck_large_trees"]':
+              value: 'Yes'
+      q22_project_deck_trees_near_row:
+        '#type': radios
+        '#title': 'Do any of these trees come close to a public right-of-way?'
+        '#description': '<p>Public right-of-way are things like sidewalks, planting strips, road shoulders, street medians, alleys, etc.</p>'
+        '#description_display': before
+        '#prepopulate': true
+        '#options': yes_no_not_sure
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="q20_project_deck_large_trees"]':
+              value: 'Yes'
+    section_send_link:
+      '#type': webform_section
+      '#title': 'Send a link?'
+      '#description': "<p>If you'd like us to send a link back to this project, please provide an email address. It will only be used to send this one email and won't be used for any other purpose.</p>"
       '#states':
         visible:
           ':input[name="q1_project_address[location_verification_status]"]':
-            empty: true
-      '#markup': '<p><strong>Please enter and verify a property address in Portland to begin.</strong></p>'
-  section_property_details:
-    '#type': webform_section
-    '#title': 'Property Details'
-    '#description': '<p><em>Information provided by </em><a href="https://portlandmaps.com" target="_blank"><em>PortlandMaps</em></a><em>.</em></p>'
-    '#states':
-      invisible:
-        ':input[name="q1_project_address[location_verification_status]"]':
-          empty: true
-    '#attributes':
-      class:
-        - mb-10
-    property_id:
-      '#type': webform_computed_twig
-      '#title': 'Property ID'
-      '#title_display': inline
-      '#display_on': form
-      '#template': |-
-        {{ data.q1_project_address.location_taxlot_id
-         }}
-      '#whitespace': trim
-      '#ajax': true
-    q1_1_environmental_overlay_zone:
-      '#type': webform_computed_twig
-      '#title': 'Is the site in an environmental overlay zone?'
-      '#title_display': inline
-      '#display_on': form
-      '#mode': text
-      '#template': |-
-        {% set value = data.hidden_zoning_overlays %}
-        {% if 'c' in value or 'p' in value %}Yes{% else %}No{% endif %}
-      '#whitespace': trim
-      '#ajax': true
-    q1_2_greenway_overlay_zone:
-      '#type': webform_computed_twig
-      '#title': 'Is the site in a greenway overlay zone?'
-      '#title_display': inline
-      '#display_on': form
-      '#mode': text
-      '#template': |-
-        {% set value = data.hidden_zoning_overlays %}
-        {% if 'g' in value  %}Yes{% else %}No{% endif %}
-      '#whitespace': trim
-      '#ajax': true
-    q1_3_historic_landmark:
-      '#type': webform_computed_twig
-      '#title': 'Is the property a historic/conservation landmark or in a historic district?'
-      '#title_display': inline
-      '#display_on': form
-      '#mode': text
-      '#template': '{% if data.hidden_historic_district != "" or data.hidden_national_register_district != "" or data.hidden_conservation_district != "" or data.hidden_historic_resource != "" %}Yes{% else %}No{% endif %}'
-      '#whitespace': trim
-      '#ajax': true
-    q4_project_deck_site_slope:
-      '#type': webform_computed_twig
-      '#title': 'What is the slope of the property?'
-      '#wrapper_attributes':
+            filled: true
+      '#attributes':
         class:
-          - d-none
-      '#display_on': form
-      '#mode': text
-      '#template': '{{ data.hidden_percent_slope }}'
-      '#whitespace': trim
-      '#ajax': true
-    slope_display:
-      '#type': webform_computed_twig
-      '#title': 'What is the slope of the property?'
-      '#title_display': inline
-      '#display_on': form
-      '#template': '{{ data.hidden_percent_slope }}%'
-      '#ajax': true
-  section_project_details:
-    '#type': webform_section
-    '#title': 'Project Details'
-    '#states':
-      invisible:
-        ':input[name="q1_project_address[location_verification_status]"]':
-          empty: true
-    '#attributes':
-      class:
-        - mb-10
-    q2_project_deck_height:
-      '#type': number
-      '#title': 'How high off the ground will the deck be at its highest edge?'
-      '#description': '<p>Measure (in inches) from the ground next to the deck — where the drop is biggest. This is called “adjacent grade.” If your yard slopes, use the lowest point next to the edge of the deck.</p>'
-      '#description_display': before
-      '#field_suffix': inches
-      '#required': true
-      '#prepopulate': true
-    q3_project_deck_builder:
-      '#type': radios
-      '#title': 'Who will be doing the construction?'
-      '#options':
-        'The property owner': 'The property owner'
-        'A hired contractor': 'A hired contractor'
-      '#required': true
-      '#prepopulate': true
-    q5_project_deck_near_waterbody:
-      '#type': radios
-      '#title': 'Is there a wetland or waterbody near the worksite?'
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q6_project_waterbody_distance:
-      '#type': number
-      '#title': 'How far away is the wetland or waterbody from the worksite?'
-      '#description': '<p>Enter the distance (in feet) of the wetland or water body from the worksite.</p>'
-      '#field_suffix': feet
-      '#prepopulate': true
-      '#required': true
-      '#states':
-        visible:
-          ':input[name="q5_project_deck_near_waterbody"]':
-            value: 'Yes'
-    q7_project_using_powered_machinery:
-      '#type': radios
-      '#title': 'Will you be using powered machinery to disturb the ground?'
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q8_project_deck_single_level:
-      '#type': radios
-      '#title': 'Are you building a single-level deck?'
-      '#description': "<p>A single-level deck is one flat surface, usually connected to the house. If your deck will have multiple sections at different heights, it's not single-level.</p>"
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q9_project_deck_connected_to_house:
-      '#type': radios
-      '#title': 'Will the deck connect to the outside wall of the house?'
-      '#description': '<p>This means the deck will be physically attached to the house, not free-standing. It helps determine what kind of permit or inspection might be needed.</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q10_project_deck_finish:
-      '#type': radios
-      '#title': 'Will you add tile, concrete, or other finish materials on top of the deck?'
-      '#description': '<p>Some decks are designed to hold finish materials like tile or concrete. These materials add extra weight, so your deck may need special design or permits.</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q11_project_deck_rectangular:
-      '#type': radios
-      '#title': 'Will the deck be rectangular in shape?'
-      '#description': '<p>This means your deck is shaped like a rectangle — not an L-shape, hexagon, or something more complex.</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q12_project_deck_one_row_posts:
-      '#type': radios
-      '#title': 'Will the deck have just one row of posts supporting the outer edge?'
-      '#description': '<p>This means the joists (the boards under the deck that support the surface) run straight from the house to a single beam (a heavy board that rests on posts). This is called a single-span deck, and the joists may cantilever (stick out a little past the beam).</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q13_project_deck_heavy:
-      '#type': radios
-      '#title': 'Will the deck need to hold something very heavy, like a hot tub?'
-      '#description': '<p>Will the deck need to hold something very heavy, like a hot tub?</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q14_project_deck_manufactured_handrails:
-      '#type': radios
-      '#title': 'Will the deck have manufactured handrails made of glass, cable, aluminum, or steel?'
-      '#description': '<p>This refers to handrail systems that are pre-made by a company, often called proprietary handrails.</p>'
-      '#description_display': before
-      '#prepopulate': true
-      '#options': yes_no_not_sure
-      '#required': true
-    q15_project_large_impervious_surface:
-      '#type': radios
-      '#title': 'Will the project add more than 500 square feet of impervious surface?'
-      '#description': '<p>Impervious surfaces are things like concrete, asphalt, or decks that stop water from soaking into the ground. We use this to understand how your project affects rainwater drainage.</p>'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q16_project_deck_has_roof:
-      '#type': radios
-      '#title': 'Will the deck have a solid, covered roof?'
-      '#description_display': before
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q17_project_deck_roof_over_200_sqft:
-      '#type': radios
-      '#title': 'Will the solid, covered roof be more than 200 square feet?'
-      '#description_display': before
-      '#prepopulate': true
-      '#options': yes_no_not_sure
-      '#required': true
-      '#states':
-        visible:
-          ':input[name="q16_project_deck_has_roof"]':
-            value: 'Yes'
-    q18_project_septic_on_property:
-      '#type': radios
-      '#title': 'Is there a septic system or cesspool on the property?'
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q19_project_deck_septic_distance:
-      '#type': number
-      '#title': 'How far is the septic system or cesspool from the deck?'
-      '#description': '<p>Enter the distance (in feet) that the septic system or cesspool is away from the deck.</p>'
-      '#description_display': before
-      '#field_suffix': feet
-      '#prepopulate': true
-      '#required': true
-      '#states':
-        visible:
-          ':input[name="q18_project_septic_on_property"]':
-            value: 'Yes'
-    q20_project_deck_large_trees:
-      '#type': radios
-      '#title': 'Are there trees measuring more than 8” in diameter near the worksite?'
-      '#options': yes_no_not_sure
-      '#required': true
-      '#prepopulate': true
-    q21_project_deck_trees_distance:
-      '#type': number
-      '#title': 'How far are the trees from the worksite?'
-      '#description': '<p>Enter the distance (in feet) that the trees are away from the project.</p>'
-      '#description_display': before
-      '#field_suffix': feet
-      '#prepopulate': true
-      '#required': true
-      '#states':
-        visible:
-          ':input[name="q20_project_deck_large_trees"]':
-            value: 'Yes'
-    q22_project_deck_trees_near_row:
-      '#type': radios
-      '#title': 'Do any of these trees come close to a public right-of-way?'
-      '#description': '<p>Public right-of-way are things like sidewalks, planting strips, road shoulders, street medians, alleys, etc.</p>'
-      '#description_display': before
-      '#prepopulate': true
-      '#options': yes_no_not_sure
-      '#required': true
-      '#states':
-        visible:
-          ':input[name="q20_project_deck_large_trees"]':
-            value: 'Yes'
-  section_send_link:
-    '#type': webform_section
-    '#title': 'Send a link?'
-    '#description': "<p>If you'd like us to send a link back to this project, please provide an email address. It will only be stored long enough to send this one email and won't be used for any other purpose.</p>"
-    '#states':
-      visible:
-        ':input[name="q1_project_address[location_verification_status]"]':
-          filled: true
-    '#attributes':
-      class:
-        - mb-10
-    email_address_optional:
-      '#type': textfield
-      '#title': 'Email address (optional)'
-  computed_results:
-    '#type': webform_computed_twig
-    '#title': 'Computed Results'
-    '#title_display': none
-    '#display_on': none
-    '#mode': html
-    '#template': |-
-      <h3>Your permitting plan</h3>
-      <p>We've created a plan to help you follow the City of Portland's building rules based on the details you provided about your project.</p>
-      <hr>
-
-      <ol class="process-list">
-        <!--<li>
-          <h4>Review your project details</h4>
-          <p>To make sure you have all the required information gathered and prepared, you may want to consider scheduling some free 15 minute appointments. These appointments aren't required but are helpful if you have open questions.</p>
-          
-          <div class="text-body rounded border border-3 p-5 clearfix">
-            <h4 style="float: left;">Zoning</h4>
-            <p style="float: right;"><a aria-label="Schedule a 15 minute appointment about zoning" href="#" class="btn btn-primary rounded rounded-1">Schedule</a></p>
-            <p style="clear: left; float: left;">Covers property use, building height, and setbacks.</p>
-            <div style="clear: both;" class="alert alert-info text-body mt-8 mb-0 border-top-0 border-end-0 border-bottom-0 border-info border-5">
-              <p>Your deck may affect setbacks, height limits, or lot coverage. It's a good idea to talk with <strong>Zoning</strong> to confirm that your project complies with property use and building placement rules.</p>
-            </div>
-          </div>    
-        </li>-->
-
-        <li>
-          <h4>Gather Requirements</h4>
-          <p>You'll need to complete these forms, waivers, and other requirements to get a permit. Additional forms or waivers may be needed depending on the type of project, but this is the starting point:</p>
-          
-          {% if data.q2_project_deck_height > 30 %}
-          <!-- Building permit application -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Building permit application</h4>
-            <p style="float: right;"><a aria-label="Download building permit application" href="/ppd/documents/building-permit-application-building-site-development-demolition-and-zoning-permits/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Used to get approval to build or change a structure by sharing details about the project and ensuring it meets safety and construction codes.</p>
-          </div>
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Site plan</h4>
-            <p style="float: right;"><a aria-label="Download site plan template" href="/ppd/documents/sample-site-plan/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Shows where your project will go on the property and verifies that it meets zoning and tree preservation rules. </p>
-          </div>
-          {% endif %}
-          
-          {% if (data.q8_project_deck_single_level == "Yes" or data.q8_project_deck_single_level == "Not sure") and 
-             (data.q9_project_deck_connected_to_house == "Yes" or data.q9_project_deck_connected_to_house == "Not sure") and 
-             (data.q10_project_deck_finish == "No" or data.q10_project_deck_finish == "Not sure") and 
-             (data.q11_project_deck_rectangular == "Yes" or data.q11_project_deck_rectangular == "Not sure") and 
-             (data.q12_project_deck_one_row_posts == "Yes" or data.q12_project_deck_one_row_posts == "Not sure") and 
-             (data.q13_project_deck_heavy == "No" or data.q13_project_deck_heavy == "Not sure") %}
-          <!-- (Pre-Approved) Residential Deck Plans -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> (Pre-approved) residential deck plans</h4>
-            <p style="float: right;"><a aria-label="Download pre-approved residential deck plans" href="/bcd/permit-services/Documents/permit-ready-deck.pdf" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Used to show how a structure will be built and confirm that the design meets building and safety codes.
-            {% if data.q14_project_deck_manufactured_handrails == "Yes" %}
-            <br><br><strong>NOTE:</strong> Since the deck has handrails made of glass, cable, aluminum, or steel, you must also provide stamped structural drawings for the handrail and its attachment at the base to the structure along with the permit ready drawings.</p>
-            {% endif %}
-            {% if (data.q8_project_deck_single_level == "Not sure") or 
-              (data.q9_project_deck_connected_to_house == "Not sure") or 
-              (data.q10_project_deck_finish == "Not sure") or 
-              (data.q11_project_deck_rectangular == "Not sure") or 
-              (data.q12_project_deck_one_row_posts == "Not sure") or 
-              (data.q13_project_deck_heavy == "Not sure") %}
-              <p style="clear: left; float: left;" class="mt-5 mb-0"><strong>NOTE:</strong> You answered "Not sure" on one or more question, so you may not be able to use a pre-approved deck plan.</p>
-             {% endif %}
-          </div>
-          {% endif %}
-          
-          {% if (data.q7_project_using_powered_machinery == "Yes" or data.q7_project_using_powered_machinery == "Not sure") and data.q4_project_deck_site_slope < 10 and data.q1_1_environmental_overlay_zone == "No" and data.q1_2_greenway_overlay_zone == "No" and (data.q5_project_deck_near_waterbody == "No" or data.q5_project_deck_near_waterbody == "Not sure" or data.q6_project_waterbody_distance > 50) %}
-          <!-- Simple Site Erosion Control Plan -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Simple site erosion control plan</h4>
-            <p style="float: right;"><a aria-label="Download simple site erosion control plan template" href="/ppd/documents/simple-site-plan-erosion-control-requirements-form/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Explains how you'll manage erosion and rain runoff on small, low-risk sites where soil will be disturbed.</p>
-            {% if data.q5_project_deck_near_waterbody == "Not sure" or data.q7_project_using_powered_machinery == "Not sure" %}
-              <p style="clear: left; float: left;" class="mt-5 mb-0"><strong>NOTE:</strong> You answered "Not sure" on one or more question, so you may need the submit a full <a href="/ppd/documents/plan-review-checklist-erosion-sediment-and-pollution-controls-residential-and/download">erosion control plan</a>.</p>
-             {% endif %}
-          </div>
-          {% endif %}
-          
-          {% if data.q15_project_large_impervious_surface == "Yes" %}
-          <!-- Stormwater Mitigation Plan -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Stormwater mitigation plan</h4>
-            <p style="float: right;"><a aria-label="Download stormwater mitigation plan template" href="/ppd/documents/simple-site-plan-erosion-control-requirements-form/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Explains how you'll manage rain runoff from new roofs or hard surfaces that don't absorb water.</p>
-          </div>
-          {% endif %}
-          
-          {% if data.q8_project_deck_single_level == "No" or data.q9_project_deck_connected_to_house == "No" or data.q10_project_deck_finish == "Yes" or data.q11_project_deck_rectangular == "No" or data.q12_project_deck_one_row_posts == "No" or data.q13_project_deck_heavy == "Yes" %}
-          <!-- Residential Deck Plans -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Residential deck plans</h4>
-            <p style="float: right;"><a aria-label="Download residential deck plan template" href="#" class="btn btn-primary rounded rounded-1">Download NEED LINK</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Used to show how a structure will be built and confirm that the design meets building and safety codes.</p>
-          </div>
-          {% endif %}
-          
-          {% if data.q3_project_deck_builder == "The property owner" %}
-          <!-- “Owner doing work” form -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> "Owner doing work" form</h4>
-            <p style="float: right;"><a aria-label="Download owner doing work form" href="/ppd/documents/owner-doing-work-form-information-notice-owners-about-construction-responsibilities/download" class="btn btn-primary rounded rounded-1">Download NEED LINK</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Used to confirm that a property owner understands the rules when doing construction work themselves instead of hiring a licensed contractor.</p>
-          </div>
-          {% endif %}
-          
-          {% if (data.q7_project_using_powered_machinery == "Yes") and (data.q4_project_deck_site_slope >= 10 or data.q1_1_environmental_overlay_zone == "Yes" or data.q1_2_greenway_overlay_zone == "Yes" or (data.q5_project_deck_near_waterbody == "Yes" and data.q6_project_waterbody_distance < 50)) %}
-          <!-- Erosion control plan -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Erosion control plan</h4>
-            <p style="float: right;"><a aria-label="Download erosion control plan template" href="/ppd/documents/plan-review-checklist-erosion-sediment-and-pollution-controls-residential-and/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Shows how you'll prevent erosion during construction on steep, sensitive, or environmentally protected sites.</p>
-          </div>
-          {% endif %}
-          
-          {% if data.q18_project_septic_on_property == "Yes" or data.q18_project_septic_on_property == "Not sure" %}
-          <!-- Disclaimer for existing on-site sewage system -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Disclaimer for existing on-site sewage system</h4>
-            <p style="float: right;"><a aria-label="Download disclaimer for existing on-site sewage systems" href="/ppd/documents/disclaimer-existing-site-sewage-disposal-system/download" class="btn btn-primary rounded rounded-1">Download</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Confirms whether the property has a septic system or cesspool and notifies the city if it needs to be decommissioned.</p>
-            {% if data.q18_project_septic_on_property == "Not sure" %}
-              <p style="clear: left; float: left;" class="mt-5 mb-0"><strong>NOTE:</strong> You answered "Not sure" whether there is a septic system or cesspool on the property. If there is, you will need to submit this item.</p>
-             {% endif %}
-          </div>
-          {% endif %}
-          
-          {% if data.q1_3_historic_landmark == "Yes" or data.q1_1_environmental_overlay_zone == "Yes" %}
-          <!-- Land use review application -->
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Land use review application</h4>
-            <p style="float: right;"><a aria-label="Download land use review application" href="#" class="btn btn-primary rounded rounded-1">Schedule</a></p>
-            <p style="clear: left; float: left;" class="mb-0">Used to request approval for projects that may affect zoning, environmental standards, or the appearance of historic sites. Requires a 15 minute appointment.</p>
-          </div>
-          {% endif %}
-          
-        </li>
-
-        <!--<li>
-          <h4>Gather other requirements</h4>
-          <p>You'll need to fill out these forms to get a permit. After your conversations in Step 1, you may need to provide additional forms or waivers based on the details of your project:</p>
-          
-          <div class="text-body rounded border border-3 p-5 clearfix mb-4">
-            <h4 style="float: left;"><i class="fa-solid fa-file-pdf"></i> Site plan</h4>
-            <p style="float: right;"><a aria-label="Learn more about site plans" href="#" class="btn btn-outline-primary rounded rounded-1 border-2">Learn <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
-            <p style="clear: left; float: left;" class="mb-0">Shows where your project will go on the property and verifies that it meets zoning rules.</p>
-          </div>
-        </li>-->
-
-        <li>
-          <h4>Submit your application</h4>
-          <p>You'll need to fill out these forms to get a permit. After your conversations in Step 1, you may need to provide additional forms or waivers based on the details of your project:</p>
-          <p class="mb-0"><a aria-label="Submit permit application requirements" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">Submit requirements</a>
-            <a aria-label="Learn more about submitting permit requirements" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">Learn <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
-        </li>
-
-        <li>
-          <h4>Check your application status</h4>
-          <p>When you apply for a permit, it goes through various departments where it's reviewed by different specialists. You will want to check frequently to know if there are adjustments you need to make or where it is in the overall process.</p>
-          <p class="mb-0"><a aria-label="Check permit status" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">Check status</a>
-            <a aria-label="Learn more about checking permit status" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">Learn <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
-        </li>
-
-        <li>
-          <h4>Get your permit and start building!</h4>
-          <p>Once approved, you can start your project. Follow the permit rules and schedule inspections as needed.</p>
-        </li>
-
-        <li>
-          <h4>Schedule inspections</h4>
-          <p>After your project is complete, you can schedule inspections. Your permit allows for 3 inspections &#151; extra inspections will cost more.</p>
-          <p class="mb-0"><a aria-label="Schedule inspection" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">Schedule inspection</a>
-            <a aria-label="Learn more about scheduling an inspection" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">Learn <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
-        </li>
-
-      </ul>
-
-      <hr>
-
-      <h3>Your project details</h3>
-
-      <table>
-        <tr class="">
-          <th>Project type:</th>
-          <td>Residential deck</td>
-        </tr>
-
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Location:</th>
-          <td>{{ data.q1_project_address.location_address }}</td>
-        </tr>
-
-      {% if data.q1_1_environmental_overlay_zone != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Environmental overlay zone?</th>
-          <td>{{ data.q1_1_environmental_overlay_zone }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q1_2_greenway_overlay_zone != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Greenway overlay zone?</th>
-          <td>{{ data.q1_2_greenway_overlay_zone }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q1_3_historic_landmark != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Historic/conservation landmark or district?</th>
-          <td>{{ data.q1_3_historic_landmark }}</td>
-        </tr>
-      {% endif %}
-
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Who is doing the work?</th>
-          <td>{{ data.q3_project_deck_builder }}</td>
-        </tr>
-
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Deck height:</th>
-          <td>{{ data.q2_project_deck_height }} ft</td>
-        </tr>
-
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Site slope:</th>
-          <td>{{ data.q4_project_deck_site_slope }}%</td>
-        </tr>
-
-      {% if data.q5_project_deck_near_waterbody != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Near wetland or waterbody?</th>
-          <td>{{ data.q5_project_deck_near_waterbody }}</td>
-        </tr>
-        {% if data.q6_project_waterbody_distance != "No" %}
-        <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
-          <th class="ps-5">Distance:</th>
-          <td>{{ data.q6_project_waterbody_distance }} feet</td>
-        </tr>
-        {% endif %}
-      {% endif %}
-
-      {% if data.q7_project_using_powered_machinery != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Using powered machinery to disturb the ground?</th>
-          <td>{{ data.q7_project_using_powered_machinery }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q8_project_deck_single_level != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Single level deck?</th>
-          <td>{{ data.q8_project_deck_single_level }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q9_project_deck_connected_to_house != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Connected to outside wall of house?</th>
-          <td>{{ data.q9_project_deck_connected_to_house }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q10_project_deck_finish != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Tile, concrete, or other finish materials on deck?</th>
-          <td>{{ data.q10_project_deck_finish }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q11_project_deck_rectangular != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Rectangular in shape?</th>
-          <td>{{ data.q11_project_deck_rectangular }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q12_project_deck_one_row_posts != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>One row of posts supporting outer edge?</th>
-          <td>{{ data.q12_project_deck_one_row_posts }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q13_project_deck_heavy != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Heavy weight bearing, such as hot tub?</th>
-          <td>{{ data.q13_project_deck_heavy }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q14_project_deck_manufactured_handrails != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Manufactured handrails?</th>
-          <td>{{ data.q14_project_deck_manufactured_handrails }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q15_project_large_impervious_surface != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>More than 500 sq ft impervious surface?</th>
-          <td>{{ data.q15_project_large_impervious_surface }}</td>
-        </tr>
-      {% endif %}
-
-      {% if data.q16_project_deck_has_roof != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Solid, covered roof?</th>
-          <td>{{ data.q16_project_deck_has_roof }}</td>
-        </tr>
-
-        {% if data.q17_project_deck_roof_over_200_sqft != "No" %}
-        <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
-          <th class="ps-5">More than 200 sq ft?</th>
-          <td>{{ data.q17_project_deck_roof_over_200_sqft }}</td>
-        </tr>
-        {% endif %}
-      {% endif %}
-
-      {% if data.q18_project_septic_on_property != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Septic system or cesspool on property?</th>
-          <td>{{ data.q18_project_septic_on_property }}</td>
-        </tr>
-        {% if data.q19_project_deck_septic_distance %}
-        <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
-          <th class="ps-5">Distance:</th>
-          <td>{{ data.q19_project_deck_septic_distance }} feet</td>
-        </tr>
-        {% endif %}
-      {% endif %}
-
-      {% if data.q20_project_deck_large_trees != "No" %}
-        <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
-          <th>Trees larger than 8" diameter near worksite?</th>
-          <td>{{ data.q20_project_deck_large_trees }}</td>
-        </tr>
-        {% if data.q21_project_deck_trees_distance %}
-        <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
-          <th class="ps-5">Distance:</th>
-          <td>{{ data.q21_project_deck_trees_distance }} feet</td>
-        </tr>
-        {% endif %}
-        {% if data.q22_project_deck_trees_near_row %}
-        <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
-          <th class="ps-5">Trees near public right-of-way?</th>
-          <td>{{ data.q22_project_deck_trees_near_row }}</td>
-        </tr>
-        {% endif %}
-      {% endif %}
-
-      </table>
-    '#whitespace': spaceless
+          - mb-10
+      email_address_optional:
+        '#type': textfield
+        '#title': 'Email address (optional)'
   return_link:
     '#type': webform_computed_twig
     '#title': 'Return Link'
     '#display_on': none
-    '#template': "https://{{ webform_token('[site:url-brief]', webform_submission, [], options) }}{{ webform_token('[current-page:url:path]', webform_submission, [], options) }}?returning_user=1&q1_project_address[location_address]={{ data.q1_project_address.location_address }}&q1_project_address[location_city]={{ data.q1_project_address.location_city }}&q1_project_address[location_state]={{ data.q1_project_address.location_state }}&q1_project_address[location_zip]={{ data.q1_project_address.location_zip }}&q1_1_environmental_overlay_zone={{ data.q1_1_environmental_overlay_zone }}&q1_2_greenway_overlay_zone={{ data.q1_2_greenway_overlay_zone }}&q1_3_historic_landmark={{ data.q1_3_historic_landmark }}&q2_project_deck_height={{ data.q2_project_deck_height }}&q3_project_deck_builder={{ data.q3_project_deck_builder }}&q4_project_deck_site_slope={{ data.q4_project_deck_site_slope }}&q5_project_deck_near_waterbody={{ data.q5_project_deck_near_waterbody }}&q6_project_waterbody_distance={{ data.q6_project_waterbody_distance }}&q7_project_using_powered_machinery={{ data.q7_project_using_powered_machinery }}&q8_project_deck_single_level={{ data.q8_project_deck_single_level }}&q9_project_deck_connected_to_house={{ data.q9_project_deck_connected_to_house }}&q10_project_deck_finish={{ data.q10_project_deck_finish }}&q11_project_deck_rectangular={{ data.q11_project_deck_rectangular }}&q12_project_deck_one_row_posts={{ data.q12_project_deck_one_row_posts }}&q13_project_deck_heavy={{ data.q13_project_deck_heavy }}&q14_project_deck_manufactured_handrails={{ data.q14_project_deck_manufactured_handrails }}&q15_project_large_impervious_surface={{ data.q15_project_large_impervious_surface }}&q16_project_deck_has_roof={{ data.q16_project_deck_has_roof }}&q17_project_deck_roof_over_200_sqft={{ data.q17_project_deck_roof_over_200_sqft }}&q18_project_septic_on_property={{ data.q18_project_septic_on_property }}&q19_project_deck_septic_distance={{ data.q19_project_deck_septic_distance }}&q20_project_deck_large_trees={{ data.q20_project_deck_large_trees }}&q21_project_deck_trees_distance={{ data.q21_project_deck_trees_distance }}&q22_project_deck_trees_near_row={{ data.q22_project_deck_trees_near_row }}"
+    '#template': "https://{{ webform_token('[site:url-brief]', webform_submission, [], options) }}{{ webform_token('[current-page:url:path]', webform_submission, [], options) }}?returning_user=1&q1_project_address[location_address]={{ data.q1_project_address.location_address }}&q1_project_address[location_city]={{ data.q1_project_address.location_city }}&q1_project_address[location_state]={{ data.q1_project_address.location_state }}&q1_project_address[location_zip]={{ data.q1_project_address.location_zip }}&q1_1_environmental_overlay_zone={{ data.q1_1_environmental_overlay_zone }}&q1_2_greenway_overlay_zone={{ data.q1_2_greenway_overlay_zone }}&q1_3_historic_landmark={{ data.q1_3_historic_landmark }}&q2_project_deck_height={{ data.q2_project_deck_height }}&q3_project_deck_builder={{ data.q3_project_deck_builder }}&q4_project_deck_site_slope={{ data.q4_project_deck_site_slope }}&q5_project_deck_near_waterbody={{ data.q5_project_deck_near_waterbody }}&q6_project_waterbody_distance={{ data.q6_project_waterbody_distance }}&q7_project_using_powered_machinery={{ data.q7_project_using_powered_machinery }}&q8_project_deck_single_level={{ data.q8_project_deck_single_level }}&q9_project_deck_connected_to_house={{ data.q9_project_deck_connected_to_house }}&q10_project_deck_finish={{ data.q10_project_deck_finish }}&q11_project_deck_rectangular={{ data.q11_project_deck_rectangular }}&q12_project_deck_one_row_posts={{ data.q12_project_deck_one_row_posts }}&q13_project_deck_heavy={{ data.q13_project_deck_heavy }}&q14_project_deck_manufactured_handrails={{ data.q14_project_deck_manufactured_handrails }}&q15_project_large_impervious_surface={{ data.q15_project_large_impervious_surface }}&q16_project_deck_has_roof={{ data.q16_project_deck_has_roof }}&q17_project_deck_roof_over_200_sqft={{ data.q17_project_deck_roof_over_200_sqft }}&q18_project_septic_on_property={{ data.q18_project_septic_on_property }}&q19_project_deck_septic_distance={{ data.q19_project_deck_septic_distance }}&q20_project_deck_large_trees={{ data.q20_project_deck_large_trees }}&q21_project_deck_trees_distance={{ data.q21_project_deck_trees_distance }}&q22_project_deck_trees_near_row={{ data.q22_project_deck_trees_near_row }}&email_address_optional={{ data.email_address_optional }}"
+  container_welcome_back_results:
+    '#type': container
+    '#states':
+      visible:
+        ':input[name="returning_user"]':
+          filled: true
+        ':input[name="edit_my_project[Edit my project]"]':
+          unchecked: true
+    computed_results:
+      '#type': webform_computed_twig
+      '#title': 'Computed Results'
+      '#title_display': none
+      '#states':
+        visible:
+          ':input[name="returning_user"]':
+            filled: true
+          ':input[name="action_edit_details[Edit my project]"]':
+            unchecked: true
+      '#display_on': form
+      '#mode': html
+      '#template': |-
+        <h2>{{ "Your project guide"|t }}</h2>
+        <p>{{ "We've created a plan to help you follow the City of Portland's building rules based on the details you provided about your project. Print this page or save it as a PDF for reference. If you provided an email address in the project details, we'll send you a link to your filled-out form that you can reference anytime."|t }}</p>
+        <hr>
+
+        {% if data.test %}
+        <div class="bg-info p-3 mb-5">
+          NOTE: These results are being viewed in reviewer mode, with all possible options displayed for testing purposes. To exit reviewer mode, remove the parameter <strong>test=true</strong> from the URL.
+        </div>
+        {% endif %}
+
+        <ol class="process-list">
+
+          <li>
+            <h3>{{ "Gather requirements"|t }}</h3>
+            <p>{{ "You'll need to complete these forms, waivers, and other requirements to get a permit. Additional forms or waivers may be needed depending on the type of project, but this is the starting point:"|t }}</p>
+            
+            <!-- Building permit application -->
+            {% if data.q2_project_deck_height > 30 or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Building permit application"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Used to get approval to build or change a structure by sharing details about the project and ensuring it meets safety and construction codes."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/building-permit-application-building-site-development-demolition-and-zoning-permits/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download building permit application"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Site plan"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Shows where your project will go on the property and verifies that it meets zoning and tree preservation rules."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/sample-site-plan/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download site plan template"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+            
+            <!-- (Pre-Approved) Residential Deck Plans -->
+            {% if ((data.q8_project_deck_single_level == "Yes" or data.q8_project_deck_single_level == "Not sure") and 
+               (data.q9_project_deck_connected_to_house == "Yes" or data.q9_project_deck_connected_to_house == "Not sure") and 
+               (data.q10_project_deck_finish == "No" or data.q10_project_deck_finish == "Not sure") and 
+               (data.q11_project_deck_rectangular == "Yes" or data.q11_project_deck_rectangular == "Not sure") and 
+               (data.q12_project_deck_one_row_posts == "Yes" or data.q12_project_deck_one_row_posts == "Not sure") and 
+               (data.q13_project_deck_heavy == "No" or data.q13_project_deck_heavy == "Not sure")) or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "(Pre-approved) residential deck plans"|t }}</h4>
+                  <p class="mb-3 mb-md-0">
+                    {{ "Used to show how a structure will be built and confirm that the design meets building and safety codes."|t }}
+                    {% if data.q14_project_deck_manufactured_handrails == "Yes" %}
+                    <br><br><strong>{{ "Since the deck has handrails made of glass, cable, aluminum, or steel, you must also provide stamped structural drawings for the handrail and its attachment at the base to the structure along with the permit ready drawings."|t }}</strong>
+                    {% endif %}
+                  </p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="/bcd/permit-services/Documents/permit-ready-deck.pdf" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download pre-approved residential deck plans"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+              {% if ((data.q8_project_deck_single_level == "Not sure") or 
+                    (data.q9_project_deck_connected_to_house == "Not sure") or 
+                    (data.q10_project_deck_finish == "Not sure") or 
+                    (data.q11_project_deck_rectangular == "Not sure") or 
+                    (data.q12_project_deck_one_row_posts == "Not sure") or 
+                    (data.q13_project_deck_heavy == "Not sure")) or data.test == "true" %}
+                <p class="mt-4 mb-0"><strong>{{ "You answered \"Not sure\" on one or more question, so you may not be able to use a pre-approved deck plan."|t }}</strong></p>
+              {% endif %}
+            </div>
+            {% endif %}
+
+            <!-- Simple Site Erosion Control Plan -->
+            {% if ((data.q7_project_using_powered_machinery == "Yes" or data.q7_project_using_powered_machinery == "Not sure") and data.q4_project_deck_site_slope < 10 and data.q1_1_environmental_overlay_zone == "No" and data.q1_2_greenway_overlay_zone == "No" and (data.q5_project_deck_near_waterbody == "No" or data.q5_project_deck_near_waterbody == "Not sure" or data.q6_project_waterbody_distance > 50)) or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Simple site erosion control plan"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Explains how you'll manage erosion and rain runoff on small, low-risk sites where soil will be disturbed."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/simple-site-plan-erosion-control-requirements-form/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download simple site erosion control plan template"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+              {% if data.q5_project_deck_near_waterbody == "Not sure" or data.q7_project_using_powered_machinery == "Not sure" or data.test == "true" %}
+                <p class="mt-4 mb-0"><strong>{{ "You answered \"Not sure\" on one or more question, so you may need to submit a full <a href=\"https://portland.gov/ppd/documents/plan-review-checklist-erosion-sediment-and-pollution-controls-residential-and/download\">erosion control plan</a>."|t|raw }}</strong></p>
+              {% endif %}
+            </div>
+            {% endif %}
+
+            <!-- Stormwater Mitigation Plan -->
+            {% if data.q15_project_large_impervious_surface == "Yes" or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Stormwater mitigation plan"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Explains how you'll manage rain runoff from new roofs or hard surfaces that don't absorb water."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/simple-site-plan-erosion-control-requirements-form/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download stormwater mitigation plan template"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+            <!-- Residential Deck Plans -->
+            {% if (data.q8_project_deck_single_level == "No" or data.q9_project_deck_connected_to_house == "No" or data.q10_project_deck_finish == "Yes" or data.q11_project_deck_rectangular == "No" or data.q12_project_deck_one_row_posts == "No" or data.q13_project_deck_heavy == "Yes") or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Residential deck plans"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Used to show how a structure will be built and confirm that the design meets building and safety codes."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="#" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download residential deck plan template"|t }}">{{ "Download -NEED LINK-"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+            <!-- “Owner doing work” form -->
+            {% if data.q3_project_deck_builder == "The property owner" or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "\"Owner doing work\" form"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Used to confirm that a property owner understands the rules when doing construction work themselves instead of hiring a licensed contractor."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/owner-doing-work-form-information-notice-owners-about-construction-responsibilities/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download owner doing work form"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+            <!-- Erosion control plan -->
+            {% if ((data.q7_project_using_powered_machinery == "Yes") and (data.q4_project_deck_site_slope >= 10 or data.q1_1_environmental_overlay_zone == "Yes" or data.q1_2_greenway_overlay_zone == "Yes" or (data.q5_project_deck_near_waterbody == "Yes" and data.q6_project_waterbody_distance < 50))) or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Erosion control plan"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Shows how you'll prevent erosion during construction on steep, sensitive, or environmentally protected sites."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/plan-review-checklist-erosion-sediment-and-pollution-controls-residential-and/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download erosion control plan template"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+            <!-- Disclaimer for existing on-site sewage system -->
+            {% if data.q18_project_septic_on_property == "Yes" or data.q18_project_septic_on_property == "Not sure" or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Disclaimer for existing on-site sewage system"|t }}</h4>
+                  <p class="mb-3 mb-md-0">
+                    {{ "Confirms whether the property has a septic system or cesspool and notifies the city if it needs to be decommissioned."|t }}
+                    {% if data.q18_project_septic_on_property == "Not sure" or data.test == "true" %}
+                    <br><br><strong>{{ "You answered \"Not sure\" whether there is a septic system or cesspool on the property. If there is, you will need to submit this item."|t }}</strong>
+                    {% endif %}
+                  </p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="https://portland.gov/ppd/documents/disclaimer-existing-site-sewage-disposal-system/download" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download disclaimer for existing on-site sewage systems"|t }}">{{ "Download"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+            <!-- Land use review application -->
+            {% if data.q1_3_historic_landmark == "Yes" or data.q1_1_environmental_overlay_zone == "Yes" or data.test == "true" %}
+            <div class="text-body rounded border border-3 p-4 mb-4">
+              <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3">
+                <div class="flex-grow-1">
+                  <h4 class="mb-2"><i class="fa-solid fa-file-pdf me-2"></i>{{ "Land use review application"|t }}</h4>
+                  <p class="mb-3 mb-md-0">{{ "Used to request approval for projects that may affect zoning, environmental standards, or the appearance of historic sites. Requires a 15 minute appointment."|t }}</p>
+                </div>
+                <div class="flex-shrink-0">
+                  <a href="#" class="btn btn-primary rounded-1 ms-md-3 ms-0" aria-label="{{ "Download land use review application"|t }}">{{ "Schedule"|t }}</a>
+                </div>
+              </div>
+            </div>
+            {% endif %}
+
+
+          </li>
+
+          <!--<li>
+            <h3>{{ "Gather other requirements"|t }}</h3>
+            <p>{{ "You'll need to fill out these forms to get a permit. After your conversations in Step 1, you may need to provide additional forms or waivers based on the details of your project:"|t }}</p>
+            
+            <div class="text-body rounded border border-3 p-5 clearfix mb-4">
+              <h3><i class="fa-solid fa-file-pdf"></i>{{ "Site plan"|t }}</h3>
+              <p class="float-right"><a aria-label="{{ "Learn more about site plans"|t }}" href="#" class="btn btn-outline-primary rounded rounded-1 border-2">{{ "Learn"|t }} <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
+              <p class="mb-0">{{ "Shows where your project will go on the property and verifies that it meets zoning rules."|t }}</p>
+            </div>
+          </li>-->
+
+          <li>
+            <h3>{{ "Submit your application"|t }}</h3>
+            <p>{{ "You'll need to fill out these forms to get a permit. After your conversations in Step 1, you may need to provide additional forms or waivers based on the details of your project:"|t }}</p>
+            <p class="mb-0" class="float-right"><a aria-label="{{ "Submit permit application requirements"|t }}" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">{{ "Submit requirements"|t }}</a>
+              <a aria-label="{{ "Learn more about submitting permit requirements"|t }}" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">{{ "Learn"|t }} <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
+          </li>
+
+          <li>
+            <h3>{{ "Check your application status"|t }}</h3>
+            <p>{{ "When you apply for a permit, it goes through various departments where it's reviewed by different specialists. You will want to check frequently to know if there are adjustments you need to make or where it is in the overall process."|t }}</p>
+            <p class="mb-0" class="float-right"><a aria-label="{{ "Check permit status"|t }}" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">{{ "Check status"|t }}</a>
+              <a aria-label="{{ "Learn more about checking permit status"|t }}" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">{{ "Learn"|t }} <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
+          </li>
+
+          <li>
+            <h3>{{ "Get your permit and start building!"|t }}</h3>
+            <p>{{ "Once approved, you can start your project. Follow the permit rules and schedule inspections as needed."|t }}</p>
+          </li>
+
+          <li>
+            <h3>{{ "Schedule inspections"|t }}</h3>
+            <p>{{ "After your project is complete, you can schedule inspections. Your permit allows for 3 inspections &#151; extra inspections will cost more."|t }}</p>
+            <p class="mb-0" class="float-right"><a aria-label="{{ "Schedule inspection"|t }}" href="#" class="btn btn-primary ms-auto me-3 rounded rounded-1">{{ "Schedule inspection"|t }}</a>
+              <a aria-label="{{ "Learn more about scheduling an inspection"|t }}" href="#" class="btn btn-outline-primary ms-auto rounded rounded-1 border-2">{{ "Learn"|t }} <i class="fa-solid fa-arrow-up-right-from-square"></i></a></p>
+          </li>
+
+        </ol>
+
+        <hr>
+
+        <h3>{{ "Your project details"|t }}</h3>
+
+        <table>
+          <tr class="">
+            <th style="text-align: left;">{{ "Project type:"|t }}</th>
+            <td>{{ "Residential deck"|t }}</td>
+          </tr>
+
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Location:"|t }}</th>
+            <td>{{ data.q1_project_address.location_address }}</td>
+          </tr>
+
+        {% if data.q1_1_environmental_overlay_zone != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Environmental overlay zone?"|t }}</th>
+            <td>{{ data.q1_1_environmental_overlay_zone }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q1_2_greenway_overlay_zone != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Greenway overlay zone?"|t }}</th>
+            <td>{{ data.q1_2_greenway_overlay_zone }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q1_3_historic_landmark != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Historic/conservation landmark or district?"|t }}</th>
+            <td>{{ data.q1_3_historic_landmark }}</td>
+          </tr>
+        {% endif %}
+
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Who is doing the work?"|t }}</th>
+            <td>{{ data.q3_project_deck_builder }}</td>
+          </tr>
+
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Deck height:"|t }}</th>
+            <td>{{ data.q2_project_deck_height }} ft</td>
+          </tr>
+
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Site slope:"|t }}</th>
+            <td>{{ data.q4_project_deck_site_slope }}%</td>
+          </tr>
+
+        {% if data.q5_project_deck_near_waterbody != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Near wetland or waterbody?"|t }}</th>
+            <td>{{ data.q5_project_deck_near_waterbody }}</td>
+          </tr>
+          {% if data.q6_project_waterbody_distance != "No" %}
+          <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
+            <th class="ps-5" style="text-align: left;">{{ "Distance:"|t }}</th>
+            <td>{{ data.q6_project_waterbody_distance }} {{ "feet"|t }}</td>
+          </tr>
+          {% endif %}
+        {% endif %}
+
+        {% if data.q7_project_using_powered_machinery != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Using powered machinery to disturb the ground?"|t }}</th>
+            <td>{{ data.q7_project_using_powered_machinery }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q8_project_deck_single_level != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Single level deck?"|t }}</th>
+            <td>{{ data.q8_project_deck_single_level }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q9_project_deck_connected_to_house != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Connected to outside wall of house?"|t }}</th>
+            <td>{{ data.q9_project_deck_connected_to_house }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q10_project_deck_finish != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Tile, concrete, or other finish materials on deck?"|t }}</th>
+            <td>{{ data.q10_project_deck_finish }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q11_project_deck_rectangular != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Rectangular in shape?"|t }}</th>
+            <td>{{ data.q11_project_deck_rectangular }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q12_project_deck_one_row_posts != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "One row of posts supporting outer edge?"|t }}</th>
+            <td>{{ data.q12_project_deck_one_row_posts }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q13_project_deck_heavy != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Heavy weight bearing, such as hot tub?"|t }}</th>
+            <td>{{ data.q13_project_deck_heavy }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q14_project_deck_manufactured_handrails != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Manufactured handrails?"|t }}</th>
+            <td>{{ data.q14_project_deck_manufactured_handrails }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q15_project_large_impervious_surface != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "More than 500 sq ft impervious surface?"|t }}</th>
+            <td>{{ data.q15_project_large_impervious_surface }}</td>
+          </tr>
+        {% endif %}
+
+        {% if data.q16_project_deck_has_roof != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Solid, covered roof?"|t }}</th>
+            <td>{{ data.q16_project_deck_has_roof }}</td>
+          </tr>
+
+          {% if data.q17_project_deck_roof_over_200_sqft != "No" %}
+          <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
+            <th class="ps-5" style="text-align: left;">{{ "More than 200 sq ft?"|t }}</th>
+            <td>{{ data.q17_project_deck_roof_over_200_sqft }}</td>
+          </tr>
+          {% endif %}
+        {% endif %}
+
+        {% if data.q18_project_septic_on_property != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Septic system or cesspool on property?"|t }}</th>
+            <td>{{ data.q18_project_septic_on_property }}</td>
+          </tr>
+          {% if data.q19_project_deck_septic_distance %}
+          <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
+            <th class="ps-5" style="text-align: left;">{{ "Distance:"|t }}</th>
+            <td>{{ data.q19_project_deck_septic_distance }} feet</td>
+          </tr>
+          {% endif %}
+        {% endif %}
+
+        {% if data.q20_project_deck_large_trees != "No" %}
+          <tr class="border-top border-1 border-dark border-bottom-0 border-start-0 border-end-0">
+            <th style="text-align: left;">{{ "Trees larger than 8\" diameter near worksite?"|t }}</th>
+            <td>{{ data.q20_project_deck_large_trees }}</td>
+          </tr>
+          {% if data.q21_project_deck_trees_distance %}
+          <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
+            <th class="ps-5" style="text-align: left;">{{ "Distance:"|t }}</th>
+            <td>{{ data.q21_project_deck_trees_distance }} feet</td>
+          </tr>
+          {% endif %}
+          {% if data.q22_project_deck_trees_near_row %}
+          <tr class="border-top border-1 border border-bottom-0 border-start-0 border-end-0">
+            <th class="ps-5" style="text-align: left;">{{ "Trees near public right-of-way?"|t }}</th>
+            <td>{{ data.q22_project_deck_trees_near_row }}</td>
+          </tr>
+          {% endif %}
+        {% endif %}
+        </table>
+      '#whitespace': spaceless
+      '#ajax': true
+    edit_my_project:
+      '#type': checkboxes
+      '#title': 'Edit project details'
+      '#title_display': none
+      '#options':
+        'Edit my project': 'Edit project details'
+      '#options_display': buttons_horizontal
+      '#states':
+        invisible:
+          ':input[name="action_edit_details[Edit my project]"]':
+            checked: true
+      '#wrapper_attributes':
+        class:
+          - mb-0
+          - checkbox-button-outline-primary
+      '#access_create_roles': {  }
+    computed_edit_link:
+      '#type': webform_computed_twig
+      '#title': 'Computed Edit Link'
+      '#title_display': none
+      '#display_on': form
+      '#mode': html
+      '#template': "<a href=\"{{ data.return_link|replace({'returning_user=1&':''}) }}#body-content\" class=\"btn btn-outline-primary ms-auto rounded rounded-1 border-2\">{{ 'Edit project details'|t }}</a>"
+      '#whitespace': trim
   actions:
     '#type': webform_actions
     '#title': 'Submit button(s)'
     '#states':
       invisible:
-        ':input[name="q1_project_address[location_verification_status]"]':
-          empty: true
-css: ''
-javascript: ''
+        - ':input[name="q1_project_address[location_verification_status]"]':
+            empty: true
+        - or
+        - ':input[name="q1_project_address[location_verification_status]"]':
+            empty: false
+          ':input[name="edit_my_project[Edit my project]"]':
+            unchecked: true
+          ':input[name="returning_user"]':
+            empty: false
+css: "  .checkbox-button-outline-primary label.option {\r\n    display: inline-block;\r\n    padding: 0.375rem 0.75rem;\r\n    font-size: 1rem;\r\n    font-weight: 400;\r\n    line-height: 1.5;\r\n    text-align: center;\r\n    white-space: nowrap;\r\n    vertical-align: middle;\r\n    user-select: none;\r\n    background-color: transparent;\r\n    color: #1d62c9;\r\n    border: 2px solid #1d62c9;\r\n    border-radius: 0.2rem;\r\n    margin-left: auto;\r\n    margin-right: 0;\r\n    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;\r\n    cursor: pointer;\r\n  }\r\n  \r\n  .checkbox-button-outline-primary label.option:hover {\r\n    background-color: #1d62c9;\r\n    color: #ffffff;\r\n    border: 2px solid #1d62c9;\r\n    border-radius: 0.2rem;\r\n  }\r\n"
+javascript: "(function ($, Drupal) {\r\n  Drupal.behaviors.bodyLinkHandler = {\r\n    attach: function (context, settings) {\r\n      $('#edit-edit-my-project label.webform-options-display-buttons-label').on('click', function() {\r\n        document.location = '#body-content';\r\n      });\r\n    }\r\n  };\r\n})(jQuery, Drupal);\r\n"
 settings:
   ajax: true
   ajax_scroll_top: form
@@ -950,7 +1071,7 @@ handlers:
       bcc_options: {  }
       cc_mail: ''
       cc_options: {  }
-      from_mail: _default
+      from_mail: ppd@portlandoregon.gov
       from_options: {  }
       from_name: _default
       reply_to: ''
@@ -958,7 +1079,7 @@ handlers:
       sender_mail: ''
       sender_name: ''
       subject: _default
-      body: '<p><a class="btn btn-primary" href="[webform_submission:values:return_link]">Return to my project</a></p>'
+      body: '<p>Thanks for telling us about your deck project on <a href="https://portland.gov">Portland.gov</a>. We use these details to show you what you''ll need to apply for a permit. Those results are included below.&nbsp;</p><p>You can return to update your project and review the requirements anytime by using this link: <a href="[webform_submission:values:return_link]"><strong>Return to your deck project details</strong></a></p><p>For more on completing your permitting project, <a href="https://www.portland.gov/ppd/residential-permitting/decks#body-content">visit our pages on residential decks</a>.</p><p>Have questions? Just reply to this email. We''re happy to help.</p><p>Thank you,</p><p>Portland Permitting &amp; Development (PPD)<br>City of Portland<br><a href="http://portland.gov/ppd">Portland.gov/ppd</a></p><hr style="margin:30px 0;"><p>[webform_submission:values:computed_results:html]</p>'
       excluded_elements: {  }
       ignore_access: false
       exclude_empty: true

--- a/web/sites/default/config/webform.webform.test_node_fetcher_widget.yml
+++ b/web/sites/default/config/webform.webform.test_node_fetcher_widget.yml
@@ -1,0 +1,222 @@
+uuid: 4ee53c8a-d0bd-4946-b718-9a2ed98bff0e
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 60
+template: false
+archive: false
+id: test_node_fetcher_widget
+title: 'Test Node Fetcher Widget'
+description: '<p>Used for testing the import of content from arbitrary nodes in the site.</p>'
+categories:
+  - Test
+elements: |-
+  markup:
+    '#type': webform_markup
+    '#markup': '<p>This is a test form for the Portland Node Fetcher webform element. The element takes a node alias path as a configuration value, fetches the associated node content, and makes it available in the form.</p>'
+  fetch_node:
+    '#type': portland_node_fetcher
+    '#title': 'Fetch Node'
+    '#description': '<p>This is the description.</p>'
+    '#node_alias_path': /ppd/residential-decks
+  display_node_content:
+    '#type': webform_computed_twig
+    '#title': 'Node Content (computed twig element)'
+    '#description': '<p>Below is the body content from the selected node.</p>'
+    '#description_display': before
+    '#template': |-
+      <p><strong>Selected node alias:</strong> {{ data.fetch_node.node_alias_path }}</p>
+
+      <hr>
+
+      <h2>{{ data.fetch_node.title }}</h2>
+      {{ data.fetch_node.field_body_content|raw }}
+    '#ajax': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/themes/custom/cloudy/src/components/_form.scss
+++ b/web/themes/custom/cloudy/src/components/_form.scss
@@ -130,6 +130,7 @@ select.form-control {
 
 // stylelint-disable-next-line no-duplicate-selectors
 select.form-control {
+
   &[size],
   &[multiple] {
     height: auto;
@@ -165,8 +166,8 @@ textarea.form-control {
   margin-right: -$grid-gutter-width * 0.5;
   margin-left: -$grid-gutter-width * 0.5;
 
-  > .col,
-  > [class*="col-"] {
+  >.col,
+  >[class*="col-"] {
     padding-right: calc($grid-gutter-width / 2);
     padding-left: calc($grid-gutter-width / 2);
   }
@@ -183,7 +184,7 @@ textarea.form-control {
 .form-check-input {
   margin-right: spacer(1);
 
-  &:disabled ~ .form-check-label {
+  &:disabled~.form-check-label {
     color: $cloudy-color-neutral-500;
   }
 }
@@ -212,6 +213,7 @@ textarea.form-control {
   margin-right: spacer(4);
   display: inline;
   max-width: 100%; // We are adding a harmless max-width here to protect against floating items breaking outside their parent
+
   // We target inputs with the `size` attribute here so that they respect our layout's margins and not overflow the layout
   input[size] {
     width: 100%;
@@ -221,6 +223,7 @@ textarea.form-control {
 // Fix spacing between radio items
 .form-checkboxes,
 .form-radios {
+
   .form-item,
   .webform-options-display-buttons-wrapper {
     margin-top: spacer(2);
@@ -312,6 +315,7 @@ textarea.form-control {
       width: auto;
       padding-left: 0;
     }
+
     .form-check-input {
       position: relative;
       flex-shrink: 0;
@@ -324,6 +328,7 @@ textarea.form-control {
       align-items: center;
       justify-content: center;
     }
+
     .custom-control-label {
       margin-bottom: 0;
     }
@@ -412,9 +417,11 @@ div.date-links {
   flex-basis: 100%;
   margin-bottom: 30px;
 }
+
 span.prev-link {
   margin-right: 30px;
 }
+
 span.next-link .fas {
   margin: 0 0 0 spacer(2);
 }
@@ -429,10 +436,12 @@ span.next-link .fas {
 .chosen-container-multi {
   .chosen-choices {
     padding: (spacer(4) * 0.375) (spacer(4) * 0.75);
+
     li.search-choice {
       padding: (spacer(4) * 0.375) (spacer(4) * 1.5) (spacer(4) * 0.375) (spacer(4) * 0.75);
       display: flex;
       align-items: center;
+
       .search-choice-close {
         top: spacer(4) * 0.5;
         right: spacer(4) * 0.25;
@@ -518,6 +527,7 @@ span.next-link .fas {
 }
 
 .webform-submission-form {
+
   // Webforms use cloudy alert style as opposed to bootstrap alert
   .alert {
     @extend .cloudy-alert;
@@ -530,6 +540,42 @@ span.next-link .fas {
   .alert p:last-of-type {
     margin-bottom: 0 !important;
   }
+
+  .float-right {
+    float: right !important;
+  }
+
+  .float-left {
+    float: left !important;
+  }
+
+  .checkbox-button-outline-primary label.option {
+    display: inline-block;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    background-color: transparent;
+    color: #1d62c9;
+    border: 2px solid #1d62c9;
+    border-radius: 0.2rem;
+    margin-left: auto;
+    margin-right: 0;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+    cursor: pointer;
+  }
+  
+  .checkbox-button-outline-primary label.option:hover {
+    background-color: #1d62c9;
+    color: #ffffff;
+    border: 2px solid #1d62c9;
+    border-radius: 0.2rem;
+  }
+  
 }
 
 img.inline-icon {


### PR DESCRIPTION
* PGOV-1565 conditional logic initial draft

* PGOV-1565 more work on conditional logic form, added styling to list of required documents

* PGOV-1565 started prototyping 'not sure' logic into results

* PGOV-1565 finished initial draft of conditional logic prototype for demo

* PGOV-1565 knocked the header levels down due to the template where this will be embedded, enabled ajax.

* PGOV-1565 fixed issue where confirmation page would break the ajax and cause a full postback instead of displaying the confirmation in the context of the parent page.

* PGOV-1565 fixed aria labels for download, schedule, and learn button links

* PGOV-1651 work in progress setting up entity browser for content components

* PGOV-1651 incremental commit of work to support embedding of content fragments. Basic entity embed with autocomplete is working.

* PGOV-1651 incremental commit: content component browser and entity embed button working as a baseline

* PGOV-1651 added hook to only let glossary editors use the new toolbar button, updates to entity browser view; feature appears to be code complete.

* PGOV-1651 final tweaks to verbiage

* PGOV-1651 touching file to trigger build

* PGOV-1651 updated texts

* PGOV-1651 removed install script, added unpublished class to embedded content components

* PGOV-1651 fixed reference to taxonomy term in field dependencies, added unpublished badge to embedded content fragment.

* PGOV-1651 removed troubleshooting code, removed unused use statements in module file.

* PGOV-1565 incremental commit

* SITU-1161 initial code complete of new node fetcher widget and test form.

* PGOV_1565 ongoing work to configure api queries

* PGOV-1565 got PortlandMaps API integration working! Added secondary_queries feature to Address Verifier.

* PGOV-1565 added portland maps api key to the form config

* PGOV-1565 fix URL in portland maps api config (needs www subdomain)

* PGOV-1565 fix issue with address invalidation when additional taxlot id call is made

* PGOV-1565 post QA tweaks to conditional logic, handled 'Not sure' answers

* PGOV-1565 removed outdated functions

* PGOV-1565 moved computed results to confirmation page.

* PGOV-1565 added return email text

* PGOV-1565 update widget to auto-verify if address is present in postback or populated by URL params

* PGOV-1565 code cleanup

* PGOV-1565 added support for logging js layer API errors

* PGOV-1565 formatting tweaks to results, added results to email, added email address to prepopulation, fixed bug in address verifier code.

* PGOV-1565 a whole mess of updates and improvements to the form, main one being that returning with the prepopulated link shows the results first, not the form, and has an Edit Details button.

* PGOV-1565 made Edit Project Details a simple link to the form with returning_user parameter removed

* PGOV-1565 update conditional logic on Page content type to show webform field if sub-type is Service or Guide (previously was only Guide).

* PGOV-1565 added test mode element and logic

* PGOV-1565 added |t filter to all text content in computed twig elements, tweaked layout styles in results for better responsiveness

* SITU-1226 start fixing regression caused by recent error handling update.

* PGOV-1565 emergency fix to address verifier--recent updates deployed on 7/8 broke the secondary query feature for webforms using the old method. Have restored backwards compatibility.

* PGOV-1565 fixed incorrect reference to view in address verifier

* PGOV-1565 PGOV-1703 fixed permission issue with Content Component browser

* PGOV-1565 manually reverting a file that shouldn't have changed.

* PGOV-1565 manually reverting a file that shouldn't have changed.