### PR TITLE
SITU-1463 Fix required field issues in location widget

### DIFF
--- a/web/modules/custom/portland/modules/portland_location_picker/README.md
+++ b/web/modules/custom/portland/modules/portland_location_picker/README.md
@@ -10,7 +10,17 @@ This widget currently supports only a single instance per page. The implementati
 
 ## Configuration
 
-The location_lat field should be marked required in the element configuration panel if location coordinates are required. The address field should always be populated after a map click; if a location with no address is used, then "N/A" is put in the field so that it passes required field validation. If the location_lat field has a value, it can be assumed that the location_lon field has one. If there is no location_lat value, the widget will report a validation error on the location map.
+### Making location required
+
+There are two ways to make location selection required:
+
+1. **Mark the composite element itself as required** in the element's configuration panel (the "Required" checkbox at the top level of the element). This is the simplest approach.
+
+2. **Mark the `location_lat` sub-element as required** in the element configuration panel. This is the legacy method and remains in place for backwards compatibility.
+
+Either approach produces the same result: a "* Location is required" label is rendered between the search field and the map, `aria-required` is set on the composite wrapper, and a custom validator ensures a location has been selected (i.e., `location_lat` has a non-empty value) before the form can be submitted. The `location_search` field is never marked required regardless of configuration, since users can also satisfy location selection by clicking the map.
+
+The address field should always be populated after a map click; if a location with no address is used, then "N/A" is put in the field so that it passes required field validation. If the location_lat field has a value, it can be assumed that the location_lon field has one. If there is no location_lat value, the widget will report a validation error on the location map.
 
 When fields are marked as required in the UI, instead of the custom code for the widget, they're not required if disabled/hidden by conditional logic. If field requirements are hard coded in the module, Drupal still thinks they're required even if they're not enabled/visible. This is one of the reasons no fields are required by default in the module code.
 

--- a/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
+++ b/web/modules/custom/portland/modules/portland_location_picker/js/portland_location_picker.js
@@ -263,7 +263,6 @@
           map.on('popupclose', handlePopupClose);
 
           initializeLocationTextBlock();
-          initializeVisibleRequiredLabel();
 
           // only allow map clicks if primary layer behavior is not "selection." if it is, only asset markers can be clicked to select a locaiton.
           if (primaryLayerBehavior != PRIMARY_LAYER_BEHAVIOR.SelectionOnly) { map.on('click', handleMapClick); }
@@ -1231,18 +1230,15 @@
         function syncMapValidationState() {
           if (!isLocationPickerRequired()) {
             clearMapInvalid();
-            updateVisibleRequiredLabel();
             return;
           }
 
           if (!hasLocationSelection() && (hasExistingLocationPickerError() || hasLocationPickerVisualError())) {
             setMapInvalid(getLocationRequiredErrorMessage());
-            updateVisibleRequiredLabel();
             return;
           }
 
           clearMapInvalid();
-          updateVisibleRequiredLabel();
         }
 
         function bindLocationPickerValidation() {
@@ -1489,43 +1485,6 @@
 
           mapContainer.parentNode.insertBefore(wrapper, mapContainer.nextSibling);
           locationTextBlock = wrapper;
-        }
-
-        function initializeVisibleRequiredLabel() {
-          var mapContainer = document.getElementById('location_map_container');
-          if (!mapContainer || !mapContainer.parentNode) {
-            return;
-          }
-
-          var existingLabel = document.getElementById('location-required-label-wrapper');
-          if (existingLabel) {
-            return;
-          }
-
-          var wrapper = document.createElement('div');
-          wrapper.id = 'location-required-label-wrapper';
-          wrapper.className = 'location-required-label-wrapper';
-          wrapper.setAttribute('aria-hidden', 'true');
-          wrapper.innerHTML = '<div class="location-required-label"><span class="required-asterisk">*</span> Location is required</div>';
-          
-          // Insert before the map container
-          mapContainer.parentNode.insertBefore(wrapper, mapContainer);
-          
-          // Only show if the picker is required
-          updateVisibleRequiredLabel();
-        }
-
-        function updateVisibleRequiredLabel() {
-          var labelWrapper = document.getElementById('location-required-label-wrapper');
-          if (!labelWrapper) {
-            return;
-          }
-          
-          if (isLocationPickerRequired()) {
-            labelWrapper.style.display = 'block';
-          } else {
-            labelWrapper.style.display = 'none';
-          }
         }
 
         function updateLocationTextAnnouncement(message) {

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
@@ -39,17 +39,23 @@ class PortlandLocationPicker extends WebformCompositeBase {
       $element_id = $element['#webform_key'];
     }
 
+    $locationIsRequired = !empty($element['#location_selection_required'])
+      || !empty($element['#location_lat__required'])
+      || (!empty($element['location_lat']) && (!empty($element['location_lat']['#required']) || !empty($element['location_lat']['#_required'])));
+
     $element['location_search'] = [
       '#type' => 'textfield',
-      '#title' => t('Location search'),
+      '#title' => t('Location'),
       '#id' => 'location_search',
       '#attributes' => ['class' => ['location-picker-address'], 'autocomplete' => 'off'],
-      '#description' => t('Search the map for an address, cross streets, park, or community center. Or use the map to click a location.'),
+      '#description' => t('Search the map for an address, cross streets, park, or community center. Or use the map to pick a location.'),
       '#description_display' => 'before',
     ];
-    if (!empty($element['#location_search__required']) || !empty($element['location_search']['#required'])) {
-      $element['location_search']['#attributes']['aria-required'] = 'true';
-    }
+    $element['location_required_label'] = [
+      '#type' => 'markup',
+      '#access' => $locationIsRequired,
+      '#markup' => '<div class="location-required-label-wrapper" aria-hidden="true"><div class="location-required-label"><span class="required-asterisk">*</span> ' . t('Location is required') . '</div></div>',
+    ];
     $element['precision_text'] = [
       '#type' => 'markup',
       '#markup' => '<div class="alert alert--info next-steps visually-hidden precision_text" aria-hidden="true" id="precision_text">' . t('<strong>IMPORTANT:</strong> To help us provide better service, please click, tap, or drag the marker to the precise location on the map.') . '</div>',

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
@@ -45,7 +45,7 @@ class PortlandLocationPicker extends WebformCompositeBase {
 
     $element['location_search'] = [
       '#type' => 'textfield',
-      '#title' => t('Location'),
+      '#title' => t('Location search'),
       '#id' => 'location_search',
       '#attributes' => ['class' => ['location-picker-address'], 'autocomplete' => 'off'],
       '#description' => t('Search the map for an address, cross streets, park, or community center. Or use the map to pick a location.'),

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Element/PortlandLocationPicker.php
@@ -39,9 +39,17 @@ class PortlandLocationPicker extends WebformCompositeBase {
       $element_id = $element['#webform_key'];
     }
 
+    // #location_selection_required is set by the Plugin's prepare() method, but
+    // getCompositeElements() may run before prepare(). Also check composite-level
+    // #required/#_required and lon-based flags so the required label is rendered
+    // whenever the widget is required, regardless of call order.
     $locationIsRequired = !empty($element['#location_selection_required'])
+      || !empty($element['#required'])
+      || !empty($element['#_required'])
       || !empty($element['#location_lat__required'])
-      || (!empty($element['location_lat']) && (!empty($element['location_lat']['#required']) || !empty($element['location_lat']['#_required'])));
+      || !empty($element['#location_lon__required'])
+      || (!empty($element['location_lat']) && (!empty($element['location_lat']['#required']) || !empty($element['location_lat']['#_required'])))
+      || (!empty($element['location_lon']) && (!empty($element['location_lon']['#required']) || !empty($element['location_lon']['#_required'])));
 
     $element['location_search'] = [
       '#type' => 'textfield',

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -4,6 +4,7 @@ namespace Drupal\portland_location_picker\Plugin\WebformElement;
 
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform\WebformSubmissionForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Component\Utility\Html;
@@ -285,6 +286,56 @@ class PortlandLocationPicker extends WebformCompositeBase {
    * location_lat sub-element, so Drupal's scroll-to-error behaviour works.
    */
   public static function validateLocationRequired(array &$element, FormStateInterface $form_state, array &$form) {
+    // Skip required validation when conditional logic currently hides or
+    // disables this widget (or one of its parent containers) for submitted
+    // values.
+    $webform_submission = NULL;
+    if (!empty($form['#webform_submission']) && $form['#webform_submission'] instanceof WebformSubmissionInterface) {
+      $webform_submission = $form['#webform_submission'];
+    }
+    else {
+      $form_object = $form_state->getFormObject();
+      if ($form_object instanceof WebformSubmissionForm) {
+        $webform_submission = $form_object->getEntity();
+      }
+    }
+
+    if ($webform_submission instanceof WebformSubmissionInterface) {
+      $webform = $webform_submission->getWebform();
+      if ($webform) {
+        $element_values = array_intersect_key(
+          (array) $form_state->getValues(),
+          $webform->getElementsInitializedFlattenedAndHasValue()
+        );
+        $webform_submission->setData($element_values + $webform_submission->getData());
+      }
+
+      $conditions_validator = \Drupal::service('webform_submission.conditions_validator');
+      $elements_to_check = [];
+      $array_parents = $element['#array_parents'] ?? [];
+      if (!empty($array_parents)) {
+        $current = $form;
+        foreach ($array_parents as $part) {
+          if (!is_array($current) || !array_key_exists($part, $current) || !is_array($current[$part])) {
+            break;
+          }
+          $current = $current[$part];
+          $elements_to_check[] = $current;
+        }
+      }
+
+      if (empty($elements_to_check)) {
+        $elements_to_check[] = $element;
+      }
+
+      foreach ($elements_to_check as $element_to_check) {
+        if (!$conditions_validator->isElementVisible($element_to_check, $webform_submission)
+          || !$conditions_validator->isElementEnabled($element_to_check, $webform_submission)) {
+          return;
+        }
+      }
+    }
+
     // Use the element's parents path so nested elements validate correctly.
     $parents = $element['#parents'] ?? NULL;
     if ($parents === NULL) {

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -223,15 +223,40 @@ class PortlandLocationPicker extends WebformCompositeBase {
 
     $element['#attached']['drupalSettings']['webform']['portland_location_picker']['max_zoom'] = $maxZoom;
 
-    $latRequired = !empty($element['#location_lat__required']) || (!empty($element['location_lat']) && !empty($element['location_lat']['#required']));
-    $lonRequired = !empty($element['#location_lon__required']) || (!empty($element['location_lon']) && !empty($element['location_lon']['#required']));
+    $latRequired = !empty($element['#location_lat__required'])
+      || (!empty($element['location_lat'])
+        && (!empty($element['location_lat']['#required']) || !empty($element['location_lat']['#_required'])));
+    $lonRequired = !empty($element['#location_lon__required'])
+      || (!empty($element['location_lon'])
+        && (!empty($element['location_lon']['#required']) || !empty($element['location_lon']['#_required'])));
     $isLocationRequired = $latRequired || $lonRequired;
+
+    // Keep a stable location-required flag for rendering cues that should not
+    // depend on Webform moving #required <-> #_required during states handling.
+    $element['#location_selection_required'] = $isLocationRequired;
+
+    // location_search should never be required on its own. Users can satisfy
+    // location requirements by searching OR clicking the map, so ignore any
+    // location_search required flags set in UI config.
+    $element['#location_search__required'] = FALSE;
+    if (!empty($element['location_search']) && isset($element['location_search']['#type'])) {
+      $element['location_search']['#required'] = FALSE;
+      $element['location_search']['#_required'] = FALSE;
+    }
     
-    if (!empty($element['#required']) || $isLocationRequired) {
-      // A required location should be indicated on the composite title/legend,
-      // since the validated value is hidden and the visible interaction is the
-      // overall search-and-map widget.
+    // Keep composite-level required behavior only when explicitly configured on
+    // the composite itself. Do not promote hidden lat/lon required flags to
+    // composite #required, because conditional #states handling can then mark
+    // visible sub-element labels as required incorrectly.
+    $compositeExplicitRequired = !empty($element['#required']) || !empty($element['#_required']);
+    if ($compositeExplicitRequired) {
       $element['#required'] = TRUE;
+      $element['#attributes']['aria-required'] = 'true';
+      $element['#wrapper_attributes']['aria-required'] = 'true';
+    }
+    elseif ($isLocationRequired) {
+      // Preserve ARIA cue for the overall interaction without triggering
+      // composite required rendering behavior.
       $element['#attributes']['aria-required'] = 'true';
       $element['#wrapper_attributes']['aria-required'] = 'true';
     }

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -285,6 +285,18 @@ class PortlandLocationPicker extends WebformCompositeBase {
    * location_lat sub-element, so Drupal's scroll-to-error behaviour works.
    */
   public static function validateLocationRequired(array &$element, FormStateInterface $form_state, array &$form) {
+    // Skip required validation when the picker is hidden by visibility states.
+    // Webform marks conditionally hidden elements with js-webform-states-hidden.
+    if (!\Drupal\Core\Render\Element::isVisibleElement($element)) {
+      return;
+    }
+    $wrapper_classes = isset($element['#wrapper_attributes']['class']) ? (array) $element['#wrapper_attributes']['class'] : [];
+    $element_classes = isset($element['#attributes']['class']) ? (array) $element['#attributes']['class'] : [];
+    if (in_array('js-webform-states-hidden', $wrapper_classes, TRUE)
+      || in_array('js-webform-states-hidden', $element_classes, TRUE)) {
+      return;
+    }
+
     // Use the element's parents path so nested elements validate correctly.
     $parents = $element['#parents'] ?? NULL;
     if ($parents === NULL) {

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -285,18 +285,6 @@ class PortlandLocationPicker extends WebformCompositeBase {
    * location_lat sub-element, so Drupal's scroll-to-error behaviour works.
    */
   public static function validateLocationRequired(array &$element, FormStateInterface $form_state, array &$form) {
-    // Skip required validation when the picker is hidden by visibility states.
-    // Webform marks conditionally hidden elements with js-webform-states-hidden.
-    if (!\Drupal\Core\Render\Element::isVisibleElement($element)) {
-      return;
-    }
-    $wrapper_classes = isset($element['#wrapper_attributes']['class']) ? (array) $element['#wrapper_attributes']['class'] : [];
-    $element_classes = isset($element['#attributes']['class']) ? (array) $element['#attributes']['class'] : [];
-    if (in_array('js-webform-states-hidden', $wrapper_classes, TRUE)
-      || in_array('js-webform-states-hidden', $element_classes, TRUE)) {
-      return;
-    }
-
     // Use the element's parents path so nested elements validate correctly.
     $parents = $element['#parents'] ?? NULL;
     if ($parents === NULL) {

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -252,9 +252,14 @@ class PortlandLocationPicker extends WebformCompositeBase {
       // is handled by the custom validator below instead.
       $element['#required'] = FALSE;
       $element['#_required'] = FALSE;
-      // Preserve ARIA cue for the overall composite wrapper.
+      // Preserve ARIA cue and a stable required indicator for the overall
+      // composite wrapper. The client-side behavior determines requiredness
+      // from the wrapper, so re-add the required marker without restoring
+      // native hidden-input validation.
       $element['#attributes']['aria-required'] = 'true';
       $element['#wrapper_attributes']['aria-required'] = 'true';
+      $element['#wrapper_attributes']['class'][] = 'required';
+      $element['#wrapper_attributes']['data-location-picker-required'] = 'true';
 
       // Clear lat/lon required flags so Drupal does not try to validate or
       // scroll to a hidden input. The custom validator below handles enforcement.

--- a/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
+++ b/web/modules/custom/portland/modules/portland_location_picker/src/Plugin/WebformElement/PortlandLocationPicker.php
@@ -229,7 +229,9 @@ class PortlandLocationPicker extends WebformCompositeBase {
     $lonRequired = !empty($element['#location_lon__required'])
       || (!empty($element['location_lon'])
         && (!empty($element['location_lon']['#required']) || !empty($element['location_lon']['#_required'])));
-    $isLocationRequired = $latRequired || $lonRequired;
+    // Composite-level #required is a third way to declare the widget required.
+    $compositeExplicitRequired = !empty($element['#required']) || !empty($element['#_required']);
+    $isLocationRequired = $latRequired || $lonRequired || $compositeExplicitRequired;
 
     // Keep a stable location-required flag for rendering cues that should not
     // depend on Webform moving #required <-> #_required during states handling.
@@ -243,29 +245,19 @@ class PortlandLocationPicker extends WebformCompositeBase {
       $element['location_search']['#required'] = FALSE;
       $element['location_search']['#_required'] = FALSE;
     }
-    
-    // Keep composite-level required behavior only when explicitly configured on
-    // the composite itself. Do not promote hidden lat/lon required flags to
-    // composite #required, because conditional #states handling can then mark
-    // visible sub-element labels as required incorrectly.
-    $compositeExplicitRequired = !empty($element['#required']) || !empty($element['#_required']);
-    if ($compositeExplicitRequired) {
-      $element['#required'] = TRUE;
-      $element['#attributes']['aria-required'] = 'true';
-      $element['#wrapper_attributes']['aria-required'] = 'true';
-    }
-    elseif ($isLocationRequired) {
-      // Preserve ARIA cue for the overall interaction without triggering
-      // composite required rendering behavior.
-      $element['#attributes']['aria-required'] = 'true';
-      $element['#wrapper_attributes']['aria-required'] = 'true';
-    }
 
-    // If location_lat or location_lon was marked required (via YAML shorthand or direct
-    // #required), clear the built-in required flag so Drupal doesn't try to
-    // validate or scroll to a hidden input. Instead, register a validator on
-    // the composite that can attach the error to a visible part of the widget.
     if ($isLocationRequired) {
+      // Clear composite #required so Webform's conditional states handling does
+      // not propagate required markers to visible sub-element labels. Validation
+      // is handled by the custom validator below instead.
+      $element['#required'] = FALSE;
+      $element['#_required'] = FALSE;
+      // Preserve ARIA cue for the overall composite wrapper.
+      $element['#attributes']['aria-required'] = 'true';
+      $element['#wrapper_attributes']['aria-required'] = 'true';
+
+      // Clear lat/lon required flags so Drupal does not try to validate or
+      // scroll to a hidden input. The custom validator below handles enforcement.
       $element['#location_lat__required'] = FALSE;
       $element['#location_lon__required'] = FALSE;
       // Avoid creating a sparse location_lat child override before Webform has

--- a/web/sites/default/config/webform.webform.report_abandoned_vehicle.yml
+++ b/web/sites/default/config/webform.webform.report_abandoned_vehicle.yml
@@ -142,7 +142,6 @@ elements: |-
             invisible:
               ':input[name="report_location_is_private"]':
                 value: 'Yes'
-          '#location_address__required': true
           '#location_lat__required': true
           '#place_name__access': false
           '#location_details__title': 'Location Details (optional)'
@@ -563,6 +562,7 @@ handlers:
       ticket_fork_field: report_vehicle
       is_child_incident: 0
       parent_ticket_id_field: ''
+      excluded_elements: {  }
   submit_to_zendesk_abautos_developer_test:
     id: zendesk
     handler_id: submit_to_zendesk_abautos_developer_test
@@ -593,6 +593,7 @@ handlers:
       ticket_fork_field: report_vehicle
       is_child_incident: 0
       parent_ticket_id_field: ''
+      excluded_elements: {  }
   email:
     id: email
     handler_id: email

--- a/web/sites/default/config/webform.webform.request_ada_accommodation.yml
+++ b/web/sites/default/config/webform.webform.request_ada_accommodation.yml
@@ -532,17 +532,16 @@ elements: |-
           location_lat: ''
           location_lon: ''
           location_private_owner: ''
-        '#location_type__access': false
-        '#location_park_container__access': false
-        '#location_private_owner__access': false
-        '#location_address__required': true
-        '#location_lat__required': true
         '#location_asset_id__access': false
         '#location_region_id__access': false
         '#location_municipality_name__access': false
+        '#location_type__access': false
+        '#location_park_container__access': false
+        '#location_private_owner__access': false
         '#location_is_portland__access': false
         '#geojson_layer__access': false
         '#geojson_layer_behavior__access': false
+        '#required': true
       report_barrier_description:
         '#type': textarea
         '#title': 'Description of issue'


### PR DESCRIPTION
This pull request improves the Portland Location Picker widget by standardizing and clarifying how the "required" state for location selection is configured, rendered, and validated. The changes ensure that the required indicator and validation logic are consistent regardless of whether the requirement is set at the composite or sub-element level, and that the UI accurately reflects the required state. Additionally, the implementation now avoids unnecessary client-side updates and ensures validation is skipped for hidden widgets.

**Required field logic and UI improvements:**

* Clarified in the `README.md` that location selection can be made required either by marking the composite element or the `location_lat` sub-element as required, and explained how the required label and validation behave in both cases.
* The PHP widget code now reliably determines if the location picker is required by checking all possible flags, and always renders a visible "Location is required" label in the correct place when needed. The label is now rendered server-side instead of being injected by JavaScript.
* The `prepare()` method in the widget plugin sets a stable flag for requiredness, clears required flags from hidden sub-elements to prevent unwanted validation, and ensures ARIA attributes and CSS classes are set for accessibility and styling.

**Validation behavior:**

* The custom validator now skips required validation if the widget is hidden by conditional logic, preventing errors when the field is not visible to the user.

**JavaScript and client-side simplification:**

* Removed JavaScript code that dynamically managed the required label, since this is now handled server-side for consistency and simplicity. [[1]](diffhunk://#diff-626cd021b21ec4814d9e47788e644bc2299d7b9a50c3572bbe6e7d0263698537L266) [[2]](diffhunk://#diff-626cd021b21ec4814d9e47788e644bc2299d7b9a50c3572bbe6e7d0263698537L1234-L1245) [[3]](diffhunk://#diff-626cd021b21ec4814d9e47788e644bc2299d7b9a50c3572bbe6e7d0263698537L1494-L1530)

**Configuration cleanup:**

* Cleaned up the sample webform YAML configuration to remove unnecessary required flags and ensure settings match the new logic. [[1]](diffhunk://#diff-36085c704fb985dde9874493dae314e0944ed748c235914fcae1e7c426f8f3b5L145) [[2]](diffhunk://#diff-36085c704fb985dde9874493dae314e0944ed748c235914fcae1e7c426f8f3b5R565) [[3]](diffhunk://#diff-36085c704fb985dde9874493dae314e0944ed748c235914fcae1e7c426f8f3b5R596)