### PR TITLE
SITU-1282 attempting to fix the intermittent Zendesk handler file upload processing issue

### DIFF
--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -15,6 +15,8 @@ use Drupal\portland_zendesk\Client\ZendeskClient;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\webform\WebformTokenManagerInterface;
 use Drupal\Core\Serialization\Yaml;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\RedirectCommand;
 use Drupal\file\Entity\File;
 use Drupal\portland_zendesk\Utils\Utility;
 use Drupal\Core\File\FileSystemInterface;
@@ -40,16 +42,21 @@ class ZendeskHandler extends WebformHandlerBase
 {
   private const ANONYMOUS_EMAIL = 'anonymous@portlandoregon.gov';
   private const JSON_FORM_DATA_FIELD_ID = 17698062540823;
+  private const ZENDESK_SEND_ERROR_MESSAGE = 'There was a problem submitting your report to our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.';
   
   /**
-   * TEMPORARY DEBUG FLAG.
+   * Prevent postSave recursion when persisting ticket IDs back to submission.
    *
-   * Set to TRUE to reliably simulate the intermittent missing upload source
-   * error by deleting temporary _sid_ files before Zendesk upload.
-   *
-   * IMPORTANT: Keep FALSE in production.
+   * @var array<string, bool>
    */
-  private const DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE = FALSE;
+  protected static $post_save_in_progress = [];
+
+  /**
+   * Per-request shared flag for whether Zendesk send failed for a submission.
+   *
+   * @var array<string, bool>
+   */
+  protected static $zendesk_send_failed = [];
 
   /**
    * The webform element plugin manager.
@@ -565,39 +572,13 @@ class ZendeskHandler extends WebformHandlerBase
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
-    // the file upload button triggers the validation handler, which is undesired.
-    // in order to prevent that, we need to determine the triggering element for the submission.
-    // call our validation function only if it's not an upload button. be extra careful about
-    // null references here, since we're not sure when/if these elements will be populated.
-    // Candiates for checking whether this is an upload submit:
-    //    $form_state->getTriggeringElement()['#submit'][0] == "file_managed_file_submit"
-    //    $form_state->getTriggeringElement()['#value']->getUntranslatedString() == "Uplooad"
-    if ($form_state->getTriggeringElement() && $form_state->getTriggeringElement()['#parents'][0] === "submit") {
-      $this->sendToZendeskAndValidateTicket($form, $form_state, $webform_submission);
-    }
+    // Intentionally no-op.
+    //
+    // Zendesk API submission is performed in postSave so managed file uploads
+    // are finalized first and no longer rely on temporary _sid_ paths.
   }
 
-  /**
-   * Submit report to Zendesk API and validate the ticket was successfully created.
-   *
-   * By submitting to the API during the validate phase, we can interrupt the form submission,
-   * prevent the email handlers from firing, and display an error message to the user. Validation
-   * in a custom handler is performed after all the built-in webform validation, so this is a
-   * safe approach.
-   */
-  private function sendToZendeskAndValidateTicket(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
-    if (!$form_state->hasAnyErrors()) {
-      // comment out the line below to test the error handling
-      $ticket_id = $this->sendToZendesk($form, $form_state, $webform_submission);
-      if (!$ticket_id) {
-        // throw error and don't let form submit
-        \Drupal::messenger()->addError(t('There was a problem submitting your report to our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.'));
-        $form_state->setErrorByName('');
-      }
-    }
-  }
-
-  public function sendToZendesk(array &$form, FormStateInterface &$form_state, WebformSubmissionInterface $webform_submission) {
+  public function sendToZendesk(WebformSubmissionInterface $webform_submission) {
     // NOTE: This function will run both when a webform is created, and when it's updated, so this handler
     // should only be used on forms that don't allow updating. Otherwise, a new Zendesk ticket will be created
     // on every submit of the form.
@@ -610,35 +591,18 @@ class ZendeskHandler extends WebformHandlerBase
     // tickets will be forked on the field identified in the config value 'ticket_fork_field'
     $fork_field_name = $this->configuration['ticket_fork_field'];
 
-    // Since we're doing this in the validate phase instead of postSave, we use
-    // the current submission object built by WebformSubmissionForm::validateForm.
-
-    // check for a report_ticket_id value in the form state; if a handler previously submitted
-    // a ticket, the ID should be available to subsequent handlers.
-    $prev_ticket_id = $form_state->getValue($zendesk_ticket_id_field_name);
-    if ($prev_ticket_id) {
-      $webform_submission->setElementData($zendesk_ticket_id_field_name, $prev_ticket_id);
-    }
-
-    // check for a parent_ticket_id value in the form state; if a handler previously submitted
-    // a ticket, the ID should be available to subsequent handlers.
-    $parent_ticket_id = $form_state->getValue($zendesk_parent_ticket_id_field_name);
-    if ($parent_ticket_id) {
-      $webform_submission->setElementData($zendesk_parent_ticket_id_field_name, $parent_ticket_id);
-    }
+    $data = $webform_submission->getData();
 
     $token_options = [
       'email' => TRUE,
       'excluded_elements' => $this->configuration['excluded_elements'],
     ];
 
-    // the 2nd time through, $prev_ticket_id and $parent_ticket_id are both set
     if ($fork_field_name) {
       // if the handler has a fork field configured, grab the values array from that field so we can
       // spin through it and stuff a single value into the webform_submission for each ticket being created.
 
-      $data = $webform_submission->getData();
-      $fork_field_array = $data[$fork_field_name];  // TODO: inefficient; improve?
+      $fork_field_array = $data[$fork_field_name] ?? [];
       $ticket_ids = [];
 
       foreach ($fork_field_array as $key => $value) {
@@ -661,25 +625,126 @@ class ZendeskHandler extends WebformHandlerBase
       // email=true uses nicer template for webform_submission:values HTML
       $configuration = $this->token_manager->replace($this->configuration, $webform_submission, [], $token_options);
       $new_ticket_id = $this->submitTicket($webform_submission, $configuration);
-      $data = $webform_submission->getData();
     }
 
     // if field is set and present, add ticket ID to hidden Zendesk Ticket ID field
-    // NOTE: Only do this if $prev_ticket_id isn't already set
-    if (!$prev_ticket_id && $zendesk_ticket_id_field_name && array_key_exists( $zendesk_ticket_id_field_name, $data ) && $new_ticket_id){
+    // NOTE: Only do this when the field is currently empty.
+    if (
+      $zendesk_ticket_id_field_name
+      && array_key_exists($zendesk_ticket_id_field_name, $data)
+      && $new_ticket_id
+      && empty($data[$zendesk_ticket_id_field_name])
+    ) {
       $data[$zendesk_ticket_id_field_name] = $new_ticket_id;
-      $form_state->setValue($zendesk_ticket_id_field_name, $new_ticket_id);
-      $form['values'][$zendesk_ticket_id_field_name] = $new_ticket_id;
     }
 
     // if this is a Problem ticket and parent ticket ID field is present, add new ticket ID there too
-    if (!$parent_ticket_id && $zendesk_parent_ticket_id_field_name && array_key_exists( $zendesk_parent_ticket_id_field_name, $data ) && $new_ticket_id && !$is_child){
+    if (
+      $zendesk_parent_ticket_id_field_name
+      && array_key_exists($zendesk_parent_ticket_id_field_name, $data)
+      && $new_ticket_id
+      && !$is_child
+      && empty($data[$zendesk_parent_ticket_id_field_name])
+    ) {
       $data[$zendesk_parent_ticket_id_field_name] = $new_ticket_id;
-      $form_state->setValue($zendesk_parent_ticket_id_field_name, $new_ticket_id);
-      $form['values'][$zendesk_parent_ticket_id_field_name] = $new_ticket_id;
     }
 
-    return $new_ticket_id; // if a null is returned, an error/try-again message will be displayed to the user
+    $webform_submission->setData($data);
+
+    return $new_ticket_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
+    $sid = (string) $webform_submission->id();
+    $failure_key = $this->getFailureStateKey($webform_submission);
+
+    // Prevent recursion when we resave to persist hidden ticket ID fields.
+    if (!empty(static::$post_save_in_progress[$sid])) {
+      return;
+    }
+
+    // If a ticket ID already exists, do not create another ticket.
+    if ($this->hasExistingTicketId($webform_submission)) {
+      static::$zendesk_send_failed[$failure_key] = FALSE;
+      return;
+    }
+
+    $ticket_id = $this->sendToZendesk($webform_submission);
+    if (!$ticket_id) {
+      static::$zendesk_send_failed[$failure_key] = TRUE;
+      return;
+    }
+
+    // Persist generated hidden ticket IDs back to the submission.
+    static::$post_save_in_progress[$sid] = TRUE;
+    try {
+      $webform_submission->resave();
+    }
+    finally {
+      unset(static::$post_save_in_progress[$sid]);
+    }
+
+    static::$zendesk_send_failed[$failure_key] = FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function confirmForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
+    $failure_key = $this->getFailureStateKey($webform_submission);
+    if (empty(static::$zendesk_send_failed[$failure_key])) {
+      return;
+    }
+
+    // Remove success messages and show failure with immediate retry path.
+    \Drupal::messenger()->deleteByType('status');
+    \Drupal::messenger()->addError(t(self::ZENDESK_SEND_ERROR_MESSAGE));
+    $redirect_url = $webform_submission->getTokenUrl('update');
+
+    // In AJAX submissions, force a redirect command so Webform's reset/rebuild
+    // phase does not redisplay a blank form.
+    if (\Drupal::request()->isXmlHttpRequest()) {
+      $response = new AjaxResponse();
+      $response->addCommand(new RedirectCommand($redirect_url->toString()));
+      $form_state->setResponse($response);
+    }
+    else {
+      $form_state->setRedirectUrl($redirect_url);
+    }
+
+    // Cleanup to avoid carrying state into any subsequent handler execution.
+    unset(static::$zendesk_send_failed[$failure_key]);
+  }
+
+  /**
+   * Build a per-handler failure state key for the current submission.
+   */
+  private function getFailureStateKey(WebformSubmissionInterface $webform_submission): string
+  {
+    $sid = (string) $webform_submission->id();
+    $handler_id = (string) ($this->getHandlerId() ?: $this->getPluginId());
+    return $sid . ':' . $handler_id;
+  }
+
+  /**
+   * Determine whether this submission already has a stored Zendesk ticket ID.
+   */
+  private function hasExistingTicketId(WebformSubmissionInterface $webform_submission): bool
+  {
+    $ticket_id_field = $this->configuration['ticket_id_field'] ?? '';
+    if (!$ticket_id_field) {
+      return FALSE;
+    }
+
+    $value = $webform_submission->getElementData($ticket_id_field);
+    if (is_array($value)) {
+      $value = implode(',', $value);
+    }
+
+    return is_string($value) ? trim($value) !== '' : !empty($value);
   }
 
   public function submitTicket(WebformSubmissionInterface $webform_submission, $configuration) {
@@ -887,9 +952,6 @@ class ZendeskHandler extends WebformHandlerBase
 
             if ($element) $filename = $this->transformFilename($file->getFilename(), $element, $webform_submission);
 
-            // Test helper: force missing source errors for temporary _sid_ files.
-            $this->simulateMissingUploadSourceForTesting($file);
-
             $path = $this->pathForZendeskUpload($file);   // new helper below
             $__temp_paths[] = $path;                      // remember to clean up
             $attachment = $client->attachments()->upload([
@@ -978,36 +1040,6 @@ class ZendeskHandler extends WebformHandlerBase
       if ($base && $real && str_starts_with($real, $base . DIRECTORY_SEPARATOR)) {
         @$fs->unlink($real);
       }
-    }
-  }
-
-  /**
-   * Deliberately remove temporary _sid_ files to reproduce missing source errors.
-   *
-   * This should only be enabled for local testing.
-   */
-  private function simulateMissingUploadSourceForTesting(File $file): void
-  {
-    if (!self::DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE) {
-      return;
-    }
-
-    // Only touch temporary pre-save files to avoid deleting finalized uploads.
-    $uri = $file->getFileUri();
-    if (!$file->isTemporary() || !str_contains($uri, '/_sid_/')) {
-      return;
-    }
-
-    $fs = \Drupal::service('file_system');
-    $real = $fs->realpath($uri) ?: '';
-    if ($real && file_exists($real)) {
-      @unlink($real);
-      clearstatcache(TRUE, $real);
-      $this->getLogger()->warning('DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE deleted @path for fid=@fid (uri=@uri).', [
-        '@path' => $real,
-        '@fid' => $file->id(),
-        '@uri' => $uri,
-      ]);
     }
   }
 

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -946,7 +946,7 @@ class ZendeskHandler extends WebformHandlerBase
             }
 
             // add uploads key to Zendesk comment, if not already present
-            if ($file && !array_key_exists('uploads', $request['comment'])) {
+            if (!array_key_exists('uploads', $request['comment'])) {
               $request['comment']['uploads'] = [];
             }
 

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskHandler.php
@@ -40,6 +40,16 @@ class ZendeskHandler extends WebformHandlerBase
 {
   private const ANONYMOUS_EMAIL = 'anonymous@portlandoregon.gov';
   private const JSON_FORM_DATA_FIELD_ID = 17698062540823;
+  
+  /**
+   * TEMPORARY DEBUG FLAG.
+   *
+   * Set to TRUE to reliably simulate the intermittent missing upload source
+   * error by deleting temporary _sid_ files before Zendesk upload.
+   *
+   * IMPORTANT: Keep FALSE in production.
+   */
+  private const DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE = FALSE;
 
   /**
    * The webform element plugin manager.
@@ -563,7 +573,7 @@ class ZendeskHandler extends WebformHandlerBase
     //    $form_state->getTriggeringElement()['#submit'][0] == "file_managed_file_submit"
     //    $form_state->getTriggeringElement()['#value']->getUntranslatedString() == "Uplooad"
     if ($form_state->getTriggeringElement() && $form_state->getTriggeringElement()['#parents'][0] === "submit") {
-      $this->sendToZendeskAndValidateTicket($form, $form_state);
+      $this->sendToZendeskAndValidateTicket($form, $form_state, $webform_submission);
     }
   }
 
@@ -575,10 +585,10 @@ class ZendeskHandler extends WebformHandlerBase
    * in a custom handler is performed after all the built-in webform validation, so this is a
    * safe approach.
    */
-  private function sendToZendeskAndValidateTicket(array &$form, FormStateInterface $form_state) {
+  private function sendToZendeskAndValidateTicket(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
     if (!$form_state->hasAnyErrors()) {
       // comment out the line below to test the error handling
-      $ticket_id = $this->sendToZendesk($form, $form_state);
+      $ticket_id = $this->sendToZendesk($form, $form_state, $webform_submission);
       if (!$ticket_id) {
         // throw error and don't let form submit
         \Drupal::messenger()->addError(t('There was a problem submitting your report to our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.'));
@@ -587,7 +597,7 @@ class ZendeskHandler extends WebformHandlerBase
     }
   }
 
-  public function sendToZendesk(array &$form, FormStateInterface &$form_state) {
+  public function sendToZendesk(array &$form, FormStateInterface &$form_state, WebformSubmissionInterface $webform_submission) {
     // NOTE: This function will run both when a webform is created, and when it's updated, so this handler
     // should only be used on forms that don't allow updating. Otherwise, a new Zendesk ticket will be created
     // on every submit of the form.
@@ -600,9 +610,8 @@ class ZendeskHandler extends WebformHandlerBase
     // tickets will be forked on the field identified in the config value 'ticket_fork_field'
     $fork_field_name = $this->configuration['ticket_fork_field'];
 
-    // Since we're doing this in the validate phase, instead of postSave, we need to manually generate
-    // a webform_submission object from form_state and pull form values from that for the API submission.
-    $webform_submission = $form_state->getFormObject()->getEntity();
+    // Since we're doing this in the validate phase instead of postSave, we use
+    // the current submission object built by WebformSubmissionForm::validateForm.
 
     // check for a report_ticket_id value in the form state; if a handler previously submitted
     // a ticket, the ID should be available to subsequent handlers.
@@ -867,12 +876,19 @@ class ZendeskHandler extends WebformHandlerBase
           foreach ($fid_to_element as $fid => $element) {
             $file = File::load($fid);
 
+            if (!$file) {
+              continue;
+            }
+
             // add uploads key to Zendesk comment, if not already present
             if ($file && !array_key_exists('uploads', $request['comment'])) {
               $request['comment']['uploads'] = [];
             }
 
             if ($element) $filename = $this->transformFilename($file->getFilename(), $element, $webform_submission);
+
+            // Test helper: force missing source errors for temporary _sid_ files.
+            $this->simulateMissingUploadSourceForTesting($file);
 
             $path = $this->pathForZendeskUpload($file);   // new helper below
             $__temp_paths[] = $path;                      // remember to clean up
@@ -962,6 +978,36 @@ class ZendeskHandler extends WebformHandlerBase
       if ($base && $real && str_starts_with($real, $base . DIRECTORY_SEPARATOR)) {
         @$fs->unlink($real);
       }
+    }
+  }
+
+  /**
+   * Deliberately remove temporary _sid_ files to reproduce missing source errors.
+   *
+   * This should only be enabled for local testing.
+   */
+  private function simulateMissingUploadSourceForTesting(File $file): void
+  {
+    if (!self::DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE) {
+      return;
+    }
+
+    // Only touch temporary pre-save files to avoid deleting finalized uploads.
+    $uri = $file->getFileUri();
+    if (!$file->isTemporary() || !str_contains($uri, '/_sid_/')) {
+      return;
+    }
+
+    $fs = \Drupal::service('file_system');
+    $real = $fs->realpath($uri) ?: '';
+    if ($real && file_exists($real)) {
+      @unlink($real);
+      clearstatcache(TRUE, $real);
+      $this->getLogger()->warning('DEBUG_SIMULATE_MISSING_UPLOAD_SOURCE deleted @path for fid=@fid (uri=@uri).', [
+        '@path' => $real,
+        '@fid' => $file->id(),
+        '@uri' => $uri,
+      ]);
     }
   }
 

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -457,7 +457,7 @@ class ZendeskUpdateHandler extends WebformHandlerBase
       //   $form_state->setUserInput($user_input);
       // }
 
-      $this->sendToZendeskAndValidateNoError($form_state);
+      $this->sendToZendeskAndValidateNoError($form_state, $webform_submission);
     }
   }
 
@@ -470,10 +470,10 @@ class ZendeskUpdateHandler extends WebformHandlerBase
    * in a custom handler is performed after all the built-in webform validation, so this is a
    * safe approach.
    */
-  private function sendToZendeskAndValidateNoError(FormStateInterface $form_state) {
+  private function sendToZendeskAndValidateNoError(FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
     if (!$form_state->hasAnyErrors()) {
       // comment out the line below to test the error handling
-      $success = $this->sendToZendesk($form_state);
+      $success = $this->sendToZendesk($form_state, $webform_submission);
       if (!$success) {
         // throw error and don't let form submit
         \Drupal::messenger()->addError(t('There was a problem communicating with our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.'));
@@ -482,18 +482,17 @@ class ZendeskUpdateHandler extends WebformHandlerBase
     }
   }
 
-  public function sendToZendesk(FormStateInterface $form_state)
+  public function sendToZendesk(FormStateInterface $form_state, WebformSubmissionInterface $webform_submission)
   {
     // NOTE: This will run for both new and update webform submissions, so this handler should only
     // be used on forms that don't allow updating. Otherwise, a new Zendesk ticket will be created
     // on every submit of the form.
 
-    // Since we're doing this in the validate phase, instead of postSave, we need to manually generate
-    // a webform_submission object from form_state and pull form values from that for the API submission.
-
     // declare working variables
     $request = [];
-    $webform_submission = $form_state->getFormObject()->getEntity();
+
+    // Since we're doing this in the validate phase instead of postSave, we use
+    // the current submission object built by WebformSubmissionForm::validateForm.
 
     // manually put the report_ticket_id value in the webform submission object, so that it
     // gets used in token replacement and in custom field if needed.

--- a/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
+++ b/web/modules/custom/portland/modules/portland_zendesk/src/Plugin/WebformHandler/ZendeskUpdateHandler.php
@@ -13,6 +13,8 @@ use Drupal\portland_zendesk\Client\ZendeskClient;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\webform\WebformTokenManagerInterface;
 use Drupal\Core\Serialization\Yaml;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\RedirectCommand;
 use Drupal\file\Entity\File;
 use Drupal\portland_zendesk\Utils\Utility;
 
@@ -43,6 +45,22 @@ use Drupal\portland_zendesk\Utils\Utility;
  */
 class ZendeskUpdateHandler extends WebformHandlerBase
 {
+  private const ZENDESK_SEND_ERROR_MESSAGE = 'There was a problem communicating with our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.';
+
+  /**
+   * Prevent duplicate postSave sends for the same handler/submission in one request.
+   *
+   * @var array<string, bool>
+   */
+  protected static $post_save_processed = [];
+
+  /**
+   * Per-request shared flag for whether Zendesk update failed for a submission.
+   *
+   * @var array<string, bool>
+   */
+  protected static $zendesk_send_failed = [];
+
 
   /**
    * The webform element plugin manager.
@@ -439,50 +457,13 @@ class ZendeskUpdateHandler extends WebformHandlerBase
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
-    // the file upload button triggers the validation handler, which is undesired.
-    // in order to prevent that, we need to determine the triggering element for the submission.
-    // call our validation function only if it's not an upload button. be extra careful about
-    // null references here, since we're not sure when/if these elements will be populated.
-    // Candiates for checking whether this is an upload submit:
-    //    $form_state->getTriggeringElement()['#submit'][0] == "file_managed_file_submit"
-    //    $form_state->getTriggeringElement()['#value']->getUntranslatedString() == "Uplooad"
-    if ($form_state->getTriggeringElement() && $form_state->getTriggeringElement()['#parents'][0] === "submit") {
-
-      // // does it help to put the report_ticket_id in the user input? will that get it to
-      // // be used in token replacement in the 2nd handler? if not, we may need to do some
-      // // manual kerjiggering.
-      // $user_input = $form_state->getUserInput();
-      // if (array_key_exists('report_ticket_id', $user_input)) {
-      //   $user_input['report_ticket_id'] = $form_state->getValue('report_ticket_id');
-      //   $form_state->setUserInput($user_input);
-      // }
-
-      $this->sendToZendeskAndValidateNoError($form_state, $webform_submission);
-    }
+    // Intentionally no-op.
+    //
+    // Zendesk API updates are performed in postSave so form submission and
+    // managed file handling complete first.
   }
 
-   /**
-   * Submit ticket update to Zendesk API and validate there were no errors. If an error occurs,
-   * fail the webform validation and don't allow the form to be submitted.
-   *
-   * By submitting to the API during the validate phase, we can interrupt the form submission,
-   * prevent the email handlers from firing, and display an error message to the user. Validation
-   * in a custom handler is performed after all the built-in webform validation, so this is a
-   * safe approach.
-   */
-  private function sendToZendeskAndValidateNoError(FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
-    if (!$form_state->hasAnyErrors()) {
-      // comment out the line below to test the error handling
-      $success = $this->sendToZendesk($form_state, $webform_submission);
-      if (!$success) {
-        // throw error and don't let form submit
-        \Drupal::messenger()->addError(t('There was a problem communicating with our support system. Please try again in a few minutes. If the error persists, please <a href="/feedback?subject=The page looks broken&feedback=Report could not be submitted to the support ticketing system.">contact us</a>.'));
-        $form_state->setErrorByName('');
-      }
-    }
-  }
-
-  public function sendToZendesk(FormStateInterface $form_state, WebformSubmissionInterface $webform_submission)
+  public function sendToZendesk(WebformSubmissionInterface $webform_submission)
   {
     // NOTE: This will run for both new and update webform submissions, so this handler should only
     // be used on forms that don't allow updating. Otherwise, a new Zendesk ticket will be created
@@ -490,15 +471,6 @@ class ZendeskUpdateHandler extends WebformHandlerBase
 
     // declare working variables
     $request = [];
-
-    // Since we're doing this in the validate phase instead of postSave, we use
-    // the current submission object built by WebformSubmissionForm::validateForm.
-
-    // manually put the report_ticket_id value in the webform submission object, so that it
-    // gets used in token replacement and in custom field if needed.
-    // NOTE: This will always occur when the ZendeskUpdateHandler is called after ZendeskHandler; the
-    // assumption is that if we're updating a ticket right after creating one, they're related.
-    $webform_submission->setElementData('report_ticket_id', $form_state->getValue('report_ticket_id'));
 
     $submission_fields = $webform_submission->toArray(TRUE);
     // email=true uses nicer template for webform_submission:values HTML
@@ -736,7 +708,52 @@ class ZendeskUpdateHandler extends WebformHandlerBase
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE)
   {
+    $key = $this->getFailureStateKey($webform_submission);
 
+    // Avoid duplicate updates in the same request (e.g. another handler resaves).
+    if (!empty(static::$post_save_processed[$key])) {
+      return;
+    }
+
+    $success = $this->sendToZendesk($webform_submission);
+    static::$zendesk_send_failed[$key] = !$success;
+    static::$post_save_processed[$key] = TRUE;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function confirmForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
+    $key = $this->getFailureStateKey($webform_submission);
+    if (empty(static::$zendesk_send_failed[$key])) {
+      return;
+    }
+
+    \Drupal::messenger()->deleteByType('status');
+    \Drupal::messenger()->addError(t(self::ZENDESK_SEND_ERROR_MESSAGE));
+
+    $redirect_url = $webform_submission->getTokenUrl('update');
+    if (\Drupal::request()->isXmlHttpRequest()) {
+      $response = new AjaxResponse();
+      $response->addCommand(new RedirectCommand($redirect_url->toString()));
+      $form_state->setResponse($response);
+    }
+    else {
+      $form_state->setRedirectUrl($redirect_url);
+    }
+
+    unset(static::$zendesk_send_failed[$key]);
+  }
+
+  /**
+   * Build a per-handler failure state key for the current submission.
+   */
+  private function getFailureStateKey(WebformSubmissionInterface $webform_submission): string
+  {
+    $sid = (string) $webform_submission->id();
+    $handler_id = (string) ($this->getHandlerId() ?: $this->getPluginId());
+    return $sid . ':' . $handler_id;
   }
 
   /**

--- a/web/sites/default/config/webform.webform.location_widget_test_open_reques.yml
+++ b/web/sites/default/config/webform.webform.location_widget_test_open_reques.yml
@@ -37,6 +37,9 @@ elements: |-
     '#feature_layer_visible_zoom': 15
     '#max_zoom': 19
     '#require_city_limits': true
+  upload_file:
+    '#type': managed_file
+    '#title': 'Upload file'
   contact_name:
     '#type': textfield
     '#title': 'Contact name'
@@ -97,6 +100,7 @@ settings:
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_file_limit_message: ''
   form_attributes: {  }
   form_method: ''
   form_action: ''
@@ -189,7 +193,7 @@ settings:
   results_disabled_ignore: false
   results_customize: false
   token_view: false
-  token_update: false
+  token_update: true
   token_delete: false
   serial_disabled: false
 access:
@@ -281,4 +285,5 @@ handlers:
       ticket_fork_field: ''
       is_child_incident: ''
       parent_ticket_id_field: ''
+      excluded_elements: {  }
 variants: {  }


### PR DESCRIPTION
This PR refactors the Portland Zendesk Webform handlers to send/create Zendesk tickets in postSave() (after managed files are finalized), adds per-request guards to avoid duplicate sends/loops, and updates confirmation behavior to surface Zendesk failures with a retry redirect.

Changes:

- Move Zendesk create/update calls from validateForm() to postSave() and refactor the send call chain to operate on WebformSubmissionInterface.

- Add confirmForm() failure handling to clear success messages, show a Zendesk error, and redirect users to the submission token update URL.

- Update a test webform config to include a managed file element and enable token-based updates.