### PR TITLE
PGOV-2132 Fix read more link on Council written testimony

### DIFF
--- a/web/modules/custom/portland/modules/portland_smartsheet/src/Plugin/views/query/Smartsheet.php
+++ b/web/modules/custom/portland/modules/portland_smartsheet/src/Plugin/views/query/Smartsheet.php
@@ -89,17 +89,22 @@ class Smartsheet extends QueryPluginBase {
     $client = new SmartsheetClient($this->options['sheet_id']);
     $current_page = $view->pager?->getCurrentPage() ?? 0;
     $items_per_page = $view->pager?->getItemsPerPage() ?? 0;
-
-    return $client->getSheet([
+    $query = [
       'exclude' => 'filteredOutRows',
       'filterId' => $this->options['filter_id'],
       'include' => 'attachments',
-      // smartsheet pages are 1-indexed
-      'page' => $paging_strategy === SmartsheetPagingStrategy::IN_MEMORY ? 1 : $current_page + 1,
-      // if in-mem, load API max of 10,000 rows
-      'pageSize' => ($items_per_page === 0 || $paging_strategy === SmartsheetPagingStrategy::IN_MEMORY) ? 10000 : $items_per_page,
       'rowIds' => join(',', $this->whereRowId),
-    ]);
+    ];
+    // If we're not filtering for specific row ID(s), then add paging parameters.
+    // If filtering by row ID, adding paging parameters can cause the API to return an empty result set.
+    if (empty($this->whereRowId)) {
+      // smartsheet pages are 1-indexed
+      $query['page'] = $paging_strategy === SmartsheetPagingStrategy::IN_MEMORY ? 1 : $current_page + 1;
+      // if in-mem, load API max of 10,000 rows
+      $query['pageSize'] = ($items_per_page === 0 || $paging_strategy === SmartsheetPagingStrategy::IN_MEMORY) ? 10000 : $items_per_page;
+    }
+
+    return $client->getSheet($query);
   }
 
   /**


### PR DESCRIPTION
The Smartsheet API doesn't like when you provide a page parameter if you're filtering for a specific row ID. It appears to override the result set so if your desired row ID isn't on the specified page, it won't return it at all.

By omitting the page parameter when a row ID filter is applied, it appears to always return the correct row(s).