### PR TITLE
PGOV-2097 create local patch to resolve patching issue for 3551513

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -423,8 +423,9 @@
             },
             "drupal/webform": {
                 "3549865 - Required WebformMultiple field [...]": "https://git.drupalcode.org/project/webform/-/merge_requests/750.patch",
-                "3551513 - JavaScript Asset not being loaded when loading a webform is loaded via AJAX": "patches/3551513-webform-ajax-assets-local.patch",
+                "3551513 - JavaScript asset not loaded when a webform is loaded via AJAX": "patches/3551513-webform-ajax-assets-local.patch",
                 "3551969 - Fix progress tracker accessibility issues": "patches/3551969-webform-progress-tracker-accessibility.patch"
+            }
             },
             "smillart/wai-aria-patterns-and-widgets": {
                 "POWR-1879 Set hidden value to until-found": "https://github.com/smillart/WAI-ARIA-Patterns-And-Widgets/pull/22.patch"

--- a/composer.json
+++ b/composer.json
@@ -425,7 +425,6 @@
                 "3549865 - Required WebformMultiple field [...]": "https://git.drupalcode.org/project/webform/-/merge_requests/750.patch",
                 "3551513 - JavaScript asset not loaded when a webform is loaded via AJAX": "patches/3551513-webform-ajax-assets-local.patch",
                 "3551969 - Fix progress tracker accessibility issues": "patches/3551969-webform-progress-tracker-accessibility.patch"
-            }
             },
             "smillart/wai-aria-patterns-and-widgets": {
                 "POWR-1879 Set hidden value to until-found": "https://github.com/smillart/WAI-ARIA-Patterns-And-Widgets/pull/22.patch"

--- a/composer.json
+++ b/composer.json
@@ -423,6 +423,7 @@
             },
             "drupal/webform": {
                 "3549865 - Required WebformMultiple field [...]": "https://git.drupalcode.org/project/webform/-/merge_requests/750.patch",
+                "3551513 - JavaScript Asset not being loaded when loading a webform is loaded via AJAX": "patches/3551513-webform-ajax-assets-local.patch",
                 "3551969 - Fix progress tracker accessibility issues": "patches/3551969-webform-progress-tracker-accessibility.patch"
             },
             "smillart/wai-aria-patterns-and-widgets": {

--- a/patches/3551513-webform-ajax-assets-local.patch
+++ b/patches/3551513-webform-ajax-assets-local.patch
@@ -1,0 +1,46 @@
+diff --git a/src/Hook/WebformFormAlterHooks.php b/src/Hook/WebformFormAlterHooks.php
+index 74659ff71..75973b6ab 100644
+--- a/src/Hook/WebformFormAlterHooks.php
++++ b/src/Hook/WebformFormAlterHooks.php
+@@ -48,7 +48,7 @@ class WebformFormAlterHooks {
+     // Alter the webform submission form.
+     if (str_starts_with($form_id, 'webform_submission') && $form_object instanceof WebformSubmissionForm) {
+       // Make sure webform libraries are always attached to submission form.
+-      _webform_page_attachments($form);
++      _webform_page_attachments($form, $form_object->getWebform());
+       // After build.
+       $form['#after_build'][] = '_webform_form_webform_submission_form_after_build';
+     }
+diff --git a/webform.module b/webform.module
+index e21081747..7594e76b0 100644
+--- a/webform.module
++++ b/webform.module
+@@ -20,6 +20,7 @@ use Drupal\Core\Session\AccountInterface;
+ use Drupal\file\FileInterface;
+ use Drupal\webform\Utility\WebformElementHelper;
+ use Drupal\webform\Utility\WebformOptionsHelper;
++use Drupal\webform\WebformInterface;
+ 
+ require_once __DIR__ . '/includes/webform.date.inc';
+ require_once __DIR__ . '/includes/webform.editor.inc';
+@@ -258,8 +259,10 @@ function webform_metatags_alter(array &$metatags, array &$context) {
+  *
+  * @param array $attachments
+  *   An array of page attachments.
++ * @param \Drupal\webform\WebformInterface|null $webform
++ *   The webform we're attaching to (if not supplied it will be determined from the request).
+  */
+-function _webform_page_attachments(array &$attachments) {
++function _webform_page_attachments(array &$attachments, ?WebformInterface $webform = NULL) {
+   // Attach webform theme specific libraries.
+   /** @var \Drupal\webform\WebformThemeManagerInterface $theme_manager */
+   $theme_manager = \Drupal::service('webform.theme_manager');
+@@ -288,7 +291,7 @@ function _webform_page_attachments(array &$attachments) {
+   // Get current webform, if it does not exist exit.
+   /** @var \Drupal\webform\WebformRequestInterface $request_handler */
+   $request_handler = \Drupal::service('webform.request');
+-  $webform = $request_handler->getCurrentWebform();
++  $webform ??= $request_handler->getCurrentWebform();
+   if (!$webform) {
+     return;
+   }


### PR DESCRIPTION
This pull request addresses a bug where JavaScript assets were not being loaded when a webform was rendered via AJAX. The fix involves updating the way webform assets are attached, ensuring that the correct webform context is always used when loading assets, particularly in AJAX scenarios.

Bug fix for webform AJAX asset loading:

* Added a new patch (`3551513-webform-ajax-assets-local.patch`) and registered it in `composer.json` to resolve an issue where JavaScript assets were not loaded when a webform was rendered via AJAX. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R426) [[2]](diffhunk://#diff-1cc7f6e654d283e756142d4d6ce2c23edfae2b2c5e02f10d8b1d2816184193bdR1-R46)
* Modified the `_webform_page_attachments` function to accept an optional `WebformInterface` parameter, ensuring that the correct webform context is used when attaching assets.
* Updated `WebformFormAlterHooks` to pass the current webform to `_webform_page_attachments`, guaranteeing assets are loaded correctly during AJAX form loads.